### PR TITLE
fix(cache): isolate worktree disk caches

### DIFF
--- a/crates/aft/src/commands/configure.rs
+++ b/crates/aft/src/commands/configure.rs
@@ -20,8 +20,8 @@ use crate::lsp::registry::{resolve_lsp_binary, servers_for_file, ServerKind};
 use crate::parser::{detect_language, LangId};
 use crate::protocol::{RawRequest, Response};
 use crate::search_index::{
-    build_path_filters, current_git_head, project_cache_key, resolve_cache_dir, walk_project_files,
-    CacheLock, SearchIndex,
+    build_path_filters, current_git_head, disk_cache_key, resolve_cache_dir_with_key,
+    walk_project_files, CacheLock, SearchIndex,
 };
 use crate::semantic_index::{SemanticIndex, SemanticIndexLock};
 use crate::{slog_info, slog_warn};
@@ -1462,10 +1462,11 @@ pub fn handle_configure(req: &RawRequest, ctx: &AppContext) -> Response {
     ctx.set_degraded_reasons(degraded_reasons.clone());
 
     let storage_dir = ctx.config().storage_dir.clone();
+    let checkout_disk_key = disk_cache_key(&canonical_cache_root);
     let mut search_index_cache_reused = false;
 
     if search_index {
-        let cache_dir = resolve_cache_dir(&canonical_cache_root, storage_dir.as_deref());
+        let cache_dir = resolve_cache_dir_with_key(storage_dir.as_deref(), &checkout_disk_key);
         let current_head = current_git_head(&canonical_cache_root);
         let mut baseline = SearchIndex::read_from_disk(&cache_dir, &canonical_cache_root);
         search_index_cache_reused = baseline.is_some();
@@ -1489,7 +1490,7 @@ pub fn handle_configure(req: &RawRequest, ctx: &AppContext) -> Response {
         let root_clone = canonical_cache_root.clone();
         let symbol_cache = ctx.symbol_cache();
         let symbol_storage = storage_dir.clone();
-        let symbol_project_key = project_cache_key(&canonical_cache_root);
+        let symbol_disk_key = checkout_disk_key.clone();
         let is_worktree_bridge_for_search = is_worktree_bridge;
         let session_id_for_bg = log_ctx::current_session();
         thread::spawn(move || {
@@ -1530,7 +1531,7 @@ pub fn handle_configure(req: &RawRequest, ctx: &AppContext) -> Response {
                         let loaded_count = cache.load_from_disk_for_generation(
                             symbol_cache_generation,
                             storage_dir,
-                            &symbol_project_key,
+                            &symbol_disk_key,
                             &root_clone,
                         );
                         slog_info!("loaded symbol cache from disk: {} files", loaded_count);
@@ -1571,7 +1572,7 @@ pub fn handle_configure(req: &RawRequest, ctx: &AppContext) -> Response {
                             match crate::symbol_cache_disk::write_to_disk(
                                 &cache,
                                 storage_dir,
-                                &symbol_project_key,
+                                &symbol_disk_key,
                             ) {
                                 Ok(()) => {
                                     slog_info!("persisted symbol cache: {} files", cache.len());
@@ -1610,7 +1611,7 @@ pub fn handle_configure(req: &RawRequest, ctx: &AppContext) -> Response {
 
         let root_clone = canonical_cache_root.clone();
         let semantic_storage = storage_dir.clone();
-        let semantic_project_key = crate::search_index::project_cache_key(&canonical_cache_root);
+        let semantic_disk_key = checkout_disk_key.clone();
         let semantic_config = semantic_config.clone();
         let tx_progress = tx.clone();
         let is_worktree_bridge_for_semantic = is_worktree_bridge;
@@ -1638,7 +1639,7 @@ pub fn handle_configure(req: &RawRequest, ctx: &AppContext) -> Response {
                             .then(|| ())
                             .and_then(|_| semantic_storage.as_ref())
                             .and_then(|dir| {
-                                match SemanticIndexLock::acquire(dir, &semantic_project_key) {
+                                match SemanticIndexLock::acquire(dir, &semantic_disk_key) {
                                     Ok(lock) => Some(lock),
                                     Err(error) => {
                                         slog_warn!(
@@ -1653,7 +1654,7 @@ pub fn handle_configure(req: &RawRequest, ctx: &AppContext) -> Response {
                         if let Some(ref dir) = semantic_storage {
                             if let Some(cached) = SemanticIndex::read_from_disk(
                                 dir,
-                                &semantic_project_key,
+                                &semantic_disk_key,
                                 &root_clone,
                                 is_worktree_bridge_for_semantic,
                                 Some(&fingerprint_key),
@@ -1723,8 +1724,7 @@ pub fn handle_configure(req: &RawRequest, ctx: &AppContext) -> Response {
                                             cached.set_fingerprint(fingerprint);
                                             if !is_worktree_bridge_for_semantic {
                                                 if let Some(ref dir) = semantic_storage {
-                                                    cached
-                                                        .write_to_disk(dir, &semantic_project_key);
+                                                    cached.write_to_disk(dir, &semantic_disk_key);
                                                 }
                                             }
                                         }
@@ -1810,7 +1810,7 @@ pub fn handle_configure(req: &RawRequest, ctx: &AppContext) -> Response {
 
                         if !is_worktree_bridge_for_semantic {
                             if let Some(ref dir) = semantic_storage {
-                                index.write_to_disk(dir, &semantic_project_key);
+                                index.write_to_disk(dir, &semantic_disk_key);
                             }
                         }
 

--- a/crates/aft/src/commands/status.rs
+++ b/crates/aft/src/commands/status.rs
@@ -143,6 +143,7 @@ impl AppContext {
                 serde_json::json!({
                     "storage_dir": dir.display().to_string(),
                     "project_cache_key": project_key,
+                    "disk_cache_key": disk_key,
                     "trigram_disk_bytes": trigram_size,
                     "semantic_disk_bytes": semantic_size,
                 })
@@ -150,12 +151,14 @@ impl AppContext {
             (Some(dir), None) => serde_json::json!({
                 "storage_dir": dir.display().to_string(),
                 "project_cache_key": null,
+                "disk_cache_key": null,
                 "trigram_disk_bytes": 0,
                 "semantic_disk_bytes": 0,
             }),
             _ => serde_json::json!({
                 "storage_dir": null,
                 "project_cache_key": null,
+                "disk_cache_key": null,
                 "trigram_disk_bytes": 0,
                 "semantic_disk_bytes": 0,
             }),

--- a/crates/aft/src/commands/status.rs
+++ b/crates/aft/src/commands/status.rs
@@ -121,27 +121,28 @@ impl AppContext {
         // Disk cache sizes — scoped to the **current project** only.
         //
         // Both trigram (`<storage_dir>/index/<key>/`) and semantic
-        // (`<storage_dir>/semantic/<key>/`) caches are partitioned per project by
-        // `project_cache_key(project_root)`. Earlier this function reported the
+        // (`<storage_dir>/semantic/<key>/`) caches are partitioned by
+        // `disk_cache_key(project_root)`. Earlier this function reported the
         // recursive size of the entire `index/` and `semantic/` directories,
         // which summed disk usage across **every** project the user had ever
         // opened. The TUI sidebar surfaced that total as if it were the current
         // project's footprint, which was misleading (e.g. a 4.8 MB project with
         // 9 sibling projects appeared to use 16+ GB).
         //
-        // We now resolve the per-project key from `config.project_root` and
-        // size only that project's slice. When the project key can't be
+        // We now resolve the disk key from `config.project_root` and
+        // size only that project's slice. When the disk key can't be
         // resolved (no project_root), fall back to zeros — the cross-project
         // total is never the right answer to display per-session.
         let storage_dir = config.storage_dir.as_ref().map(|d| d.display().to_string());
         let disk_info = match (&config.storage_dir, &config.project_root) {
             (Some(dir), Some(root)) => {
-                let key = crate::search_index::project_cache_key(root);
-                let trigram_size = dir_size(&dir.join("index").join(&key));
-                let semantic_size = dir_size(&dir.join("semantic").join(&key));
+                let project_key = crate::search_index::project_cache_key(root);
+                let disk_key = crate::search_index::disk_cache_key(root);
+                let trigram_size = dir_size(&dir.join("index").join(&disk_key));
+                let semantic_size = dir_size(&dir.join("semantic").join(&disk_key));
                 serde_json::json!({
                     "storage_dir": dir.display().to_string(),
-                    "project_cache_key": key,
+                    "project_cache_key": project_key,
                     "trigram_disk_bytes": trigram_size,
                     "semantic_disk_bytes": semantic_size,
                 })

--- a/crates/aft/src/search_index.rs
+++ b/crates/aft/src/search_index.rs
@@ -1654,7 +1654,6 @@ pub fn project_cache_key(project_root: &Path) -> String {
     use sha2::{Digest, Sha256};
 
     let mut hasher = Sha256::new();
-    let canonical_root = canonicalize_or_normalize(project_root);
 
     if let Some(root_commit) = run_git(project_root, &["rev-list", "--max-parents=0", "HEAD"]) {
         // Git repo identity is intentionally checkout-path independent. This
@@ -1664,6 +1663,7 @@ pub fn project_cache_key(project_root: &Path) -> String {
         hasher.update(root_commit.as_bytes());
     } else {
         // Non-git project identity is the canonical filesystem path.
+        let canonical_root = canonicalize_or_normalize(project_root);
         hasher.update(canonical_root.to_string_lossy().as_bytes());
     }
 

--- a/crates/aft/src/search_index.rs
+++ b/crates/aft/src/search_index.rs
@@ -1404,15 +1404,23 @@ pub fn lexical_score(index: &SearchIndex, query_trigrams: &[u32], file_id: u32) 
 }
 
 pub fn resolve_cache_dir(project_root: &Path, storage_dir: Option<&Path>) -> PathBuf {
+    let key = disk_cache_key(project_root);
+    resolve_cache_dir_with_key(storage_dir, &key)
+}
+
+pub(crate) fn resolve_cache_dir_with_key(
+    storage_dir: Option<&Path>,
+    disk_cache_key: &str,
+) -> PathBuf {
     // Respect AFT_CACHE_DIR for testing — prevents tests from polluting the user's storage
     if let Some(override_dir) = std::env::var_os("AFT_CACHE_DIR") {
         return PathBuf::from(override_dir)
             .join("index")
-            .join(project_cache_key(project_root));
+            .join(disk_cache_key);
     }
     // Use configured storage dir (from plugin, XDG-compliant)
     if let Some(dir) = storage_dir {
-        return dir.join("index").join(project_cache_key(project_root));
+        return dir.join("index").join(disk_cache_key);
     }
     // Fallback to ~/.cache/aft/ (legacy, for standalone binary usage).
     // On Windows `HOME` is typically unset, so try `USERPROFILE` next.
@@ -1425,7 +1433,7 @@ pub fn resolve_cache_dir(project_root: &Path, storage_dir: Option<&Path>) -> Pat
     home.join(".cache")
         .join("aft")
         .join("index")
-        .join(project_cache_key(project_root))
+        .join(disk_cache_key)
 }
 
 pub(crate) fn build_path_filters(
@@ -1646,19 +1654,74 @@ pub fn project_cache_key(project_root: &Path) -> String {
     use sha2::{Digest, Sha256};
 
     let mut hasher = Sha256::new();
+    let canonical_root = canonicalize_or_normalize(project_root);
 
     if let Some(root_commit) = run_git(project_root, &["rev-list", "--max-parents=0", "HEAD"]) {
-        // Git repo: root commit is the unique identity.
-        // Same repo cloned anywhere produces the same key.
+        // Git repo identity is intentionally checkout-path independent. This
+        // key is also used by DB-backed task/compression/status state, so keep
+        // it stable across clones/worktrees and use `disk_cache_key` for local
+        // on-disk search/semantic/symbol cache partitioning.
         hasher.update(root_commit.as_bytes());
     } else {
-        // Non-git project: use the canonical filesystem path as identity.
-        let canonical_root = canonicalize_or_normalize(project_root);
+        // Non-git project identity is the canonical filesystem path.
         hasher.update(canonical_root.to_string_lossy().as_bytes());
     }
 
     let digest = format!("{:x}", hasher.finalize());
     digest[..16].to_string()
+}
+
+pub fn disk_cache_key(project_root: &Path) -> String {
+    use sha2::{Digest, Sha256};
+
+    let Some(worktree_id) = linked_worktree_identity(project_root) else {
+        return project_cache_key(project_root);
+    };
+
+    let Some(root_commit) = run_git(project_root, &["rev-list", "--max-parents=0", "HEAD"]) else {
+        return project_cache_key(project_root);
+    };
+
+    let mut hasher = Sha256::new();
+    // Linked worktrees share the repo identity from `project_cache_key`, but
+    // their disk caches contain worktree-local paths, mtimes, generated files,
+    // and local edits. Include Git's worktree-private metadata path only for
+    // linked worktrees; ordinary clones keep the existing root-commit key.
+    hasher.update(b"git-disk-cache-v1\0");
+    hasher.update(root_commit.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(worktree_id.to_string_lossy().as_bytes());
+
+    let digest = format!("{:x}", hasher.finalize());
+    digest[..16].to_string()
+}
+
+fn linked_worktree_identity(project_root: &Path) -> Option<PathBuf> {
+    let git_dir = git_path(
+        project_root,
+        &["rev-parse", "--path-format=absolute", "--git-dir"],
+    )?;
+    let common_dir = git_path(
+        project_root,
+        &["rev-parse", "--path-format=absolute", "--git-common-dir"],
+    )?;
+    if git_dir == common_dir {
+        return None;
+    }
+
+    let head_path = run_git(project_root, &["rev-parse", "--git-path", "HEAD"])?;
+    let path = PathBuf::from(head_path);
+    let path = if path.is_absolute() {
+        path
+    } else {
+        project_root.join(path)
+    };
+    Some(canonicalize_or_normalize(&path))
+}
+
+fn git_path(project_root: &Path, args: &[&str]) -> Option<PathBuf> {
+    let path = PathBuf::from(run_git(project_root, args)?);
+    Some(canonicalize_or_normalize(&path))
 }
 
 impl PathFilters {
@@ -2411,7 +2474,83 @@ mod tests {
     }
 
     #[test]
-    fn project_cache_key_includes_checkout_path() {
+    fn disk_cache_key_distinguishes_git_worktrees_but_project_key_does_not() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let source = dir.path().join("source");
+        fs::create_dir_all(&source).expect("create source repo dir");
+        fs::write(source.join("tracked.txt"), "content\n").expect("write tracked file");
+
+        assert!(Command::new("git")
+            .current_dir(&source)
+            .args(["init"])
+            .status()
+            .expect("init git repo")
+            .success());
+        assert!(Command::new("git")
+            .current_dir(&source)
+            .args(["add", "."])
+            .status()
+            .expect("git add")
+            .success());
+        assert!(Command::new("git")
+            .current_dir(&source)
+            .args([
+                "-c",
+                "user.name=AFT Tests",
+                "-c",
+                "user.email=aft-tests@example.com",
+                "commit",
+                "-m",
+                "initial",
+            ])
+            .status()
+            .expect("git commit")
+            .success());
+
+        let source_key = project_cache_key(&source);
+        assert_eq!(source_key.len(), 16);
+
+        let worktree = dir.path().join("worktree");
+        assert!(Command::new("git")
+            .current_dir(&source)
+            .args(["worktree", "add", "--detach"])
+            .arg(&worktree)
+            .arg("HEAD")
+            .status()
+            .expect("git worktree add")
+            .success());
+
+        let worktree_key = project_cache_key(&worktree);
+        assert_eq!(worktree_key.len(), 16);
+        assert_eq!(source_key, worktree_key);
+
+        let source_disk_key = disk_cache_key(&source);
+        let worktree_disk_key = disk_cache_key(&worktree);
+        assert_eq!(source_disk_key.len(), 16);
+        assert_eq!(worktree_disk_key.len(), 16);
+        assert_ne!(source_disk_key, worktree_disk_key);
+        assert_eq!(
+            resolve_cache_dir(&source, Some(dir.path())),
+            dir.path().join("index").join(&source_disk_key)
+        );
+    }
+
+    #[test]
+    fn non_git_disk_cache_key_uses_stable_canonical_path_identity() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let project = dir.path().join("project");
+        fs::create_dir_all(&project).expect("create project dir");
+
+        let direct_key = disk_cache_key(&project);
+        let equivalent_key = disk_cache_key(&project.join(".").join("nested").join(".."));
+
+        assert_eq!(direct_key.len(), 16);
+        assert_eq!(direct_key, equivalent_key);
+        assert_eq!(project_cache_key(&project), direct_key);
+    }
+
+    #[test]
+    fn disk_cache_key_preserves_same_root_commit_clone_sharing() {
         let dir = tempfile::tempdir().expect("create temp dir");
         let source = dir.path().join("source");
         fs::create_dir_all(&source).expect("create source repo dir");
@@ -2455,11 +2594,13 @@ mod tests {
 
         let source_key = project_cache_key(&source);
         let clone_key = project_cache_key(&clone);
-
         assert_eq!(source_key.len(), 16);
         assert_eq!(clone_key.len(), 16);
-        // Same repo (same root commit) → same cache key regardless of clone path
+        // Same repo (same root commit) → same project key regardless of clone path.
         assert_eq!(source_key, clone_key);
+        // Ordinary clones keep sharing disk caches; linked worktrees are the
+        // case that needs isolation.
+        assert_eq!(disk_cache_key(&source), disk_cache_key(&clone));
     }
 
     #[test]

--- a/crates/aft/tests/integration/status_disk_scope_test.rs
+++ b/crates/aft/tests/integration/status_disk_scope_test.rs
@@ -112,6 +112,11 @@ fn status_disk_bytes_only_count_current_project() {
         Some(project_cache_key(&project_a).as_str()),
         "status should retain durable project_cache_key"
     );
+    assert_eq!(
+        status["disk"]["disk_cache_key"].as_str(),
+        Some(disk_cache_key(&project_a).as_str()),
+        "status should expose the disk key used for cache byte sizing"
+    );
 }
 
 #[test]

--- a/crates/aft/tests/integration/status_disk_scope_test.rs
+++ b/crates/aft/tests/integration/status_disk_scope_test.rs
@@ -7,12 +7,12 @@
 //! displayed that cross-project total as if it were the current project's
 //! footprint (e.g. a 4 MB project showed 16 GB because a sibling project's
 //! cache was huge). Status must scope to the current project's slice using
-//! `project_cache_key(project_root)`.
+//! `disk_cache_key(project_root)`.
 
 use std::fs;
 use std::path::PathBuf;
 
-use aft::search_index::project_cache_key;
+use aft::search_index::{disk_cache_key, project_cache_key};
 use serde_json::json;
 use tempfile::tempdir;
 
@@ -26,7 +26,7 @@ fn write_fake_cache_for_project(
     trigram_bytes: usize,
     semantic_bytes: usize,
 ) {
-    let key = project_cache_key(project_root);
+    let key = disk_cache_key(project_root);
 
     let trigram_dir = storage_root.join("index").join(&key);
     fs::create_dir_all(&trigram_dir).expect("create trigram dir");
@@ -58,8 +58,8 @@ fn status_disk_bytes_only_count_current_project() {
     // Ensure the two projects have distinct cache keys (they should, because
     // they have distinct canonical paths). Sanity check this — if it ever
     // fails the test logic falls apart.
-    let key_a = project_cache_key(&project_a);
-    let key_b = project_cache_key(&project_b);
+    let key_a = disk_cache_key(&project_a);
+    let key_b = disk_cache_key(&project_b);
     assert_ne!(
         key_a, key_b,
         "projects {project_a:?} and {project_b:?} unexpectedly share cache key {key_a}"
@@ -107,12 +107,10 @@ fn status_disk_bytes_only_count_current_project() {
          got {semantic} (sibling B has 5 MB which would be visible without scoping)"
     );
 
-    // The status response must also expose the project_cache_key so the
-    // host can correlate disk numbers with cache directories.
     assert_eq!(
         status["disk"]["project_cache_key"].as_str(),
-        Some(key_a.as_str()),
-        "status should include project_cache_key for the configured project"
+        Some(project_cache_key(&project_a).as_str()),
+        "status should retain durable project_cache_key"
     );
 }
 


### PR DESCRIPTION
Closes #50

## Summary
Linked git worktrees share one disk-cache key, so they overwrite and reload each
other's search, semantic, and symbol caches. This gives each linked worktree its
own disk cache while keeping project identity stable across clones.

## What changed
- `search_index.rs`: `project_cache_key()` is unchanged and still identifies the
  project by root commit. A new `disk_cache_key()` diverges only for linked
  worktrees, which it detects when the git dir differs from the git common dir,
  and hashes the root commit together with the worktree's private HEAD path.
  Ordinary clones and non-git projects keep the existing key.
- `configure.rs`, `status.rs`: trigram, semantic, and symbol caches now use the
  disk key, and status reports the size of the right slice.
- Tests: linked worktrees get different keys; ordinary clones still share one.

## Why linked-worktree-only
The existing key intentionally makes the same repo produce the same identity
wherever it's cloned. I kept that for clones and changed only the case that
actually breaks: linked worktrees holding different working state under one
shared key. Isolating ordinary clones too would be a larger behavior change and
isn't needed to fix this.

## Validation
- `cargo fmt --check`
- `cargo test -p agent-file-tools disk_cache_key status_disk`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolate disk caches for linked Git worktrees to prevent cross-worktree clobbering while keeping stable project identity across clones. Status now scopes disk usage to the current checkout and exposes both keys for correlation.

- **Bug Fixes**
  - Added `disk_cache_key(project_root)` that differs only for linked worktrees (root commit + worktree-private HEAD path); `project_cache_key` stays unchanged for identity.
  - Search/trigram, semantic, and symbol caches now read/write/lock using the disk key via `resolve_cache_dir_with_key`, isolating worktrees without changing ordinary clone behavior.
  - `status` sizes per-checkout directories via the disk key and returns both `project_cache_key` and `disk_cache_key` with scoped disk byte totals.
  - Tests confirm: linked worktrees get different disk keys; ordinary clones share; non-git projects remain stable.

- **Performance**
  - Skip canonicalizing git project roots in `project_cache_key`; only canonicalize for non-git projects to avoid an unnecessary filesystem call.

<sup>Written for commit f3733c2202e28c0251a26b14379370534390714e. Summary will update on new commits. <a href="https://cubic.dev/pr/cortexkit/aft/pull/54?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

