### PR TITLE
feat(opencode-plugin,aft): add optional external semantic embedding backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,7 @@ dependencies = [
  "rayon",
  "regex",
  "regex-syntax",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2",
@@ -642,6 +643,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1739,6 +1741,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",

--- a/crates/aft/Cargo.toml
+++ b/crates/aft/Cargo.toml
@@ -59,6 +59,7 @@ content_inspector = "0.2.4"
 memchr = "2"
 rayon = "1"
 fastembed = { version = "5", default-features = false, features = ["hf-hub-rustls-tls", "ort-load-dynamic"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/aft/src/commands/configure.rs
+++ b/crates/aft/src/commands/configure.rs
@@ -213,7 +213,11 @@ pub fn handle_configure(req: &RawRequest, ctx: &AppContext) -> Response {
     }
 
     if experimental_semantic_search {
-        *ctx.semantic_index_status().borrow_mut() = SemanticIndexStatus::Building;
+        *ctx.semantic_index_status().borrow_mut() = SemanticIndexStatus::Building {
+            stage: "queued".to_string(),
+            files: None,
+            entries: None,
+        };
         let (tx, rx): (
             crossbeam_channel::Sender<SemanticIndexEvent>,
             crossbeam_channel::Receiver<SemanticIndexEvent>,
@@ -223,19 +227,30 @@ pub fn handle_configure(req: &RawRequest, ctx: &AppContext) -> Response {
         let root_clone = root_path.clone();
         let semantic_storage = storage_dir.clone();
         let semantic_project_key = crate::search_index::project_cache_key(&root_path);
+        let tx_progress = tx.clone();
         thread::spawn(move || {
             let build_result = catch_unwind(AssertUnwindSafe(
-                || -> Result<SemanticIndexEvent, String> {
+                || -> Result<SemanticIndex, String> {
                     if let Some(ref dir) = semantic_storage {
                         if let Some(cached) =
                             SemanticIndex::read_from_disk(dir, &semantic_project_key)
                         {
-                            return Ok(SemanticIndexEvent::Ready(cached));
+                            let _ = tx_progress.send(SemanticIndexEvent::Progress {
+                                stage: "loaded_cached_index".to_string(),
+                                files: None,
+                                entries: Some(cached.entry_count()),
+                            });
+                            return Ok(cached);
                         }
                     }
 
                     let filters = build_path_filters(&[], &[]).unwrap_or_default();
                     let files = walk_project_files(&root_clone, &filters);
+                    let _ = tx_progress.send(SemanticIndexEvent::Progress {
+                        stage: "scanned_project_files".to_string(),
+                        files: Some(files.len()),
+                        entries: None,
+                    });
 
                     // Cap file count to prevent OOM on huge project roots (e.g., /home/user).
                     // fastembed model (~200MB) + embeddings + batch buffers can exceed memory
@@ -255,6 +270,11 @@ pub fn handle_configure(req: &RawRequest, ctx: &AppContext) -> Response {
                         ));
                     }
 
+                    let _ = tx_progress.send(SemanticIndexEvent::Progress {
+                        stage: "initializing_embedding_model".to_string(),
+                        files: Some(files.len()),
+                        entries: None,
+                    });
                     let mut model = crate::semantic_index::initialize_text_embedding()?;
 
                     let mut embed = |texts: Vec<String>| {
@@ -263,23 +283,33 @@ pub fn handle_configure(req: &RawRequest, ctx: &AppContext) -> Response {
                             .map_err(|error| error.to_string())
                     };
 
+                    let _ = tx_progress.send(SemanticIndexEvent::Progress {
+                        stage: "embedding_symbols".to_string(),
+                        files: Some(files.len()),
+                        entries: None,
+                    });
                     let index = SemanticIndex::build(&root_clone, &files, &mut embed, 64)?;
                     log::info!(
                         "[aft] built semantic index: {} files, {} entries",
                         files.len(),
                         index.len()
                     );
+                    let _ = tx_progress.send(SemanticIndexEvent::Progress {
+                        stage: "persisting_index".to_string(),
+                        files: Some(files.len()),
+                        entries: Some(index.len()),
+                    });
 
                     if let Some(ref dir) = semantic_storage {
                         index.write_to_disk(dir, &semantic_project_key);
                     }
 
-                    Ok(SemanticIndexEvent::Ready(index))
+                    Ok(index)
                 },
             ));
 
             let event = match build_result {
-                Ok(Ok(event)) => event,
+                Ok(Ok(index)) => SemanticIndexEvent::Ready(index),
                 Ok(Err(error)) => {
                     log::warn!("[aft] failed to build semantic index: {}", error);
                     SemanticIndexEvent::Failed(error)

--- a/crates/aft/src/commands/configure.rs
+++ b/crates/aft/src/commands/configure.rs
@@ -7,6 +7,7 @@ use crossbeam_channel::unbounded;
 use notify::{RecursiveMode, Watcher};
 
 use crate::callgraph::CallGraph;
+use crate::config::{SemanticBackend, SemanticBackendConfig};
 use crate::context::{AppContext, SemanticIndexEvent, SemanticIndexStatus};
 use crate::protocol::{RawRequest, Response};
 use crate::search_index::{
@@ -47,6 +48,68 @@ fn validate_storage_dir(raw: &str) -> Result<PathBuf, String> {
     }
 
     Ok(normalized)
+}
+
+fn parse_semantic_config(
+    value: &serde_json::Value,
+    current: &SemanticBackendConfig,
+) -> Result<SemanticBackendConfig, String> {
+    let Some(obj) = value.as_object() else {
+        return Err("configure: semantic must be an object".to_string());
+    };
+
+    let mut semantic = current.clone();
+
+    if let Some(raw) = obj.get("backend") {
+        let name = raw
+            .as_str()
+            .ok_or_else(|| "configure: semantic.backend must be a string".to_string())?
+            .trim();
+        semantic.backend = SemanticBackend::from_name(name)
+            .ok_or_else(|| format!("configure: unsupported semantic.backend '{name}'"))?;
+    }
+    if let Some(raw) = obj.get("model") {
+        semantic.model = raw
+            .as_str()
+            .ok_or_else(|| "configure: semantic.model must be a string".to_string())?
+            .trim()
+            .to_string();
+    }
+    if let Some(raw) = obj.get("base_url") {
+        let base_url = raw
+            .as_str()
+            .ok_or_else(|| "configure: semantic.base_url must be a string".to_string())?
+            .trim()
+            .to_string();
+        semantic.base_url = if base_url.is_empty() { None } else { Some(base_url) };
+    }
+    if let Some(raw) = obj.get("api_key_env") {
+        let api_key_env = raw
+            .as_str()
+            .ok_or_else(|| "configure: semantic.api_key_env must be a string".to_string())?
+            .trim()
+            .to_string();
+        semantic.api_key_env = if api_key_env.is_empty() {
+            None
+        } else {
+            Some(api_key_env)
+        };
+    }
+    if let Some(raw) = obj.get("timeout_ms") {
+        let timeout_ms = raw
+            .as_u64()
+            .ok_or_else(|| "configure: semantic.timeout_ms must be an unsigned integer".to_string())?;
+        semantic.timeout_ms = timeout_ms;
+    }
+    if let Some(raw) = obj.get("max_batch_size") {
+        let max_batch_size = raw
+            .as_u64()
+            .ok_or_else(|| "configure: semantic.max_batch_size must be an unsigned integer".to_string())?;
+        semantic.max_batch_size = usize::try_from(max_batch_size)
+            .map_err(|_| "configure: semantic.max_batch_size is too large".to_string())?;
+    }
+
+    Ok(semantic)
 }
 
 /// Handle a `configure` request.
@@ -150,16 +213,28 @@ pub fn handle_configure(req: &RawRequest, ctx: &AppContext) -> Response {
         ctx.config_mut().storage_dir = Some(storage_dir.clone());
         ctx.backup().borrow_mut().set_storage_dir(storage_dir);
     }
+    if let Some(v) = req.params.get("semantic") {
+        let current = ctx.config().semantic.clone();
+        let semantic = match parse_semantic_config(v, &current) {
+            Ok(config) => config,
+            Err(error) => {
+                return Response::error(&req.id, "invalid_request", error);
+            }
+        };
+        ctx.config_mut().semantic = semantic;
+    }
 
     let experimental_search_index = ctx.config().experimental_search_index;
     let experimental_semantic_search = ctx.config().experimental_semantic_search;
     let search_index_max_file_size = ctx.config().search_index_max_file_size;
+    let semantic_config = ctx.config().semantic.clone();
 
     *ctx.search_index().borrow_mut() = None;
     *ctx.search_index_rx().borrow_mut() = None;
     *ctx.semantic_index().borrow_mut() = None;
     *ctx.semantic_index_rx().borrow_mut() = None;
     *ctx.semantic_index_status().borrow_mut() = SemanticIndexStatus::Disabled;
+    *ctx.semantic_embedding_model().borrow_mut() = None;
 
     let storage_dir = ctx.config().storage_dir.clone();
 
@@ -216,7 +291,8 @@ pub fn handle_configure(req: &RawRequest, ctx: &AppContext) -> Response {
         *ctx.semantic_index_status().borrow_mut() = SemanticIndexStatus::Building {
             stage: "queued".to_string(),
             files: None,
-            entries: None,
+            entries_done: None,
+            entries_total: None,
         };
         let (tx, rx): (
             crossbeam_channel::Sender<SemanticIndexEvent>,
@@ -227,18 +303,30 @@ pub fn handle_configure(req: &RawRequest, ctx: &AppContext) -> Response {
         let root_clone = root_path.clone();
         let semantic_storage = storage_dir.clone();
         let semantic_project_key = crate::search_index::project_cache_key(&root_path);
+        let semantic_config = semantic_config.clone();
         let tx_progress = tx.clone();
         thread::spawn(move || {
             let build_result = catch_unwind(AssertUnwindSafe(
                 || -> Result<SemanticIndex, String> {
+                    let _ = tx_progress.send(SemanticIndexEvent::Progress {
+                        stage: "initializing_embedding_model".to_string(),
+                        files: None,
+                        entries_done: None,
+                        entries_total: None,
+                    });
+                    let mut model = crate::semantic_index::EmbeddingModel::from_config(&semantic_config)?;
+                    let fingerprint = model.fingerprint(&semantic_config)?;
+                    let fingerprint_key = fingerprint.as_string();
+
                     if let Some(ref dir) = semantic_storage {
                         if let Some(cached) =
-                            SemanticIndex::read_from_disk(dir, &semantic_project_key)
+                            SemanticIndex::read_from_disk(dir, &semantic_project_key, Some(&fingerprint_key))
                         {
                             let _ = tx_progress.send(SemanticIndexEvent::Progress {
                                 stage: "loaded_cached_index".to_string(),
                                 files: None,
-                                entries: Some(cached.entry_count()),
+                                entries_done: Some(cached.entry_count()),
+                                entries_total: Some(cached.entry_count()),
                             });
                             return Ok(cached);
                         }
@@ -249,7 +337,8 @@ pub fn handle_configure(req: &RawRequest, ctx: &AppContext) -> Response {
                     let _ = tx_progress.send(SemanticIndexEvent::Progress {
                         stage: "scanned_project_files".to_string(),
                         files: Some(files.len()),
-                        entries: None,
+                        entries_done: None,
+                        entries_total: None,
                     });
 
                     // Cap file count to prevent OOM on huge project roots (e.g., /home/user).
@@ -270,25 +359,31 @@ pub fn handle_configure(req: &RawRequest, ctx: &AppContext) -> Response {
                         ));
                     }
 
-                    let _ = tx_progress.send(SemanticIndexEvent::Progress {
-                        stage: "initializing_embedding_model".to_string(),
-                        files: Some(files.len()),
-                        entries: None,
-                    });
-                    let mut model = crate::semantic_index::initialize_text_embedding()?;
+                    let mut embed = |texts: Vec<String>| model.embed(texts);
 
-                    let mut embed = |texts: Vec<String>| {
-                        model
-                            .embed(texts, None::<usize>)
-                            .map_err(|error| error.to_string())
+                    let _ = tx_progress.send(SemanticIndexEvent::Progress {
+                        stage: "extracting_symbols".to_string(),
+                        files: Some(files.len()),
+                        entries_done: None,
+                        entries_total: None,
+                    });
+                    let mut progress = |done: usize, total: usize| {
+                        let _ = tx_progress.send(SemanticIndexEvent::Progress {
+                            stage: "embedding_symbols".to_string(),
+                            files: Some(files.len()),
+                            entries_done: Some(done),
+                            entries_total: Some(total),
+                        });
                     };
-
-                    let _ = tx_progress.send(SemanticIndexEvent::Progress {
-                        stage: "embedding_symbols".to_string(),
-                        files: Some(files.len()),
-                        entries: None,
-                    });
-                    let index = SemanticIndex::build(&root_clone, &files, &mut embed, 64)?;
+                    let index = SemanticIndex::build_with_progress(
+                        &root_clone,
+                        &files,
+                        &mut embed,
+                        semantic_config.max_batch_size.max(1),
+                        &mut progress,
+                    )?;
+                    let mut index = index;
+                    index.set_fingerprint(fingerprint);
                     log::info!(
                         "[aft] built semantic index: {} files, {} entries",
                         files.len(),
@@ -297,7 +392,8 @@ pub fn handle_configure(req: &RawRequest, ctx: &AppContext) -> Response {
                     let _ = tx_progress.send(SemanticIndexEvent::Progress {
                         stage: "persisting_index".to_string(),
                         files: Some(files.len()),
-                        entries: Some(index.len()),
+                        entries_done: Some(index.len()),
+                        entries_total: Some(index.len()),
                     });
 
                     if let Some(ref dir) = semantic_storage {

--- a/crates/aft/src/commands/semantic_search.rs
+++ b/crates/aft/src/commands/semantic_search.rs
@@ -43,12 +43,26 @@ pub fn handle_semantic_search(req: &RawRequest, ctx: &AppContext) -> Response {
                 }),
             );
         }
-        SemanticIndexStatus::Building => {
+        SemanticIndexStatus::Building {
+            stage,
+            files,
+            entries,
+        } => {
+            let mut detail = format!("Semantic index is still building (stage: {}).", stage);
+            if let Some(files) = files {
+                detail.push_str(&format!(" files: {}", files));
+            }
+            if let Some(entries) = entries {
+                detail.push_str(&format!(" entries: {}", entries));
+            }
             return Response::success(
                 &req.id,
                 serde_json::json!({
                     "status": "building",
-                    "text": "Semantic index is still building...",
+                    "text": detail,
+                    "stage": stage,
+                    "files": files,
+                    "entries": entries,
                 }),
             );
         }
@@ -77,7 +91,7 @@ pub fn handle_semantic_search(req: &RawRequest, ctx: &AppContext) -> Response {
                 &req.id,
                 serde_json::json!({
                     "status": "not_ready",
-                    "text": "Semantic index is still building...",
+                    "text": "Semantic index is not ready yet.",
                 }),
             );
         };

--- a/crates/aft/src/commands/semantic_search.rs
+++ b/crates/aft/src/commands/semantic_search.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use crate::context::{AppContext, SemanticIndexStatus};
 use crate::protocol::{RawRequest, Response};
 use crate::semantic_index::{
-    initialize_text_embedding, is_onnx_runtime_unavailable, SemanticResult,
+    EmbeddingModel, is_onnx_runtime_unavailable, SemanticResult,
 };
 use crate::symbols::SymbolKind;
 
@@ -46,14 +46,18 @@ pub fn handle_semantic_search(req: &RawRequest, ctx: &AppContext) -> Response {
         SemanticIndexStatus::Building {
             stage,
             files,
-            entries,
+            entries_done,
+            entries_total,
         } => {
             let mut detail = format!("Semantic index is still building (stage: {}).", stage);
             if let Some(files) = files {
                 detail.push_str(&format!(" files: {}", files));
             }
-            if let Some(entries) = entries {
-                detail.push_str(&format!(" entries: {}", entries));
+            if let Some(entries_done) = entries_done {
+                detail.push_str(&format!(" entries done: {}", entries_done));
+            }
+            if let Some(entries_total) = entries_total {
+                detail.push_str(&format!(" / {}", entries_total));
             }
             return Response::success(
                 &req.id,
@@ -62,7 +66,8 @@ pub fn handle_semantic_search(req: &RawRequest, ctx: &AppContext) -> Response {
                     "text": detail,
                     "stage": stage,
                     "files": files,
-                    "entries": entries,
+                    "entries_done": entries_done,
+                    "entries_total": entries_total,
                 }),
             );
         }
@@ -123,22 +128,33 @@ fn default_top_k() -> usize {
 
 fn embed_query(query: &str, ctx: &AppContext) -> Result<Vec<f32>, String> {
     let mut model_ref = ctx.semantic_embedding_model().borrow_mut();
+    let semantic_config = ctx.config().semantic.clone();
 
     if model_ref.is_none() {
-        *model_ref = Some(initialize_text_embedding()?);
+        *model_ref = Some(EmbeddingModel::from_config(&semantic_config)?);
     }
 
     let model = model_ref
         .as_mut()
         .ok_or_else(|| "embedding model was not initialized".to_string())?;
     let embeddings = model
-        .embed(vec![query.to_string()], None)
+        .embed(vec![query.to_string()])
         .map_err(|error| format!("failed to embed query: {error}"))?;
 
     let query_vector = embeddings
         .first()
         .cloned()
         .ok_or_else(|| "embedding model returned no query vector".to_string())?;
+
+    if let Some(index) = ctx.semantic_index().borrow().as_ref() {
+        if index.dimension() != query_vector.len() {
+            return Err(format!(
+                "semantic embedding dimension mismatch: query backend returned {}, index expects {}. Rebuild the semantic index for the active backend/model.",
+                query_vector.len(),
+                index.dimension()
+            ));
+        }
+    }
 
     Ok(query_vector)
 }

--- a/crates/aft/src/commands/status.rs
+++ b/crates/aft/src/commands/status.rs
@@ -41,25 +41,41 @@ pub fn handle_status(req: &RawRequest, ctx: &AppContext) -> Response {
                     "status": idx.status_label(),
                     "entries": idx.entry_count(),
                     "dimension": idx.dimension(),
+                    "backend": idx.backend_label().unwrap_or(config.semantic_backend_label()),
+                    "model": idx.model_label().unwrap_or(config.semantic.model.as_str()),
                 })
             }
             None => {
                 match &*ctx.semantic_index_status().borrow() {
-                    SemanticIndexStatus::Disabled => serde_json::json!({ "status": "disabled" }),
+                    SemanticIndexStatus::Disabled => serde_json::json!({
+                        "status": "disabled",
+                        "backend": config.semantic_backend_label(),
+                        "model": config.semantic.model.as_str(),
+                    }),
                     SemanticIndexStatus::Building {
                         stage,
                         files,
-                        entries,
+                        entries_done,
+                        entries_total,
                     } => serde_json::json!({
                         "status": "loading",
                         "stage": stage,
                         "files": files,
-                        "entries": entries,
+                        "entries_done": entries_done,
+                        "entries_total": entries_total,
+                        "backend": config.semantic_backend_label(),
+                        "model": config.semantic.model.as_str(),
                     }),
-                    SemanticIndexStatus::Ready => serde_json::json!({ "status": "ready" }),
+                    SemanticIndexStatus::Ready => serde_json::json!({
+                        "status": "ready",
+                        "backend": config.semantic_backend_label(),
+                        "model": config.semantic.model.as_str(),
+                    }),
                     SemanticIndexStatus::Failed(error) => serde_json::json!({
                         "status": "failed",
                         "error": error,
+                        "backend": config.semantic_backend_label(),
+                        "model": config.semantic.model.as_str(),
                     }),
                 }
             }

--- a/crates/aft/src/commands/status.rs
+++ b/crates/aft/src/commands/status.rs
@@ -1,6 +1,7 @@
 //! AFT status command — returns the current state of indexes, features, and configuration.
 
 use crate::context::AppContext;
+use crate::context::SemanticIndexStatus;
 use crate::protocol::{RawRequest, Response};
 
 pub fn handle_status(req: &RawRequest, ctx: &AppContext) -> Response {
@@ -43,12 +44,24 @@ pub fn handle_status(req: &RawRequest, ctx: &AppContext) -> Response {
                 })
             }
             None => {
-                let status = if ctx.config().experimental_semantic_search {
-                    "loading"
-                } else {
-                    "disabled"
-                };
-                serde_json::json!({ "status": status })
+                match &*ctx.semantic_index_status().borrow() {
+                    SemanticIndexStatus::Disabled => serde_json::json!({ "status": "disabled" }),
+                    SemanticIndexStatus::Building {
+                        stage,
+                        files,
+                        entries,
+                    } => serde_json::json!({
+                        "status": "loading",
+                        "stage": stage,
+                        "files": files,
+                        "entries": entries,
+                    }),
+                    SemanticIndexStatus::Ready => serde_json::json!({ "status": "ready" }),
+                    SemanticIndexStatus::Failed(error) => serde_json::json!({
+                        "status": "failed",
+                        "error": error,
+                    }),
+                }
             }
         }
     };

--- a/crates/aft/src/config.rs
+++ b/crates/aft/src/config.rs
@@ -4,7 +4,63 @@ use std::path::PathBuf;
 ///
 /// Holds project-scoped settings and tuning knobs. Values are set at startup
 /// and remain immutable for the lifetime of the process.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SemanticBackend {
+    Fastembed,
+    OpenAiCompatible,
+    Ollama,
+}
+
+impl SemanticBackend {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Fastembed => "fastembed",
+            Self::OpenAiCompatible => "openai_compatible",
+            Self::Ollama => "ollama",
+        }
+    }
+
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "fastembed" => Some(Self::Fastembed),
+            "openai_compatible" => Some(Self::OpenAiCompatible),
+            "ollama" => Some(Self::Ollama),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SemanticBackendConfig {
+    pub backend: SemanticBackend,
+    pub model: String,
+    pub base_url: Option<String>,
+    pub api_key_env: Option<String>,
+    pub timeout_ms: u64,
+    pub max_batch_size: usize,
+}
+
+impl Default for SemanticBackendConfig {
+    fn default() -> Self {
+        Self {
+            backend: SemanticBackend::Fastembed,
+            model: DEFAULT_SEMANTIC_MODEL.to_string(),
+            base_url: None,
+            api_key_env: None,
+            timeout_ms: 60_000,
+            max_batch_size: 64,
+        }
+    }
+}
+
+pub const DEFAULT_SEMANTIC_MODEL: &str = "all-MiniLM-L6-v2";
+
+impl Config {
+    pub fn semantic_backend_label(&self) -> &'static str {
+        self.semantic.backend.as_str()
+    }
+}
+
 pub struct Config {
     /// Root directory of the project being analyzed. `None` if not scoped.
     pub project_root: Option<PathBuf>,
@@ -38,6 +94,7 @@ pub struct Config {
     pub experimental_semantic_search: bool,
     /// Maximum file size to fully index in bytes (default: 1MB).
     pub search_index_max_file_size: u64,
+    pub semantic: SemanticBackendConfig,
     /// Persistent storage directory for indexes (trigram, semantic).
     /// Set by the plugin to the XDG-compliant path (e.g. ~/.local/share/opencode/storage/plugin/aft/).
     /// Falls back to ~/.cache/aft/ if not set.
@@ -63,6 +120,7 @@ impl Default for Config {
             experimental_search_index: false,
             experimental_semantic_search: false,
             search_index_max_file_size: 1_048_576,
+            semantic: SemanticBackendConfig::default(),
             storage_dir: None,
         }
     }

--- a/crates/aft/src/context.rs
+++ b/crates/aft/src/context.rs
@@ -17,12 +17,21 @@ use crate::semantic_index::SemanticIndex;
 #[derive(Debug, Clone)]
 pub enum SemanticIndexStatus {
     Disabled,
-    Building,
+    Building {
+        stage: String,
+        files: Option<usize>,
+        entries: Option<usize>,
+    },
     Ready,
     Failed(String),
 }
 
 pub enum SemanticIndexEvent {
+    Progress {
+        stage: String,
+        files: Option<usize>,
+        entries: Option<usize>,
+    },
     Ready(SemanticIndex),
     Failed(String),
 }

--- a/crates/aft/src/context.rs
+++ b/crates/aft/src/context.rs
@@ -2,7 +2,6 @@ use std::cell::{Ref, RefCell, RefMut};
 use std::path::{Component, Path, PathBuf};
 use std::sync::mpsc;
 
-use fastembed::TextEmbedding;
 use notify::RecommendedWatcher;
 
 use crate::backup::BackupStore;
@@ -20,7 +19,8 @@ pub enum SemanticIndexStatus {
     Building {
         stage: String,
         files: Option<usize>,
-        entries: Option<usize>,
+        entries_done: Option<usize>,
+        entries_total: Option<usize>,
     },
     Ready,
     Failed(String),
@@ -30,7 +30,8 @@ pub enum SemanticIndexEvent {
     Progress {
         stage: String,
         files: Option<usize>,
-        entries: Option<usize>,
+        entries_done: Option<usize>,
+        entries_total: Option<usize>,
     },
     Ready(SemanticIndex),
     Failed(String),
@@ -102,7 +103,7 @@ pub struct AppContext {
     semantic_index: RefCell<Option<SemanticIndex>>,
     semantic_index_rx: RefCell<Option<crossbeam_channel::Receiver<SemanticIndexEvent>>>,
     semantic_index_status: RefCell<SemanticIndexStatus>,
-    semantic_embedding_model: RefCell<Option<TextEmbedding>>,
+    semantic_embedding_model: RefCell<Option<crate::semantic_index::EmbeddingModel>>,
     watcher: RefCell<Option<RecommendedWatcher>>,
     watcher_rx: RefCell<Option<mpsc::Receiver<notify::Result<notify::Event>>>>,
     lsp_manager: RefCell<LspManager>,
@@ -188,7 +189,7 @@ impl AppContext {
     }
 
     /// Access the cached semantic embedding model.
-    pub fn semantic_embedding_model(&self) -> &RefCell<Option<TextEmbedding>> {
+    pub fn semantic_embedding_model(&self) -> &RefCell<Option<crate::semantic_index::EmbeddingModel>> {
         &self.semantic_embedding_model
     }
 

--- a/crates/aft/src/main.rs
+++ b/crates/aft/src/main.rs
@@ -348,12 +348,14 @@ fn drain_semantic_index_events(ctx: &AppContext) {
             SemanticIndexEvent::Progress {
                 stage,
                 files,
-                entries,
+                entries_done,
+                entries_total,
             } => {
                 *ctx.semantic_index_status().borrow_mut() = SemanticIndexStatus::Building {
                     stage,
                     files,
-                    entries,
+                    entries_done,
+                    entries_total,
                 };
             }
             SemanticIndexEvent::Ready(index) => {

--- a/crates/aft/src/main.rs
+++ b/crates/aft/src/main.rs
@@ -325,31 +325,52 @@ fn drain_search_index_events(ctx: &AppContext) {
 }
 
 fn drain_semantic_index_events(ctx: &AppContext) {
-    let latest = {
+    let events = {
         let rx_ref = ctx.semantic_index_rx().borrow();
         let Some(rx) = rx_ref.as_ref() else {
             return;
         };
 
-        let mut latest = None;
+        let mut events = Vec::new();
         while let Ok(event) = rx.try_recv() {
-            latest = Some(event);
+            events.push(event);
         }
-        latest
+        events
     };
 
-    if let Some(event) = latest {
-        *ctx.semantic_index_rx().borrow_mut() = None;
+    if events.is_empty() {
+        return;
+    }
+
+    let mut keep_receiver = true;
+    for event in events {
         match event {
+            SemanticIndexEvent::Progress {
+                stage,
+                files,
+                entries,
+            } => {
+                *ctx.semantic_index_status().borrow_mut() = SemanticIndexStatus::Building {
+                    stage,
+                    files,
+                    entries,
+                };
+            }
             SemanticIndexEvent::Ready(index) => {
                 *ctx.semantic_index().borrow_mut() = Some(index);
                 *ctx.semantic_index_status().borrow_mut() = SemanticIndexStatus::Ready;
+                keep_receiver = false;
             }
             SemanticIndexEvent::Failed(error) => {
                 *ctx.semantic_index().borrow_mut() = None;
                 *ctx.semantic_index_status().borrow_mut() = SemanticIndexStatus::Failed(error);
+                keep_receiver = false;
             }
         }
+    }
+
+    if !keep_receiver {
+        *ctx.semantic_index_rx().borrow_mut() = None;
     }
 }
 

--- a/crates/aft/src/semantic_index.rs
+++ b/crates/aft/src/semantic_index.rs
@@ -1,21 +1,397 @@
 use crate::parser::FileParser;
 use crate::symbols::{Symbol, SymbolKind};
+use crate::config::{SemanticBackend, SemanticBackendConfig};
 
-use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
+use fastembed::{EmbeddingModel as FastembedEmbeddingModel, InitOptions, TextEmbedding};
+use serde::{Deserialize, Serialize};
+use reqwest::blocking::Client;
 use std::collections::HashMap;
+use std::env;
 use std::fmt::Display;
 use std::fs;
-use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
+use std::time::Duration;
+use url::Url;
 
 const DEFAULT_DIMENSION: usize = 384;
 const MAX_ENTRIES: usize = 1_000_000;
 const MAX_DIMENSION: usize = 1024;
 const F32_BYTES: usize = std::mem::size_of::<f32>();
-const HEADER_BYTES: usize = 9;
+const HEADER_BYTES_V1: usize = 9;
+const HEADER_BYTES_V2: usize = 13;
 const ONNX_RUNTIME_INSTALL_HINT: &str =
     "ONNX Runtime not found. Install via: brew install onnxruntime (macOS) or apt install libonnxruntime (Linux).";
+
+const SEMANTIC_INDEX_VERSION_V1: u8 = 1;
+const SEMANTIC_INDEX_VERSION_V2: u8 = 2;
+const DEFAULT_OPENAI_EMBEDDING_PATH: &str = "/embeddings";
+const DEFAULT_OLLAMA_EMBEDDING_PATH: &str = "/api/embed";
+const DEFAULT_OPENAI_EMBEDDING_TIMEOUT_MS: u64 = 60_000;
+const DEFAULT_MAX_BATCH_SIZE: usize = 64;
+const FALLBACK_BACKEND: &str = "none";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SemanticIndexFingerprint {
+    pub backend: String,
+    pub model: String,
+    #[serde(default)]
+    pub base_url: String,
+    pub dimension: usize,
+}
+
+impl SemanticIndexFingerprint {
+    fn from_config(config: &SemanticBackendConfig, dimension: usize) -> Self {
+        Self {
+            backend: config.backend.as_str().to_string(),
+            model: config.model.clone(),
+            base_url: config
+                .base_url
+                .clone()
+                .unwrap_or_else(|| FALLBACK_BACKEND.to_string()),
+            dimension,
+        }
+    }
+
+    pub fn as_string(&self) -> String {
+        serde_json::to_string(self).unwrap_or_else(|_| String::new())
+    }
+
+    fn matches_expected(&self, expected: &str) -> bool {
+        let encoded = self.as_string();
+        !encoded.is_empty() && encoded == expected
+    }
+}
+
+enum SemanticEmbeddingEngine {
+    Fastembed(TextEmbedding),
+    OpenAiCompatible {
+        client: Client,
+        model: String,
+        base_url: String,
+        api_key: Option<String>,
+    },
+    Ollama {
+        client: Client,
+        model: String,
+        base_url: String,
+    },
+}
+
+pub struct SemanticEmbeddingModel {
+    backend: SemanticBackend,
+    model: String,
+    base_url: Option<String>,
+    timeout_ms: u64,
+    max_batch_size: usize,
+    dimension: Option<usize>,
+    engine: SemanticEmbeddingEngine,
+}
+
+pub type EmbeddingModel = SemanticEmbeddingModel;
+
+fn normalize_base_url(raw: &str) -> Result<String, String> {
+    let parsed = Url::parse(raw).map_err(|error| format!("invalid base_url '{raw}': {error}"))?;
+    Ok(parsed.to_string().trim_end_matches('/').to_string())
+}
+
+fn build_openai_embeddings_endpoint(base_url: &str) -> String {
+    if base_url.ends_with("/v1") {
+        format!("{base_url}{DEFAULT_OPENAI_EMBEDDING_PATH}")
+    } else {
+        format!("{base_url}/v1{}", DEFAULT_OPENAI_EMBEDDING_PATH)
+    }
+}
+
+fn build_ollama_embeddings_endpoint(base_url: &str) -> String {
+    if base_url.ends_with("/api") {
+        format!("{base_url}/embed")
+    } else {
+        format!("{base_url}{DEFAULT_OLLAMA_EMBEDDING_PATH}")
+    }
+}
+
+fn normalize_api_key(value: Option<String>) -> Option<String> {
+    value.and_then(|token| {
+        let token = token.trim();
+        if token.is_empty() {
+            None
+        } else {
+            Some(token.to_string())
+        }
+    })
+}
+
+impl SemanticEmbeddingModel {
+    pub fn from_config(config: &SemanticBackendConfig) -> Result<Self, String> {
+        let timeout_ms = if config.timeout_ms == 0 {
+            DEFAULT_OPENAI_EMBEDDING_TIMEOUT_MS
+        } else {
+            config.timeout_ms
+        };
+
+        let max_batch_size = if config.max_batch_size == 0 {
+            DEFAULT_MAX_BATCH_SIZE
+        } else {
+            config.max_batch_size
+        };
+
+        let api_key_env = normalize_api_key(config.api_key_env.clone());
+        let model = config.model.clone();
+
+        let client = Client::builder()
+            .timeout(Duration::from_millis(timeout_ms))
+            .build()
+            .map_err(|error| format!("failed to configure embedding client: {error}"))?;
+
+        let engine = match config.backend {
+            SemanticBackend::Fastembed => SemanticEmbeddingEngine::Fastembed(
+                initialize_text_embedding(&model)?,
+            ),
+            SemanticBackend::OpenAiCompatible => {
+                let raw = config
+                    .base_url
+                    .as_ref()
+                    .ok_or_else(|| "base_url is required for openai_compatible backend".to_string())?;
+                let base_url = normalize_base_url(raw)?;
+
+                let api_key = match api_key_env {
+                    Some(var_name) => Some(
+                        env::var(&var_name).map_err(|_| {
+                            format!(
+                                "missing api_key_env '{var_name}' for openai_compatible backend"
+                            )
+                        })?,
+                    ),
+                    None => None,
+                };
+
+                SemanticEmbeddingEngine::OpenAiCompatible {
+                    client,
+                    model,
+                    base_url,
+                    api_key,
+                }
+            }
+            SemanticBackend::Ollama => {
+                let raw = config
+                    .base_url
+                    .as_ref()
+                    .ok_or_else(|| "base_url is required for ollama backend".to_string())?;
+                let base_url = normalize_base_url(raw)?;
+
+                SemanticEmbeddingEngine::Ollama {
+                    client,
+                    model,
+                    base_url,
+                }
+            }
+        };
+
+        Ok(Self {
+            backend: config.backend,
+            model: config.model.clone(),
+            base_url: config.base_url.clone(),
+            timeout_ms,
+            max_batch_size,
+            dimension: None,
+            engine,
+        })
+    }
+
+    pub fn backend(&self) -> SemanticBackend {
+        self.backend
+    }
+
+    pub fn model(&self) -> &str {
+        &self.model
+    }
+
+    pub fn base_url(&self) -> Option<&str> {
+        self.base_url.as_deref()
+    }
+
+    pub fn max_batch_size(&self) -> usize {
+        self.max_batch_size
+    }
+
+    pub fn timeout_ms(&self) -> u64 {
+        self.timeout_ms
+    }
+
+    pub fn fingerprint(&mut self, config: &SemanticBackendConfig) -> Result<SemanticIndexFingerprint, String> {
+        let dimension = self.dimension()?;
+        Ok(SemanticIndexFingerprint::from_config(config, dimension))
+    }
+
+    pub fn dimension(&mut self) -> Result<usize, String> {
+        if let Some(dimension) = self.dimension {
+            return Ok(dimension);
+        }
+
+        let dimension = match &mut self.engine {
+            SemanticEmbeddingEngine::Fastembed(model) => {
+                let vectors = model
+                    .embed(vec!["semantic index fingerprint probe".to_string()], None)
+                    .map_err(|error| format_embedding_init_error(error.to_string()))?;
+                vectors
+                    .first()
+                    .map(|v| v.len())
+                    .ok_or_else(|| "embedding backend returned no vectors".to_string())?
+            }
+            SemanticEmbeddingEngine::OpenAiCompatible { .. } => {
+                let vectors = self.embed_texts(vec!["semantic index fingerprint probe".to_string()])?;
+                vectors
+                    .first()
+                    .map(|v| v.len())
+                    .ok_or_else(|| "embedding backend returned no vectors".to_string())?
+            }
+            SemanticEmbeddingEngine::Ollama { .. } => {
+                let vectors = self.embed_texts(vec!["semantic index fingerprint probe".to_string()])?;
+                vectors
+                    .first()
+                    .map(|v| v.len())
+                    .ok_or_else(|| "embedding backend returned no vectors".to_string())?
+            }
+        };
+
+        self.dimension = Some(dimension);
+        Ok(dimension)
+    }
+
+    pub fn embed(&mut self, texts: Vec<String>) -> Result<Vec<Vec<f32>>, String> {
+        self.embed_texts(texts)
+    }
+
+    fn embed_texts(&mut self, texts: Vec<String>) -> Result<Vec<Vec<f32>>, String> {
+        match &mut self.engine {
+            SemanticEmbeddingEngine::Fastembed(model) => model
+                .embed(texts, None::<usize>)
+                .map_err(|error| format_embedding_init_error(error.to_string()))
+                .map_err(|error| format!("failed to embed batch: {error}")),
+            SemanticEmbeddingEngine::OpenAiCompatible {
+                client,
+                model,
+                base_url,
+                api_key,
+            } => {
+                let endpoint = build_openai_embeddings_endpoint(base_url);
+                let body = serde_json::json!({
+                    "input": texts,
+                    "model": model,
+                });
+
+                let mut request = client
+                    .post(&endpoint)
+                    .json(&body)
+                    .header("Content-Type", "application/json");
+
+                if let Some(api_key) = api_key {
+                    request = request.header("Authorization", format!("Bearer {api_key}"));
+                }
+
+                let response = request
+                    .send()
+                    .map_err(|error| format!("openai compatible request failed: {error}"))?;
+                let status = response.status();
+                let raw = response
+                    .text()
+                    .map_err(|error| format!("openai compatible response read failed: {error}"))?;
+                if !status.is_success() {
+                    return Err(format!(
+                        "openai compatible request failed (HTTP {}): {}",
+                        status, raw
+                    ));
+                }
+
+                #[derive(Deserialize)]
+                struct OpenAiResponse {
+                    data: Vec<OpenAiEmbeddingResult>,
+                }
+
+                #[derive(Deserialize)]
+                struct OpenAiEmbeddingResult {
+                    embedding: Vec<f32>,
+                    index: Option<u32>,
+                }
+
+                let parsed: OpenAiResponse = serde_json::from_str(&raw)
+                    .map_err(|error| format!("invalid openai compatible response: {error}"))?;
+
+                let mut vectors = vec![Vec::new(); parsed.data.len()];
+                for item in parsed.data {
+                    let index = item.index.unwrap_or(0) as usize;
+                    if index >= vectors.len() {
+                        return Err("openai compatible response contains invalid vector index".to_string());
+                    }
+                    vectors[index] = item.embedding;
+                }
+
+                for vector in &vectors {
+                    if vector.is_empty() {
+                        return Err("openai compatible response contained missing vectors".to_string());
+                    }
+                }
+
+                self.dimension = vectors.first().map(Vec::len);
+                Ok(vectors)
+            }
+            SemanticEmbeddingEngine::Ollama {
+                client,
+                model,
+                base_url,
+            } => {
+                let endpoint = build_ollama_embeddings_endpoint(base_url);
+
+                #[derive(Serialize)]
+                struct OllamaPayload<'a> {
+                    model: &'a str,
+                    input: Vec<String>,
+                }
+
+                let payload = OllamaPayload {
+                    model,
+                    input: texts,
+                };
+
+                let response = client
+                    .post(&endpoint)
+                    .json(&payload)
+                    .header("Content-Type", "application/json")
+                    .send()
+                    .map_err(|error| format!("ollama request failed: {error}"))?;
+                let status = response.status();
+                let raw = response
+                    .text()
+                    .map_err(|error| format!("ollama response read failed: {error}"))?;
+                if !status.is_success() {
+                    return Err(format!("ollama request failed (HTTP {}): {}", status, raw));
+                }
+
+                #[derive(Deserialize)]
+                struct OllamaResponse {
+                    embeddings: Vec<Vec<f32>>,
+                }
+
+                let parsed: OllamaResponse = serde_json::from_str(&raw)
+                    .map_err(|error| format!("invalid ollama response: {error}"))?;
+                if parsed.embeddings.is_empty() {
+                    return Err("ollama response returned no embeddings".to_string());
+                }
+
+                let vectors = parsed.embeddings;
+                for vector in &vectors {
+                    if vector.is_empty() {
+                        return Err("ollama response contained empty embeddings".to_string());
+                    }
+                }
+
+                self.dimension = vectors.first().map(Vec::len);
+                Ok(vectors)
+            }
+        }
+    }
+}
 
 /// Pre-validate ONNX Runtime by attempting a raw dlopen before ort touches it.
 /// This catches broken/incompatible .so files without risking a panic in the ort crate.
@@ -147,11 +523,16 @@ fn suggest_removal_command(lib_path: &str) -> String {
     format!("   rm '{}'", lib_path)
 }
 
-pub fn initialize_text_embedding() -> Result<TextEmbedding, String> {
+pub fn initialize_text_embedding(model: &str) -> Result<TextEmbedding, String> {
     // Pre-validate before ort can panic on a bad library
     pre_validate_onnx_runtime()?;
 
-    TextEmbedding::try_new(InitOptions::new(EmbeddingModel::AllMiniLML6V2))
+    let selected_model = match model {
+        "all-MiniLM-L6-v2" | "all-minilm-l6-v2" => FastembedEmbeddingModel::AllMiniLML6V2,
+        _ => FastembedEmbeddingModel::AllMiniLML6V2,
+    };
+
+    TextEmbedding::try_new(InitOptions::new(selected_model))
         .map_err(format_embedding_init_error)
 }
 
@@ -224,6 +605,7 @@ pub struct SemanticIndex {
     file_mtimes: HashMap<PathBuf, SystemTime>,
     /// Embedding dimension (384 for MiniLM-L6-v2)
     dimension: usize,
+    fingerprint: Option<SemanticIndexFingerprint>,
 }
 
 /// Search result from a semantic query
@@ -245,6 +627,7 @@ impl SemanticIndex {
             entries: Vec::new(),
             file_mtimes: HashMap::new(),
             dimension: DEFAULT_DIMENSION, // MiniLM-L6-v2 default
+            fingerprint: None,
         }
     }
 
@@ -262,22 +645,14 @@ impl SemanticIndex {
         }
     }
 
-    /// Build the semantic index from a set of files using the provided embedding function.
-    /// `embed_fn` takes a batch of texts and returns a batch of embedding vectors.
-    pub fn build<F>(
+    fn collect_chunks(
         project_root: &Path,
         files: &[PathBuf],
-        embed_fn: &mut F,
-        max_batch_size: usize,
-    ) -> Result<Self, String>
-    where
-        F: FnMut(Vec<String>) -> Result<Vec<Vec<f32>>, String>,
-    {
+    ) -> (Vec<SemanticChunk>, HashMap<PathBuf, SystemTime>) {
         let mut parser = FileParser::new();
         let mut chunks: Vec<SemanticChunk> = Vec::new();
         let mut file_mtimes: HashMap<PathBuf, SystemTime> = HashMap::new();
 
-        // Extract chunks from all files
         for file in files {
             let mtime = std::fs::metadata(file)
                 .and_then(|m| m.modified())
@@ -297,11 +672,28 @@ impl SemanticIndex {
             chunks.extend(file_chunks);
         }
 
+        (chunks, file_mtimes)
+    }
+
+    fn build_from_chunks<F, P>(
+        chunks: Vec<SemanticChunk>,
+        file_mtimes: HashMap<PathBuf, SystemTime>,
+        embed_fn: &mut F,
+        max_batch_size: usize,
+        mut progress: Option<&mut P>,
+    ) -> Result<Self, String>
+    where
+        F: FnMut(Vec<String>) -> Result<Vec<Vec<f32>>, String>,
+        P: FnMut(usize, usize),
+    {
+        let total_chunks = chunks.len();
+
         if chunks.is_empty() {
             return Ok(Self {
                 entries: Vec::new(),
                 file_mtimes,
                 dimension: DEFAULT_DIMENSION,
+                fingerprint: None,
             });
         }
 
@@ -324,6 +716,10 @@ impl SemanticIndex {
                     vector,
                 });
             }
+
+            if let Some(callback) = progress.as_mut() {
+                callback(entries.len(), total_chunks);
+            }
         }
 
         let dimension = entries
@@ -335,7 +731,53 @@ impl SemanticIndex {
             entries,
             file_mtimes,
             dimension,
+            fingerprint: None,
         })
+    }
+
+    /// Build the semantic index from a set of files using the provided embedding function.
+    /// `embed_fn` takes a batch of texts and returns a batch of embedding vectors.
+    pub fn build<F>(
+        project_root: &Path,
+        files: &[PathBuf],
+        embed_fn: &mut F,
+        max_batch_size: usize,
+    ) -> Result<Self, String>
+    where
+        F: FnMut(Vec<String>) -> Result<Vec<Vec<f32>>, String>,
+    {
+        let (chunks, file_mtimes) = Self::collect_chunks(project_root, files);
+        Self::build_from_chunks(
+            chunks,
+            file_mtimes,
+            embed_fn,
+            max_batch_size,
+            Option::<&mut fn(usize, usize)>::None,
+        )
+    }
+
+    /// Build the semantic index and report embedding progress using entry counts.
+    pub fn build_with_progress<F, P>(
+        project_root: &Path,
+        files: &[PathBuf],
+        embed_fn: &mut F,
+        max_batch_size: usize,
+        progress: &mut P,
+    ) -> Result<Self, String>
+    where
+        F: FnMut(Vec<String>) -> Result<Vec<Vec<f32>>, String>,
+        P: FnMut(usize, usize),
+    {
+        let (chunks, file_mtimes) = Self::collect_chunks(project_root, files);
+        let total_chunks = chunks.len();
+        progress(0, total_chunks);
+        Self::build_from_chunks(
+            chunks,
+            file_mtimes,
+            embed_fn,
+            max_batch_size,
+            Some(progress),
+        )
     }
 
     /// Search the index with a query embedding, returning top-K results sorted by relevance
@@ -407,6 +849,22 @@ impl SemanticIndex {
         self.dimension
     }
 
+    pub fn fingerprint(&self) -> Option<&SemanticIndexFingerprint> {
+        self.fingerprint.as_ref()
+    }
+
+    pub fn backend_label(&self) -> Option<&str> {
+        self.fingerprint.as_ref().map(|f| f.backend.as_str())
+    }
+
+    pub fn model_label(&self) -> Option<&str> {
+        self.fingerprint.as_ref().map(|f| f.model.as_str())
+    }
+
+    pub fn set_fingerprint(&mut self, fingerprint: SemanticIndexFingerprint) {
+        self.fingerprint = Some(fingerprint);
+    }
+
     /// Write the semantic index to disk using atomic temp+rename pattern
     pub fn write_to_disk(&self, storage_dir: &Path, project_key: &str) {
         // Don't persist empty indexes — they would be loaded on next startup
@@ -441,38 +899,21 @@ impl SemanticIndex {
     }
 
     /// Read the semantic index from disk
-    pub fn read_from_disk(storage_dir: &Path, project_key: &str) -> Option<Self> {
+    pub fn read_from_disk(
+        storage_dir: &Path,
+        project_key: &str,
+        expected_fingerprint: Option<&str>,
+    ) -> Option<Self> {
         let data_path = storage_dir
             .join("semantic")
             .join(project_key)
             .join("semantic.bin");
         let file_len = usize::try_from(fs::metadata(&data_path).ok()?.len()).ok()?;
-        if file_len < HEADER_BYTES {
+        if file_len < HEADER_BYTES_V1 {
             log::warn!(
                 "[aft] corrupt semantic index (too small: {} bytes), removing",
                 file_len
             );
-            let _ = fs::remove_file(&data_path);
-            return None;
-        }
-
-        let mut header = [0u8; HEADER_BYTES];
-        fs::File::open(&data_path)
-            .ok()?
-            .read_exact(&mut header)
-            .ok()?;
-        let version = header[0];
-        let dimension = u32::from_le_bytes(header[1..5].try_into().ok()?) as usize;
-        let entry_count = u32::from_le_bytes(header[5..9].try_into().ok()?) as usize;
-        if version != 1 || dimension == 0 || dimension > MAX_DIMENSION || entry_count > MAX_ENTRIES
-        {
-            let _ = fs::remove_file(&data_path);
-            return None;
-        }
-        let minimum_vector_bytes = entry_count
-            .checked_mul(dimension)
-            .and_then(|count| count.checked_mul(F32_BYTES))?;
-        if minimum_vector_bytes > file_len.saturating_sub(HEADER_BYTES) {
             let _ = fs::remove_file(&data_path);
             return None;
         }
@@ -484,6 +925,17 @@ impl SemanticIndex {
                     log::info!("[aft] cached semantic index is empty, will rebuild");
                     let _ = fs::remove_file(&data_path);
                     return None;
+                }
+                if let Some(expected) = expected_fingerprint {
+                    let matches = index
+                        .fingerprint()
+                        .map(|fingerprint| fingerprint.matches_expected(expected))
+                        .unwrap_or(false);
+                    if !matches {
+                        log::info!("[aft] cached semantic index fingerprint mismatch, rebuilding");
+                        let _ = fs::remove_file(&data_path);
+                        return None;
+                    }
                 }
                 log::info!(
                     "[aft] loaded semantic index from disk: {} entries",
@@ -502,11 +954,31 @@ impl SemanticIndex {
     /// Serialize the index to bytes for disk persistence
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut buf = Vec::new();
+        let fingerprint_bytes = self
+            .fingerprint
+            .as_ref()
+            .and_then(|fingerprint| {
+                let encoded = fingerprint.as_string();
+                if encoded.is_empty() {
+                    None
+                } else {
+                    Some(encoded.into_bytes())
+                }
+            });
 
-        // Header: version(1) + dimension(4) + entry_count(4)
-        buf.push(1u8); // version
+        // Header: version(1) + dimension(4) + entry_count(4) [+ fingerprint_len(4)]
+        let version = if fingerprint_bytes.is_some() {
+            SEMANTIC_INDEX_VERSION_V2
+        } else {
+            SEMANTIC_INDEX_VERSION_V1
+        };
+        buf.push(version);
         buf.extend_from_slice(&(self.dimension as u32).to_le_bytes());
         buf.extend_from_slice(&(self.entries.len() as u32).to_le_bytes());
+        if let Some(bytes) = &fingerprint_bytes {
+            buf.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
+            buf.extend_from_slice(bytes);
+        }
 
         // File mtime table: count(4) + entries
         buf.extend_from_slice(&(self.file_mtimes.len() as u32).to_le_bytes());
@@ -565,14 +1037,17 @@ impl SemanticIndex {
     pub fn from_bytes(data: &[u8]) -> Result<Self, String> {
         let mut pos = 0;
 
-        if data.len() < 9 {
+        if data.len() < HEADER_BYTES_V1 {
             return Err("data too short".to_string());
         }
 
         let version = data[pos];
         pos += 1;
-        if version != 1 {
+        if version != SEMANTIC_INDEX_VERSION_V1 && version != SEMANTIC_INDEX_VERSION_V2 {
             return Err(format!("unsupported version: {}", version));
+        }
+        if version == SEMANTIC_INDEX_VERSION_V2 && data.len() < HEADER_BYTES_V2 {
+            return Err("data too short for semantic index v2 header".to_string());
         }
 
         let dimension = read_u32(data, &mut pos)? as usize;
@@ -583,6 +1058,21 @@ impl SemanticIndex {
         if entry_count > MAX_ENTRIES {
             return Err(format!("too many semantic index entries: {}", entry_count));
         }
+
+        let fingerprint = if version == SEMANTIC_INDEX_VERSION_V2 {
+            let fingerprint_len = read_u32(data, &mut pos)? as usize;
+            if pos + fingerprint_len > data.len() {
+                return Err("unexpected end of data reading fingerprint".to_string());
+            }
+            let raw = String::from_utf8_lossy(&data[pos..pos + fingerprint_len]).to_string();
+            pos += fingerprint_len;
+            Some(
+                serde_json::from_str::<SemanticIndexFingerprint>(&raw)
+                    .map_err(|error| format!("invalid semantic fingerprint: {error}"))?,
+            )
+        } else {
+            None
+        };
 
         // File mtimes
         let mtime_count = read_u32(data, &mut pos)? as usize;
@@ -663,6 +1153,7 @@ impl SemanticIndex {
             entries,
             file_mtimes,
             dimension,
+            fingerprint,
         })
     }
 }
@@ -860,6 +1351,70 @@ fn read_string(data: &[u8], pos: &mut usize) -> Result<String, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::{SemanticBackend, SemanticBackendConfig};
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    fn start_mock_http_server<F>(handler: F) -> (String, thread::JoinHandle<()>)
+    where
+        F: Fn(String, String, String) -> String + Send + 'static,
+    {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let addr = listener.local_addr().expect("local addr");
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            let mut buf = Vec::new();
+            let mut chunk = [0u8; 4096];
+            let mut header_end = None;
+            let mut content_length = 0usize;
+            loop {
+                let n = stream.read(&mut chunk).expect("read request");
+                if n == 0 {
+                    break;
+                }
+                buf.extend_from_slice(&chunk[..n]);
+                if header_end.is_none() {
+                    if let Some(pos) = buf.windows(4).position(|window| window == b"\r\n\r\n") {
+                        header_end = Some(pos + 4);
+                        let headers = String::from_utf8_lossy(&buf[..pos + 4]);
+                        for line in headers.lines() {
+                            if let Some(value) = line.strip_prefix("Content-Length:") {
+                                content_length = value.trim().parse::<usize>().unwrap_or(0);
+                            }
+                        }
+                    }
+                }
+                if let Some(end) = header_end {
+                    if buf.len() >= end + content_length {
+                        break;
+                    }
+                }
+            }
+
+            let end = header_end.expect("header terminator");
+            let request = String::from_utf8_lossy(&buf[..end]).to_string();
+            let body = String::from_utf8_lossy(&buf[end..end + content_length]).to_string();
+            let mut lines = request.lines();
+            let request_line = lines.next().expect("request line").to_string();
+            let path = request_line
+                .split_whitespace()
+                .nth(1)
+                .expect("request path")
+                .to_string();
+            let response_body = handler(request_line, path, body);
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                response_body.len(),
+                response_body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write response");
+        });
+
+        (format!("http://{}", addr), handle)
+    }
 
     #[test]
     fn test_cosine_similarity_identical() {
@@ -902,6 +1457,12 @@ mod tests {
         index
             .file_mtimes
             .insert(PathBuf::from("/src/main.rs"), SystemTime::UNIX_EPOCH);
+        index.set_fingerprint(SemanticIndexFingerprint {
+            backend: "fastembed".to_string(),
+            model: "all-MiniLM-L6-v2".to_string(),
+            base_url: FALLBACK_BACKEND.to_string(),
+            dimension: 4,
+        });
 
         let bytes = index.to_bytes();
         let restored = SemanticIndex::from_bytes(&bytes).unwrap();
@@ -910,6 +1471,8 @@ mod tests {
         assert_eq!(restored.entries[0].chunk.name, "handle_request");
         assert_eq!(restored.entries[0].vector, vec![0.1, 0.2, 0.3, 0.4]);
         assert_eq!(restored.dimension, 4);
+        assert_eq!(restored.backend_label(), Some("fastembed"));
+        assert_eq!(restored.model_label(), Some("all-MiniLM-L6-v2"));
     }
 
     #[test]
@@ -1016,5 +1579,101 @@ mod tests {
 
         assert!(message.starts_with("ONNX Runtime not found. Install via:"));
         assert!(message.contains("Original error:"));
+    }
+
+    #[test]
+    fn openai_compatible_backend_embeds_with_mock_server() {
+        let (base_url, handle) = start_mock_http_server(|request_line, path, _body| {
+            assert!(request_line.starts_with("POST "));
+            assert_eq!(path, "/v1/embeddings");
+            "{\"data\":[{\"embedding\":[0.1,0.2,0.3],\"index\":0},{\"embedding\":[0.4,0.5,0.6],\"index\":1}]}".to_string()
+        });
+
+        let config = SemanticBackendConfig {
+            backend: SemanticBackend::OpenAiCompatible,
+            model: "test-embedding".to_string(),
+            base_url: Some(base_url),
+            api_key_env: None,
+            timeout_ms: 5_000,
+            max_batch_size: 64,
+        };
+
+        let mut model = SemanticEmbeddingModel::from_config(&config).unwrap();
+        let vectors = model
+            .embed(vec!["hello".to_string(), "world".to_string()])
+            .unwrap();
+
+        assert_eq!(vectors, vec![vec![0.1, 0.2, 0.3], vec![0.4, 0.5, 0.6]]);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn ollama_backend_embeds_with_mock_server() {
+        let (base_url, handle) = start_mock_http_server(|request_line, path, _body| {
+            assert!(request_line.starts_with("POST "));
+            assert_eq!(path, "/api/embed");
+            "{\"embeddings\":[[0.7,0.8,0.9],[1.0,1.1,1.2]]}".to_string()
+        });
+
+        let config = SemanticBackendConfig {
+            backend: SemanticBackend::Ollama,
+            model: "embeddinggemma".to_string(),
+            base_url: Some(base_url),
+            api_key_env: None,
+            timeout_ms: 5_000,
+            max_batch_size: 64,
+        };
+
+        let mut model = SemanticEmbeddingModel::from_config(&config).unwrap();
+        let vectors = model
+            .embed(vec!["hello".to_string(), "world".to_string()])
+            .unwrap();
+
+        assert_eq!(vectors, vec![vec![0.7, 0.8, 0.9], vec![1.0, 1.1, 1.2]]);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn read_from_disk_rejects_fingerprint_mismatch() {
+        let storage = tempfile::tempdir().unwrap();
+        let project_key = "proj";
+
+        let mut index = SemanticIndex::new();
+        index.entries.push(EmbeddingEntry {
+            chunk: SemanticChunk {
+                file: PathBuf::from("/src/main.rs"),
+                name: "handle_request".to_string(),
+                kind: SymbolKind::Function,
+                start_line: 10,
+                end_line: 25,
+                exported: true,
+                embed_text: "file:src/main.rs kind:function name:handle_request".to_string(),
+                snippet: "fn handle_request() {}".to_string(),
+            },
+            vector: vec![0.1, 0.2, 0.3],
+        });
+        index.dimension = 3;
+        index
+            .file_mtimes
+            .insert(PathBuf::from("/src/main.rs"), SystemTime::UNIX_EPOCH);
+        index.set_fingerprint(SemanticIndexFingerprint {
+            backend: "openai_compatible".to_string(),
+            model: "test-embedding".to_string(),
+            base_url: "http://127.0.0.1:1234/v1".to_string(),
+            dimension: 3,
+        });
+        index.write_to_disk(storage.path(), project_key);
+
+        let matching = index.fingerprint().unwrap().as_string();
+        assert!(SemanticIndex::read_from_disk(storage.path(), project_key, Some(&matching)).is_some());
+
+        let mismatched = SemanticIndexFingerprint {
+            backend: "ollama".to_string(),
+            model: "embeddinggemma".to_string(),
+            base_url: "http://127.0.0.1:11434".to_string(),
+            dimension: 3,
+        }
+        .as_string();
+        assert!(SemanticIndex::read_from_disk(storage.path(), project_key, Some(&mismatched)).is_none());
     }
 }

--- a/crates/aft/tests/integration/semantic_disk_test.rs
+++ b/crates/aft/tests/integration/semantic_disk_test.rs
@@ -94,7 +94,7 @@ fn write_and_read_roundtrip_preserves_semantic_entries() {
 
     index.write_to_disk(storage.path(), "roundtrip-project");
 
-    let restored = SemanticIndex::read_from_disk(storage.path(), "roundtrip-project")
+    let restored = SemanticIndex::read_from_disk(storage.path(), "roundtrip-project", None)
         .expect("restore semantic index from disk");
 
     assert_eq!(restored.len(), index.len());
@@ -115,7 +115,7 @@ fn write_and_read_roundtrip_preserves_semantic_entries() {
 fn read_from_nonexistent_path_returns_none() {
     let storage = tempfile::tempdir().expect("create storage dir");
 
-    let restored = SemanticIndex::read_from_disk(storage.path(), "missing-project");
+    let restored = SemanticIndex::read_from_disk(storage.path(), "missing-project", None);
 
     assert!(restored.is_none());
 }
@@ -130,7 +130,7 @@ fn read_from_corrupt_file_returns_none_and_logs_warning() {
     let semantic_file = semantic_dir.join("semantic.bin");
     fs::write(&semantic_file, b"corrupt").expect("write corrupt semantic file");
 
-    let restored = SemanticIndex::read_from_disk(storage.path(), "corrupt-project");
+    let restored = SemanticIndex::read_from_disk(storage.path(), "corrupt-project", None);
 
     assert!(restored.is_none());
     assert!(

--- a/packages/opencode-plugin/src/__tests__/config.test.ts
+++ b/packages/opencode-plugin/src/__tests__/config.test.ts
@@ -144,4 +144,59 @@ describe("loadAftConfig", () => {
     expect(result.stderr).toContain(`Config loaded from ${fixture.userConfigPath}`);
     expect(result.stderr).toContain(`Config loaded from ${fixture.projectConfigPath}`);
   });
+
+  test("loads semantic config block and propagates nested fields", () => {
+    const fixture = createConfigFixture();
+    writeFileSync(
+      fixture.userConfigPath,
+      JSON.stringify({
+        semantic: {
+          backend: "openai_compatible",
+          model: "text-embedding-3-small",
+          base_url: "https://api.example.test/v1",
+          api_key_env: "AFT_SEMANTIC_API_KEY",
+          timeout_ms: 15_000,
+          max_batch_size: 32,
+        },
+      }),
+    );
+
+    const result = runConfigLoader(fixture.projectDirectory, {
+      HOME: join(fixture.root, "home"),
+      XDG_CONFIG_HOME: fixture.xdgConfigHome,
+    });
+
+    expect(JSON.parse(result.stdout)).toEqual({
+      semantic: {
+        backend: "openai_compatible",
+        model: "text-embedding-3-small",
+        base_url: "https://api.example.test/v1",
+        api_key_env: "AFT_SEMANTIC_API_KEY",
+        timeout_ms: 15000,
+        max_batch_size: 32,
+      },
+    });
+    expect(result.stderr).toContain(`Config loaded from ${fixture.userConfigPath}`);
+  });
+
+  test("rejects invalid semantic backend value as malformed section", () => {
+    const fixture = createConfigFixture();
+    writeFileSync(
+      fixture.userConfigPath,
+      JSON.stringify({
+        semantic: {
+          backend: "gpt-4",
+          timeout_ms: 1000,
+        },
+      }),
+    );
+
+    const result = runConfigLoader(fixture.projectDirectory, {
+      HOME: join(fixture.root, "home"),
+      XDG_CONFIG_HOME: fixture.xdgConfigHome,
+    });
+
+    expect(JSON.parse(result.stdout)).toEqual({});
+    expect(result.stderr).toContain("Partial config loaded — invalid sections skipped");
+  });
 });

--- a/packages/opencode-plugin/src/__tests__/shared-status.test.ts
+++ b/packages/opencode-plugin/src/__tests__/shared-status.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { coerceAftStatus, formatStatusDialogMessage, formatStatusMarkdown } from "../shared/status.js";
+
+const baseResponse = Object.freeze({
+  version: "0.0.0-test",
+  project_root: "/tmp/project",
+  features: {
+    format_on_edit: false,
+    validate_on_edit: "off",
+    restrict_to_project_root: false,
+    experimental_search_index: true,
+    experimental_semantic_search: true,
+  },
+  search_index: { status: "ready", files: 4, trigrams: 400 },
+  semantic_index: {
+    status: "ready",
+    entries: 128,
+    dimension: 384,
+  },
+  disk: {
+    storage_dir: "/tmp/storage",
+    trigram_disk_bytes: 1024,
+    semantic_disk_bytes: 2048,
+  },
+  lsp_servers: 2,
+  symbol_cache: { local_entries: 3, warm_entries: 6 },
+  storage_dir: "/tmp/storage",
+  semantic: {
+    backend: "openai_compatible",
+    model: "text-embedding-3-small",
+    api_key_env: "AFT_SEMANTIC_KEY",
+  },
+});
+
+describe("coerceAftStatus", () => {
+  test("adds backend and model when provided", () => {
+    const status = coerceAftStatus(baseResponse as unknown as Record<string, unknown>);
+
+    expect(status.semantic_index.backend).toBe("openai_compatible");
+    expect(status.semantic_index.model).toBe("text-embedding-3-small");
+    expect(status.semantic_index).not.toHaveProperty("api_key_env");
+  });
+});
+
+describe("formatStatus* output", () => {
+  test("formats backend and model without leaking api key", () => {
+    const status = coerceAftStatus(baseResponse as unknown as Record<string, unknown>);
+    const dialog = formatStatusDialogMessage(status);
+    const markdown = formatStatusMarkdown(status);
+
+    expect(dialog).toContain("backend: openai_compatible");
+    expect(dialog).toContain("model: text-embedding-3-small");
+    expect(markdown).toContain("**Backend:** openai_compatible");
+    expect(markdown).toContain("**Model:** text-embedding-3-small");
+    expect(dialog).not.toContain("AFT_SEMANTIC_KEY");
+    expect(markdown).not.toContain("AFT_SEMANTIC_KEY");
+  });
+});

--- a/packages/opencode-plugin/src/bridge.ts
+++ b/packages/opencode-plugin/src/bridge.ts
@@ -247,11 +247,32 @@ export class BinaryBridge {
   private spawnProcess(): void {
     log(`Spawning binary: ${this.binaryPath} (cwd: ${this.cwd})`);
 
+    const ortDir =
+      typeof this.configOverrides._ort_dylib_dir === "string"
+        ? this.configOverrides._ort_dylib_dir
+        : null;
+    const ortLibraryPath =
+      ortDir == null
+        ? null
+        : join(
+            ortDir,
+            process.platform === "win32"
+              ? "onnxruntime.dll"
+              : process.platform === "darwin"
+                ? "libonnxruntime.dylib"
+                : "libonnxruntime.so",
+          );
+    const envPath =
+      process.platform === "win32" && ortDir
+        ? `${ortDir};${process.env.PATH ?? ""}`
+        : process.env.PATH;
+
     const child = spawn(this.binaryPath, [], {
       cwd: this.cwd,
       stdio: ["pipe", "pipe", "pipe"],
       env: {
         ...process.env,
+        ...(envPath ? { PATH: envPath } : {}),
         // Store fastembed model files alongside the semantic index, not the project cwd
         FASTEMBED_CACHE_DIR:
           process.env.FASTEMBED_CACHE_DIR ||
@@ -259,15 +280,8 @@ export class BinaryBridge {
             ? join(this.configOverrides.storage_dir, "semantic", "models")
             : join(homedir() || "", ".cache", "fastembed")),
         // Point ort to the auto-downloaded or system ONNX Runtime library
-        ...(typeof this.configOverrides._ort_dylib_dir === "string" && {
-          ORT_DYLIB_PATH: join(
-            this.configOverrides._ort_dylib_dir,
-            process.platform === "win32"
-              ? "onnxruntime.dll"
-              : process.platform === "darwin"
-                ? "libonnxruntime.dylib"
-                : "libonnxruntime.so",
-          ),
+        ...(ortLibraryPath && {
+          ORT_DYLIB_PATH: ortLibraryPath,
         }),
       },
     });

--- a/packages/opencode-plugin/src/bridge.ts
+++ b/packages/opencode-plugin/src/bridge.ts
@@ -246,9 +246,19 @@ export class BinaryBridge {
 
   private spawnProcess(): void {
     log(`Spawning binary: ${this.binaryPath} (cwd: ${this.cwd})`);
+    const semantic = this.configOverrides.semantic;
+    const semanticBackend = (() => {
+      if (semantic && typeof semantic === "object" && !Array.isArray(semantic)) {
+        const candidate = (semantic as { backend?: unknown }).backend;
+        return typeof candidate === "string" ? candidate : undefined;
+      }
+      return undefined;
+    })();
+    const useFastembedBackend =
+      semanticBackend === undefined || semanticBackend === "fastembed" || semanticBackend === "";
 
     const ortDir =
-      typeof this.configOverrides._ort_dylib_dir === "string"
+      typeof this.configOverrides._ort_dylib_dir === "string" && useFastembedBackend
         ? this.configOverrides._ort_dylib_dir
         : null;
     const ortLibraryPath =
@@ -267,23 +277,30 @@ export class BinaryBridge {
         ? `${ortDir};${process.env.PATH ?? ""}`
         : process.env.PATH;
 
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      ...(envPath ? { PATH: envPath } : {}),
+    };
+
+    if (useFastembedBackend) {
+      // Store fastembed model files alongside the semantic index, not the project cwd.
+      // This is only relevant when the fastembed backend is selected.
+      env.FASTEMBED_CACHE_DIR =
+        process.env.FASTEMBED_CACHE_DIR ||
+        (typeof this.configOverrides.storage_dir === "string"
+          ? join(this.configOverrides.storage_dir, "semantic", "models")
+          : join(homedir() || "", ".cache", "fastembed"));
+
+      // Point ort to the auto-downloaded or system ONNX Runtime library.
+      if (ortLibraryPath) {
+        env.ORT_DYLIB_PATH = ortLibraryPath;
+      }
+    }
+
     const child = spawn(this.binaryPath, [], {
       cwd: this.cwd,
       stdio: ["pipe", "pipe", "pipe"],
-      env: {
-        ...process.env,
-        ...(envPath ? { PATH: envPath } : {}),
-        // Store fastembed model files alongside the semantic index, not the project cwd
-        FASTEMBED_CACHE_DIR:
-          process.env.FASTEMBED_CACHE_DIR ||
-          (typeof this.configOverrides.storage_dir === "string"
-            ? join(this.configOverrides.storage_dir, "semantic", "models")
-            : join(homedir() || "", ".cache", "fastembed")),
-        // Point ort to the auto-downloaded or system ONNX Runtime library
-        ...(ortLibraryPath && {
-          ORT_DYLIB_PATH: ortLibraryPath,
-        }),
-      },
+      env,
     });
 
     child.stdout?.on("data", (chunk: Buffer) => {

--- a/packages/opencode-plugin/src/config.ts
+++ b/packages/opencode-plugin/src/config.ts
@@ -32,6 +32,23 @@ const CheckerEnum = z.enum([
   "none",
 ]);
 
+const SemanticBackendEnum = z.enum(["fastembed", "openai_compatible", "ollama"]);
+
+const SemanticConfigSchema = z.object({
+  /** Semantic backend type: local fastembed, OpenAI-compatible API, or Ollama. */
+  backend: SemanticBackendEnum.optional(),
+  /** Model identifier passed to the selected semantic backend. */
+  model: z.string().trim().min(1).optional(),
+  /** Base URL of the backend API endpoint. */
+  base_url: z.string().trim().min(1).optional(),
+  /** Environment variable that contains the API key used by external backends. */
+  api_key_env: z.string().trim().min(1).optional(),
+  /** Backend request timeout in milliseconds. */
+  timeout_ms: z.number().int().positive().optional(),
+  /** Maximum batch size used by the semantic pipeline. */
+  max_batch_size: z.number().int().positive().optional(),
+});
+
 export const AftConfigSchema = z.object({
   /** Whether to auto-format files after edits. Default: true. */
   format_on_edit: z.boolean().optional(),
@@ -72,6 +89,8 @@ export const AftConfigSchema = z.object({
   experimental_search_index: z.boolean().optional(),
   /** Enable experimental semantic search. Default: false. */
   experimental_semantic_search: z.boolean().optional(),
+  /** External semantic backend configuration for embedding and retrieval. */
+  semantic: SemanticConfigSchema.optional(),
 });
 
 export type AftConfig = z.infer<typeof AftConfigSchema>;

--- a/packages/opencode-plugin/src/index.ts
+++ b/packages/opencode-plugin/src/index.ts
@@ -134,6 +134,10 @@ const plugin: Plugin = async (input) => {
     configOverrides.experimental_search_index = aftConfig.experimental_search_index;
   if (aftConfig.experimental_semantic_search !== undefined)
     configOverrides.experimental_semantic_search = aftConfig.experimental_semantic_search;
+  if (aftConfig.semantic !== undefined) configOverrides.semantic = aftConfig.semantic;
+
+  const isFastembedSemanticBackend =
+    (aftConfig.semantic?.backend ?? "fastembed") === "fastembed";
 
   // Compute XDG-compliant storage dir for persistent indexes (trigram, semantic)
   // Pattern: ~/.local/share/opencode/storage/plugin/aft/
@@ -143,7 +147,7 @@ const plugin: Plugin = async (input) => {
   // Auto-resolve ONNX Runtime for semantic search.
   // Downloads the shared library on first use if the platform is supported.
   // The resolved path is passed to bridges via ORT_DYLIB_PATH env var.
-  if (aftConfig.experimental_semantic_search) {
+  if (aftConfig.experimental_semantic_search && isFastembedSemanticBackend) {
     const storageDir = configOverrides.storage_dir as string;
     ensureOnnxRuntime(storageDir).then(
       (ortDir) => {
@@ -262,7 +266,7 @@ const plugin: Plugin = async (input) => {
 
   rpcServer.handle("get-warnings", async () => {
     const warnings: string[] = [];
-    if (aftConfig.experimental_semantic_search && !configOverrides._ort_dylib_dir) {
+    if (aftConfig.experimental_semantic_search && isFastembedSemanticBackend && !configOverrides._ort_dylib_dir) {
       if (!isOrtAutoDownloadSupported()) {
         warnings.push(`Semantic search requires ONNX Runtime.\nInstall: ${getManualInstallHint()}`);
       }
@@ -300,7 +304,7 @@ const plugin: Plugin = async (input) => {
   }, 8000);
 
   // Warn about ONNX Runtime if semantic search is enabled but ORT is unavailable
-  if (aftConfig.experimental_semantic_search && !configOverrides._ort_dylib_dir) {
+  if (aftConfig.experimental_semantic_search && isFastembedSemanticBackend && !configOverrides._ort_dylib_dir) {
     // The ensureOnnxRuntime call above is async and may still be in flight.
     // Schedule the warning check after a short delay to let it resolve.
     setTimeout(() => {

--- a/packages/opencode-plugin/src/shared/status.ts
+++ b/packages/opencode-plugin/src/shared/status.ts
@@ -15,8 +15,11 @@ export interface AftStatusSnapshot {
   };
   semantic_index: {
     status: string;
+    stage?: string | null;
+    files?: number | null;
     entries: number | null;
     dimension: number | null;
+    error?: string | null;
   };
   disk: {
     storage_dir: string | null;
@@ -102,8 +105,11 @@ export function coerceAftStatus(response: Record<string, unknown>): AftStatusSna
     },
     semantic_index: {
       status: readString(semanticIndex.status, "unknown"),
+      stage: readNullableString(semanticIndex.stage),
+      files: readOptionalNumber(semanticIndex.files),
       entries: readOptionalNumber(semanticIndex.entries),
       dimension: readOptionalNumber(semanticIndex.dimension),
+      error: readNullableString(semanticIndex.error),
     },
     disk: {
       storage_dir: readNullableString(disk.storage_dir),
@@ -158,6 +164,16 @@ export function formatStatusDialogMessage(status: AftStatusSnapshot): string {
     lines.push(`- storage dir: ${status.storage_dir ?? status.disk.storage_dir}`);
   }
 
+  if (status.semantic_index.stage) {
+    lines.push("", "Semantic stage", status.semantic_index.stage);
+  }
+  if (status.semantic_index.files != null) {
+    lines.push(`- semantic files: ${formatCount(status.semantic_index.files)}`);
+  }
+  if (status.semantic_index.error) {
+    lines.push("", "Semantic error", status.semantic_index.error);
+  }
+
   return lines.join("\n");
 }
 
@@ -185,6 +201,16 @@ export function formatStatusMarkdown(status: AftStatusSnapshot): string {
 
   if (status.semantic_index.dimension != null) {
     lines.push(`- **Dimension:** ${formatCount(status.semantic_index.dimension)}`);
+  }
+  if (status.semantic_index.stage) {
+    lines.push(`- **Stage:** ${status.semantic_index.stage}`);
+  }
+  if (status.semantic_index.files != null) {
+    lines.push(`- **Files:** ${formatCount(status.semantic_index.files)}`);
+  }
+
+  if (status.semantic_index.error) {
+    lines.push(`- **Error:** ${status.semantic_index.error}`);
   }
 
   lines.push(

--- a/packages/opencode-plugin/src/shared/status.ts
+++ b/packages/opencode-plugin/src/shared/status.ts
@@ -15,8 +15,12 @@ export interface AftStatusSnapshot {
   };
   semantic_index: {
     status: string;
+    backend?: string | null;
+    model?: string | null;
     stage?: string | null;
     files?: number | null;
+    entries_done?: number | null;
+    entries_total?: number | null;
     entries: number | null;
     dimension: number | null;
     error?: string | null;
@@ -85,6 +89,10 @@ export function coerceAftStatus(response: Record<string, unknown>): AftStatusSna
   const features = asRecord(response.features);
   const searchIndex = asRecord(response.search_index);
   const semanticIndex = asRecord(response.semantic_index);
+  const semanticConfig = {
+    ...asRecord(response.semantic),
+    ...asRecord((response as { semantic_config?: unknown }).semantic_config),
+  };
   const disk = asRecord(response.disk);
   const symbolCache = asRecord(response.symbol_cache);
 
@@ -105,8 +113,16 @@ export function coerceAftStatus(response: Record<string, unknown>): AftStatusSna
     },
     semantic_index: {
       status: readString(semanticIndex.status, "unknown"),
+      backend: readNullableString(
+        semanticIndex.backend ?? semanticConfig.backend,
+      ),
+      model: readNullableString(
+        semanticIndex.model ?? semanticConfig.model,
+      ),
       stage: readNullableString(semanticIndex.stage),
       files: readOptionalNumber(semanticIndex.files),
+      entries_done: readOptionalNumber(semanticIndex.entries_done),
+      entries_total: readOptionalNumber(semanticIndex.entries_total),
       entries: readOptionalNumber(semanticIndex.entries),
       dimension: readOptionalNumber(semanticIndex.dimension),
       error: readNullableString(semanticIndex.error),
@@ -144,6 +160,12 @@ export function formatStatusDialogMessage(status: AftStatusSnapshot): string {
     `- status: ${status.semantic_index.status}`,
     `- entries: ${formatCount(status.semantic_index.entries)}`,
   ];
+  if (status.semantic_index.backend) {
+    lines.push(`- backend: ${status.semantic_index.backend}`);
+  }
+  if (status.semantic_index.model) {
+    lines.push(`- model: ${status.semantic_index.model}`);
+  }
 
   if (status.semantic_index.dimension != null) {
     lines.push(`- dimension: ${formatCount(status.semantic_index.dimension)}`);
@@ -169,6 +191,14 @@ export function formatStatusDialogMessage(status: AftStatusSnapshot): string {
   }
   if (status.semantic_index.files != null) {
     lines.push(`- semantic files: ${formatCount(status.semantic_index.files)}`);
+  }
+  if (
+    status.semantic_index.entries_done != null ||
+    status.semantic_index.entries_total != null
+  ) {
+    lines.push(
+      `- semantic progress: ${formatCount(status.semantic_index.entries_done ?? null)} / ${formatCount(status.semantic_index.entries_total ?? null)}`,
+    );
   }
   if (status.semantic_index.error) {
     lines.push("", "Semantic error", status.semantic_index.error);
@@ -198,6 +228,12 @@ export function formatStatusMarkdown(status: AftStatusSnapshot): string {
     `- **Status:** \`${status.semantic_index.status}\``,
     `- **Entries:** ${formatCount(status.semantic_index.entries)}`,
   ];
+  if (status.semantic_index.backend) {
+    lines.push(`- **Backend:** ${status.semantic_index.backend}`);
+  }
+  if (status.semantic_index.model) {
+    lines.push(`- **Model:** ${status.semantic_index.model}`);
+  }
 
   if (status.semantic_index.dimension != null) {
     lines.push(`- **Dimension:** ${formatCount(status.semantic_index.dimension)}`);
@@ -207,6 +243,14 @@ export function formatStatusMarkdown(status: AftStatusSnapshot): string {
   }
   if (status.semantic_index.files != null) {
     lines.push(`- **Files:** ${formatCount(status.semantic_index.files)}`);
+  }
+  if (
+    status.semantic_index.entries_done != null ||
+    status.semantic_index.entries_total != null
+  ) {
+    lines.push(
+      `- **Progress:** ${formatCount(status.semantic_index.entries_done ?? null)} / ${formatCount(status.semantic_index.entries_total ?? null)}`,
+    );
   }
 
   if (status.semantic_index.error) {


### PR DESCRIPTION
## Summary

This adds optional external semantic embedding backends to AFT while keeping the current default behavior unchanged.

Default behavior is still:
- local `fastembed + all-MiniLM-L6-v2`

New opt-in backends:
- `openai_compatible` for LM Studio / OpenAI-compatible embeddings endpoints
- `ollama` for Ollama native embeddings API

## What changed

### Plugin/config
- added nested `semantic` config block
- forwards semantic backend/model/base_url/api_key_env/timeout_ms/max_batch_size through `configure`
- keeps ONNX runtime setup only for `fastembed`
- external backends do not trigger ONNX setup

### Rust semantic backend
- introduced backend selection for semantic embedding generation
- implemented:
  - `fastembed`
  - `openai_compatible`
  - `ollama`
- query embedding uses the same configured backend as index build
- external backend failures are explicit; there is no silent fallback

### Persistence/status
- semantic cache now rebuilds when backend/model/base_url/dimension changes
- status now exposes semantic backend + model
- preserves the existing semantic progress/status work already on this branch

## Why there is no split query/index backend config

This PR intentionally uses one semantic backend for both:
- index build
- query embedding

Using one backend to build the index and another to embed queries is unsafe unless both produce vectors in the exact same embedding space. That is not guaranteed across runtimes, even for the same model family.

## Validation

### Automated checks
- `cargo test -p agent-file-tools semantic_ -- --nocapture`
- `bun test packages/opencode-plugin/src/__tests__/config.test.ts packages/opencode-plugin/src/__tests__/shared-status.test.ts packages/opencode-plugin/src/__tests__/bridge.test.ts`
- `bun run typecheck` in `packages/opencode-plugin`

### Provider validation
- OpenAI-compatible provider path tested against a live LM Studio-compatible endpoint
- Ollama provider path tested against:
  - mock-server protocol tests
  - live local Ollama endpoint

## Compatibility note

- Runtime-validated on Windows
- External-backend implementation uses cross-platform Rust HTTP/JSON codepaths and does not introduce Windows-specific logic
- Linux/macOS were not runtime-tested in this branch from this machine

## Benchmark appendix

These numbers are for the new semantic backend feature, not a replacement for the README trigram-search benchmark.

### Benchmark environments

Local benchmark machine:
- Windows 11
- AMD Radeon RX 6800M
- AMD Radeon(TM) Graphics

Remote LM Studio host:
- user-reported Windows 11 + RTX 5070 Ti

Backends tested:
- `fastembed` local CPU
- `ollama` local CPU
- `ollama` local with Vulkan forced
- `LM Studio` over LAN

### Large-repo semantic build comparison (`codex-fresh`)

- `fastembed` local CPU: `11m 33s`
- `ollama` local CPU: `8m 15s`
- `ollama` local Vulkan GPU: `3m 08s`
- `LM Studio` LAN: `2m 13s`

All successful runs ended with:
- `23,638` semantic entries
- `384` dimensions

### README-style query sets

I also reran the README query sets on current local snapshots of:
- `opencode-aft`
- `reth`
- `Chromium/base`

Important caveat:
- these are the same query sets, but not guaranteed the exact same repo snapshots as the published README tables

#### Indexed grep vs ripgrep

Observed indexed-grep speedups remained strong:

- `opencode-aft`: ~`18x` to `40x`
- `reth`: ~`12x` to `20x`
- `Chromium/base`: ~`26x` to `71x`

#### Semantic query latency

Cached semantic query latency favored local `fastembed`:

- local `fastembed` was fastest
- LM Studio was usually second
- Ollama was slower on query latency even with Vulkan enabled

This suggests:
- external backends improve semantic build throughput
- local `fastembed` still gives the best query-time latency

### Same-model note

LM Studio and Ollama were benchmarked with MiniLM-family embedding models, but not guaranteed byte-identical artifacts.

A stricter follow-up benchmark would import the same `second-state` MiniLM GGUF into both runtimes and rerun the comparison.