### PR TITLE
feat(config): support explicit tsgo checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1270,7 +1270,7 @@ The schema is identical across harnesses. Only file location differs.
 
   // Per-language type checker overrides (auto-detected if omitted)
   // Keys: "typescript", "python", "rust", "go"
-  // Values: "tsc" | "biome" | "pyright" | "ruff" | "cargo" | "go" | "staticcheck" | "none"
+  // Values: "tsc" | "tsgo" | "biome" | "pyright" | "ruff" | "cargo" | "go" | "staticcheck" | "none"
   "checker": {
     "typescript": "biome"
   },

--- a/assets/aft.schema.json
+++ b/assets/aft.schema.json
@@ -52,6 +52,7 @@
         "type": "string",
         "enum": [
           "tsc",
+          "tsgo",
           "biome",
           "pyright",
           "ruff",

--- a/crates/aft/src/commands/configure.rs
+++ b/crates/aft/src/commands/configure.rs
@@ -543,7 +543,7 @@ fn explicit_formatter_candidate(name: &str) -> Vec<ConfigureToolCandidate> {
 fn explicit_checker_candidate(name: &str) -> Vec<ConfigureToolCandidate> {
     match name {
         "none" | "off" | "false" => Vec::new(),
-        "tsc" | "cargo" | "go" | "biome" | "pyright" | "ruff" | "staticcheck" => {
+        "tsc" | "tsgo" | "cargo" | "go" | "biome" | "pyright" | "ruff" | "staticcheck" => {
             vec![configure_tool_candidate(name, "checker config", true)]
         }
         _ => Vec::new(),

--- a/crates/aft/src/config.rs
+++ b/crates/aft/src/config.rs
@@ -106,7 +106,7 @@ pub struct Config {
     /// Values: "biome", "prettier", "deno", "ruff", "black", "rustfmt", "goimports", "gofmt", "none".
     pub formatter: HashMap<String, String>,
     /// Per-language type checker overrides. Keys: "typescript", "python", "rust", "go".
-    /// Values: "tsc", "biome", "pyright", "ruff", "cargo", "go", "staticcheck", "none".
+    /// Values: "tsc", "tsgo", "biome", "pyright", "ruff", "cargo", "go", "staticcheck", "none".
     pub checker: HashMap<String, String>,
     /// Whether to restrict file operations to within `project_root` (default: false).
     /// When true, write-capable commands reject paths outside the project root.

--- a/crates/aft/src/format.rs
+++ b/crates/aft/src/format.rs
@@ -754,7 +754,7 @@ fn explicit_formatter_candidate(name: &str, file_str: &str) -> Vec<ToolCandidate
 fn explicit_checker_candidate(name: &str, file_str: &str) -> Vec<ToolCandidate> {
     match name {
         "none" | "off" | "false" => Vec::new(),
-        "tsc" => vec![ToolCandidate {
+        "tsc" | "tsgo" => vec![ToolCandidate {
             tool: name.to_string(),
             source: "checker config".to_string(),
             args: vec![
@@ -842,7 +842,7 @@ fn checker_command(candidate: &ToolCandidate, resolved: String) -> String {
 }
 
 fn checker_args(candidate: &ToolCandidate) -> Vec<String> {
-    if candidate.tool == "tsc" {
+    if candidate.tool == "tsc" || candidate.tool == "tsgo" {
         vec![
             "--noEmit".to_string(),
             "--pretty".to_string(),
@@ -931,6 +931,9 @@ pub(crate) fn install_hint(tool: &str) -> String {
         }
         "prettier" => "Run `npm install -D prettier` or install globally.".to_string(),
         "tsc" => "Run `npm install -D typescript` or install globally.".to_string(),
+        "tsgo" => {
+            "Run `npm install -D @typescript/native-preview` or install globally.".to_string()
+        }
         "pyright" | "pyright-langserver" => "Install: `npm install -g pyright`".to_string(),
         "ruff" => {
             "Install: `pip install ruff` or your Python package manager equivalent.".to_string()
@@ -1288,7 +1291,7 @@ pub struct ValidationError {
 /// flags ensure no output files are produced.
 ///
 /// Supported:
-/// - TypeScript/JavaScript/TSX → `npx tsc --noEmit` (fallback: `tsc --noEmit`)
+/// - TypeScript/JavaScript/TSX → `tsc --noEmit` (or `tsgo --noEmit` when explicitly configured)
 /// - Python → `pyright`
 /// - Rust → `cargo check`
 /// - Go → `go vet`
@@ -1318,7 +1321,7 @@ pub fn parse_checker_output(
         .and_then(|name| name.to_str())
         .unwrap_or(checker);
     match checker_name {
-        "npx" | "tsc" => parse_tsc_output(stdout, stderr, file),
+        "npx" | "tsc" | "tsgo" => parse_tsc_output(stdout, stderr, file),
         "pyright" => parse_pyright_output(stdout, file),
         "cargo" => parse_cargo_output(stdout, stderr, file),
         "go" => parse_go_vet_output(stderr, file),
@@ -2096,6 +2099,102 @@ mod tests {
             assert!(result.is_none());
         }
     }
+
+    #[cfg(unix)]
+    #[test]
+    fn detect_type_checker_defaults_to_tsc_for_typescript() {
+        let _guard = tool_cache_test_lock();
+        clear_tool_cache();
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("tsconfig.json"), "{}").unwrap();
+        let bin_dir = dir.path().join("node_modules").join(".bin");
+        fs::create_dir_all(&bin_dir).unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        let fake_tsc = bin_dir.join("tsc");
+        fs::write(&fake_tsc, "#!/bin/sh\nexit 0").unwrap();
+        fs::set_permissions(&fake_tsc, fs::Permissions::from_mode(0o755)).unwrap();
+        let fake_tsgo = bin_dir.join("tsgo");
+        fs::write(&fake_tsgo, "#!/bin/sh\nexit 0").unwrap();
+        fs::set_permissions(&fake_tsgo, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let path = dir.path().join("src/app.ts");
+        let config = Config {
+            project_root: Some(dir.path().to_path_buf()),
+            ..Config::default()
+        };
+
+        let (cmd, args) = detect_type_checker(&path, LangId::TypeScript, &config).unwrap();
+        assert!(cmd.ends_with("tsc"), "expected tsc by default, got: {cmd}");
+        assert_eq!(args, vec!["--noEmit", "--pretty", "false"]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn detect_type_checker_uses_tsgo_when_explicitly_configured() {
+        let _guard = tool_cache_test_lock();
+        clear_tool_cache();
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("tsconfig.json"), "{}").unwrap();
+        let bin_dir = dir.path().join("node_modules").join(".bin");
+        fs::create_dir_all(&bin_dir).unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        let fake_tsgo = bin_dir.join("tsgo");
+        fs::write(&fake_tsgo, "#!/bin/sh\nexit 0").unwrap();
+        fs::set_permissions(&fake_tsgo, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let path = dir.path().join("src/app.ts");
+        let mut config = Config {
+            project_root: Some(dir.path().to_path_buf()),
+            ..Config::default()
+        };
+        config
+            .checker
+            .insert("typescript".to_string(), "tsgo".to_string());
+
+        let (cmd, args) = detect_type_checker(&path, LangId::TypeScript, &config).unwrap();
+        assert!(cmd.ends_with("tsgo"), "expected tsgo, got: {cmd}");
+        assert_eq!(args, vec!["--noEmit", "--pretty", "false"]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn validate_full_explicit_tsgo_parses_diagnostics() {
+        let _guard = tool_cache_test_lock();
+        clear_tool_cache();
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("tsconfig.json"), "{}").unwrap();
+        let src_dir = dir.path().join("src");
+        fs::create_dir_all(&src_dir).unwrap();
+        let path = src_dir.join("app.ts");
+        fs::write(&path, "const value: number = 'nope';\n").unwrap();
+
+        let bin_dir = dir.path().join("node_modules").join(".bin");
+        fs::create_dir_all(&bin_dir).unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        let fake_tsgo = bin_dir.join("tsgo");
+        fs::write(
+            &fake_tsgo,
+            "#!/bin/sh\nif [ \"$1 $2 $3\" != \"--noEmit --pretty false\" ]; then echo \"bad args: $*\" >&2; exit 3; fi\nprintf '%s\n' \"src/app.ts(1,23): error TS2322: Type 'string' is not assignable to type 'number'.\"\nexit 2\n",
+        )
+        .unwrap();
+        fs::set_permissions(&fake_tsgo, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let mut config = Config {
+            project_root: Some(dir.path().to_path_buf()),
+            ..Config::default()
+        };
+        config
+            .checker
+            .insert("typescript".to_string(), "tsgo".to_string());
+
+        let (errors, reason) = validate_full(&path, &config);
+        assert_eq!(reason, None);
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].line, 1);
+        assert_eq!(errors[0].column, 23);
+        assert!(errors[0].message.contains("TS2322"));
+    }
+
     #[test]
     fn run_external_tool_capture_nonzero_not_error() {
         // `false` exits with code 1 — capture should still return Ok

--- a/crates/aft/src/format.rs
+++ b/crates/aft/src/format.rs
@@ -834,7 +834,7 @@ fn resolve_tool_candidates(
 
 fn checker_command(candidate: &ToolCandidate, resolved: String) -> String {
     match candidate.tool.as_str() {
-        "tsc" => resolved,
+        "tsc" | "tsgo" => resolved,
         "cargo" => "cargo".to_string(),
         "go" => "go".to_string(),
         _ => resolved,

--- a/crates/aft/tests/integration/configure_test.rs
+++ b/crates/aft/tests/integration/configure_test.rs
@@ -123,6 +123,44 @@ fn configure_warns_for_missing_formatter_and_checker_tools() {
 }
 
 #[test]
+fn configure_warns_for_missing_explicit_tsgo_checker() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("app.ts"), "const x = 1;\n").unwrap();
+
+    let path = empty_path();
+    let mut aft = AftProcess::spawn_with_env(&[("PATH", path.as_os_str())]);
+
+    let configure = aft.send(
+        &json!({
+            "id": "cfg-missing-tsgo",
+            "command": "configure",
+            "harness": "opencode",
+            "project_root": dir.path(),
+            "checker": {
+                "typescript": "tsgo"
+            }
+        })
+        .to_string(),
+    );
+
+    assert_eq!(
+        configure["success"], true,
+        "configure should succeed: {configure:?}"
+    );
+    let configure = aft.merge_configure_warnings(configure);
+    let checker = warning_with_kind(&configure, "checker_not_installed", "tool", "tsgo")
+        .expect("missing tsgo warning");
+    assert_eq!(checker["language"], "typescript");
+    assert!(checker["hint"]
+        .as_str()
+        .unwrap()
+        .contains("@typescript/native-preview"));
+
+    let shutdown = aft.shutdown();
+    assert!(shutdown.success());
+}
+
+#[test]
 fn configure_only_warns_for_languages_present() {
     let dir = tempfile::tempdir().unwrap();
     std::fs::write(dir.path().join("app.ts"), "const x = 1;\n").unwrap();

--- a/packages/opencode-plugin/scripts/build-schema.ts
+++ b/packages/opencode-plugin/scripts/build-schema.ts
@@ -28,7 +28,7 @@ function buildSchema(): Record<string, unknown> {
 
   const checkerEnum = {
     type: "string",
-    enum: ["tsc", "biome", "pyright", "ruff", "cargo", "go", "staticcheck", "none"],
+    enum: ["tsc", "tsgo", "biome", "pyright", "ruff", "cargo", "go", "staticcheck", "none"],
   };
 
   const lspServerEntry = {

--- a/packages/opencode-plugin/src/config.ts
+++ b/packages/opencode-plugin/src/config.ts
@@ -23,6 +23,7 @@ const FormatterEnum = z.enum([
 
 const CheckerEnum = z.enum([
   "tsc",
+  "tsgo",
   "biome",
   "pyright",
   "ruff",

--- a/packages/pi-plugin/src/config.ts
+++ b/packages/pi-plugin/src/config.ts
@@ -22,6 +22,7 @@ export type Formatter =
 
 export type Checker =
   | "tsc"
+  | "tsgo"
   | "biome"
   | "pyright"
   | "ruff"
@@ -135,6 +136,7 @@ const FormatterEnum = z.enum([
 
 const CheckerEnum = z.enum([
   "tsc",
+  "tsgo",
   "biome",
   "pyright",
   "ruff",


### PR DESCRIPTION
## Summary
Lets you choose tsgo, the native TypeScript preview compiler, as the TypeScript
checker. Defaults don't change: tsc stays the default, and tsgo runs only when
you ask for it.

## What changed
- `format.rs`, `configure.rs`: treat tsgo the same way as tsc where the
  invocation is identical, plus Windows shim detection.
- Config and schema: add tsgo to the checker enum (opencode and pi), the schema
  asset, and the generator.
- Docs: README lists tsc as the default and tsgo as an explicit opt-in.
- Tests: checker selection in configure.

## Why opt-in only
tsgo is still a preview build. Making it the default would change type-checking
for every TypeScript project, so it runs only when configured.

## Validation
- `cargo fmt --check`; `cargo test -p agent-file-tools configure`
- `bun run typecheck` in both plugins

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in support for `tsgo` as the TypeScript checker. Defaults remain `tsc`; nothing changes unless you explicitly configure `tsgo`.

- **New Features**
  - Added `tsgo` to checker enums and schemas across AFT, `opencode` and `pi` plugins.
  - Execute `tsgo` with the same args as `tsc`, with Windows shim detection, diagnostic parsing, and consistent `checker_command` handling (no behavior change).
  - Added install hint for `tsgo` and tests for selection, diagnostics, and configure warnings.

- **Migration**
  - Enable by setting `"checker": { "typescript": "tsgo" }` in your config.
  - Install `@typescript/native-preview` (dev or global).

<sup>Written for commit 9a96add7dfbf1ea7eb4e53a9517cb9b75fcbdc84. Summary will update on new commits. <a href="https://cubic.dev/pr/cortexkit/aft/pull/53?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

