### PR TITLE
fix(opencode-plugin): support Windows config paths and zip extraction

### DIFF
--- a/packages/opencode-plugin/src/config.ts
+++ b/packages/opencode-plugin/src/config.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import { parse as parseJsonc } from "comment-json";
 import { z } from "zod";
@@ -190,8 +191,13 @@ function mergeConfigs(base: AftConfig, override: AftConfig): AftConfig {
 // ---------------------------------------------------------------------------
 
 function getOpenCodeConfigDir(): string {
-  // XDG_CONFIG_HOME or ~/.config, then /opencode
-  const xdgConfig = process.env.XDG_CONFIG_HOME || join(process.env.HOME || "~", ".config");
+  const envDir = process.env.OPENCODE_CONFIG_DIR?.trim();
+  if (envDir) {
+    return envDir;
+  }
+
+  // XDG_CONFIG_HOME or homedir()/.config, then /opencode
+  const xdgConfig = process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
   return join(xdgConfig, "opencode");
 }
 

--- a/packages/opencode-plugin/src/onnx-runtime.ts
+++ b/packages/opencode-plugin/src/onnx-runtime.ts
@@ -180,8 +180,7 @@ async function downloadOnnxRuntime(
       const { execSync } = await import("node:child_process");
       execSync(`tar xzf "${archivePath}" -C "${tmpDir}"`, { stdio: "pipe" });
     } else {
-      const { execSync } = await import("node:child_process");
-      execSync(`unzip -q "${archivePath}" -d "${tmpDir}"`, { stdio: "pipe" });
+      await extractZipArchive(archivePath, tmpDir);
     }
 
     // Find and copy the library file
@@ -266,6 +265,53 @@ async function downloadOnnxRuntime(
     }
     return null;
   }
+}
+
+async function extractZipArchive(archivePath: string, destinationDir: string): Promise<void> {
+  const { execFileSync } = await import("node:child_process");
+
+  if (process.platform === "win32") {
+    let powershellError: unknown;
+
+    try {
+      execFileSync(
+        "powershell.exe",
+        [
+          "-NoProfile",
+          "-NonInteractive",
+          "-ExecutionPolicy",
+          "Bypass",
+          "-Command",
+          "& { Expand-Archive -LiteralPath $args[0] -DestinationPath $args[1] -Force }",
+          archivePath,
+          destinationDir,
+        ],
+        { stdio: "pipe", timeout: 120_000 },
+      );
+      return;
+    } catch (err) {
+      powershellError = err;
+      warn(`PowerShell Expand-Archive failed, falling back to cmd/tar: ${String(err)}`);
+    }
+
+    try {
+      execFileSync(
+        "cmd.exe",
+        ["/d", "/s", "/c", `tar -xf "${archivePath}" -C "${destinationDir}"`],
+        { stdio: "pipe", timeout: 120_000 },
+      );
+      return;
+    } catch (cmdError) {
+      throw new Error(
+        `ZIP extraction failed via PowerShell and cmd/tar. PowerShell: ${String(powershellError)} | cmd/tar: ${String(cmdError)}`,
+      );
+    }
+  }
+
+  execFileSync("unzip", ["-q", archivePath, "-d", destinationDir], {
+    stdio: "pipe",
+    timeout: 120_000,
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary
This PR fixes two Windows-specific issues in the OpenCode plugin:

1. Runtime config lookup now resolves the OpenCode config directory the same way as the CLI helpers/doctor path logic.
2. ONNX Runtime ZIP extraction no longer depends on `unzip` being available on Windows.

## Changes
- `packages/opencode-plugin/src/config.ts`
  - honor `OPENCODE_CONFIG_DIR`
  - use `homedir()` instead of `process.env.HOME || "~"`
- `packages/opencode-plugin/src/onnx-runtime.ts`
  - for Windows ZIP extraction, try PowerShell `Expand-Archive` first
  - fall back to `cmd.exe /c tar -xf ...`
  - keep `unzip` for non-Windows platforms

## Why
### 1. Runtime config mismatch on Windows
The plugin runtime was using `process.env.HOME` to derive `~/.config/opencode`, while the doctor/config-path helpers used proper platform-aware home directory resolution. On Windows this could lead to doctor seeing a valid AFT config while the live runtime ignored it.

### 2. ONNX extraction failure on Windows
The semantic-search bootstrap path used `unzip -q ...` for ZIP archives. On a standard Windows host without `unzip` in PATH, ONNX download succeeded but extraction failed immediately.

## Validation
- built `packages/opencode-plugin` successfully from source
- verified the built runtime contains the Windows extraction path (`Expand-Archive` + `cmd /c tar -xf` fallback)
- exercised the local source build through OpenCode with a temporary config
- confirmed ONNX Runtime downloaded and extracted successfully on Windows instead of failing on `unzip`