### PR TITLE
fix(lsp): preserve dotted custom root markers

### DIFF
--- a/crates/aft/src/commands/configure.rs
+++ b/crates/aft/src/commands/configure.rs
@@ -252,7 +252,7 @@ fn parse_lsp_server(value: &Value, index: usize) -> Result<UserServerDef, String
     };
 
     let id = required_string(obj.get("id"), index, "id")?;
-    let extensions = required_string_array(obj.get("extensions"), index, "extensions")?;
+    let extensions = required_extension_array(obj.get("extensions"), index)?;
     let binary = required_string(obj.get("binary"), index, "binary")?;
     let args = optional_string_array(obj.get("args"), index, "args")?;
     let root_markers = optional_string_array(obj.get("root_markers"), index, "root_markers")?;
@@ -332,6 +332,14 @@ fn required_string_array(
     Ok(values)
 }
 
+fn required_extension_array(value: Option<&Value>, index: usize) -> Result<Vec<String>, String> {
+    let values = required_string_array(value, index, "extensions")?;
+    Ok(values
+        .into_iter()
+        .map(|value| value.trim_start_matches('.').to_string())
+        .collect())
+}
+
 fn optional_string_array(
     value: Option<&Value>,
     index: usize,
@@ -353,7 +361,7 @@ fn optional_string_array(
                 "configure: lsp_servers[{index}].{field}[{entry_index}] must be a string"
             ));
         };
-        values.push(raw.trim().trim_start_matches('.').to_string());
+        values.push(raw.trim().to_string());
     }
     Ok(values)
 }
@@ -2167,6 +2175,25 @@ mod tests {
         );
         // User config preserved.
         assert!(ctx.config().search_index);
+    }
+
+    #[test]
+    fn parse_lsp_server_preserves_dotted_root_markers() {
+        let value = json!([
+            {
+                "id": "oxlint-cli",
+                "extensions": [".ts", "tsx"],
+                "binary": "oxlint",
+                "args": ["--lsp", ".keep-dotted-arg"],
+                "root_markers": [".oxlintrc.json", ".oxlintrc"]
+            }
+        ]);
+
+        let servers = super::parse_lsp_servers(&value).expect("parse lsp servers");
+
+        assert_eq!(servers[0].extensions, vec!["ts", "tsx"]);
+        assert_eq!(servers[0].args, vec!["--lsp", ".keep-dotted-arg"]);
+        assert_eq!(servers[0].root_markers, vec![".oxlintrc.json", ".oxlintrc"]);
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary
Custom LSP server `root_markers` lose their leading dot during config parsing,
so `.oxlintrc.json` is read as `oxlintrc.json`. The marker never matches, the
workspace root isn't found, and the custom server starts in the wrong directory.

## What changed
`crates/aft/src/commands/configure.rs`: leading-dot stripping now runs only on
extension lists. Root markers are kept as written. Added parser coverage for a
dotted marker.

## Why this scope
Stripping the dot is right for extensions (`.ts` becomes `ts`) but wrong for
filenames, which are matched literally. The fix stays in the parser and changes
no schema or runtime behavior beyond the marker lookup.

## Validation
- `cargo fmt --check`
- `cargo test -p agent-file-tools` (configure parser and lsp inspect tests)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes LSP config parsing to preserve dotted root markers (e.g., ".oxlintrc.json"). This lets custom servers detect the correct workspace root and start in the right directory.

- **Bug Fixes**
  - Preserve leading dots in `root_markers` and `args`.
  - Strip leading dots only for `extensions` via a new `required_extension_array`.
  - Added a test to ensure extensions are normalized and dotted markers are kept.

<sup>Written for commit 95bfe2e3bddfa17c9eadad96363b220e1c64aadf. Summary will update on new commits. <a href="https://cubic.dev/pr/cortexkit/aft/pull/51?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

