### PR TITLE
feat(semantic): support high-dimensional embeddings

### DIFF
--- a/crates/aft/src/semantic_index.rs
+++ b/crates/aft/src/semantic_index.rs
@@ -23,7 +23,9 @@ use url::Url;
 
 const DEFAULT_DIMENSION: usize = 384;
 const MAX_ENTRIES: usize = 1_000_000;
-const MAX_DIMENSION: usize = 1024;
+// Covers high-dimensional backends such as OpenAI text-embedding-3-large (3072)
+// and common local models (4096) while keeping a bounded supported shape.
+const MAX_DIMENSION: usize = 4096;
 const F32_BYTES: usize = std::mem::size_of::<f32>();
 const HEADER_BYTES_V1: usize = 9;
 const HEADER_BYTES_V2: usize = 13;
@@ -176,6 +178,8 @@ fn validate_embedding_batch(
         return Ok(());
     };
     let expected_dimension = first_vector.len();
+    validate_embedding_dimension(expected_dimension)
+        .map_err(|error| format!("{context} returned {error}"))?;
     for (index, vector) in vectors.iter().enumerate() {
         if vector.len() != expected_dimension {
             return Err(format!(
@@ -183,6 +187,16 @@ fn validate_embedding_batch(
                 vector.len()
             ));
         }
+    }
+
+    Ok(())
+}
+
+fn validate_embedding_dimension(dimension: usize) -> Result<(), String> {
+    if dimension == 0 || dimension > MAX_DIMENSION {
+        return Err(format!(
+            "invalid embedding dimension: {dimension}; supported range is 1..={MAX_DIMENSION}"
+        ));
     }
 
     Ok(())
@@ -1837,9 +1851,7 @@ impl SemanticIndex {
 
         let dimension = read_u32(data, &mut pos)? as usize;
         let entry_count = read_u32(data, &mut pos)? as usize;
-        if dimension == 0 || dimension > MAX_DIMENSION {
-            return Err(format!("invalid embedding dimension: {}", dimension));
-        }
+        validate_embedding_dimension(dimension)?;
         if entry_count > MAX_ENTRIES {
             return Err(format!("too many semantic index entries: {}", entry_count));
         }

--- a/crates/aft/tests/semantic_validation_test.rs
+++ b/crates/aft/tests/semantic_validation_test.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use aft::semantic_index::SemanticIndex;
 
@@ -12,6 +12,22 @@ fn write_source_fixture(project_root: &std::path::Path) -> PathBuf {
     )
     .expect("write source file");
     source_file
+}
+
+fn build_empty_v6_bytes(dimension: u32) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    bytes.push(6u8);
+    bytes.extend_from_slice(&dimension.to_le_bytes());
+    bytes.extend_from_slice(&0u32.to_le_bytes()); // entry_count
+    bytes.extend_from_slice(&0u32.to_le_bytes()); // fingerprint_len
+    bytes.extend_from_slice(&0u32.to_le_bytes()); // mtime_count
+    bytes
+}
+
+fn unit_vector(dimension: usize, hot_index: usize) -> Vec<f32> {
+    let mut vector = vec![0.0; dimension];
+    vector[hot_index] = 1.0;
+    vector
 }
 
 #[test]
@@ -75,6 +91,86 @@ fn build_returns_error_when_embedding_dimension_changes_across_batches() {
         error,
         "embedding dimension changed across batches: expected 384, got 512"
     );
+}
+
+#[test]
+fn build_accepts_high_dimension_embeddings_and_search_roundtrips() {
+    let project = tempfile::tempdir().expect("create project dir");
+    let source_file = write_source_fixture(project.path());
+    let files = vec![source_file.clone()];
+    let mut embed = |texts: Vec<String>| {
+        Ok::<Vec<Vec<f32>>, String>(
+            texts
+                .into_iter()
+                .map(|text| {
+                    if text.contains("handle_request") {
+                        unit_vector(4096, 0)
+                    } else if text.contains("normalize_user_id") {
+                        unit_vector(4096, 1)
+                    } else {
+                        unit_vector(4096, 2)
+                    }
+                })
+                .collect(),
+        )
+    };
+
+    let index = SemanticIndex::build(project.path(), &files, &mut embed, 16)
+        .expect("4096-dimensional build should be accepted");
+    assert_eq!(index.dimension(), 4096);
+
+    let storage = tempfile::tempdir().expect("create storage dir");
+    index.write_to_disk(storage.path(), "high-dim-project");
+    let restored = SemanticIndex::read_from_disk(
+        storage.path(),
+        "high-dim-project",
+        project.path(),
+        false,
+        None,
+    )
+    .expect("restore 4096-dimensional semantic index");
+
+    let results = restored.search(&unit_vector(4096, 1), 1);
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].name, "normalize_user_id");
+    assert_eq!(results[0].file, source_file);
+}
+
+#[test]
+fn build_rejects_unsupported_embedding_dimensions() {
+    for dimension in [0usize, 4097] {
+        let project = tempfile::tempdir().expect("create project dir");
+        let source_file = write_source_fixture(project.path());
+        let files = vec![source_file];
+        let mut embed = move |texts: Vec<String>| {
+            Ok::<Vec<Vec<f32>>, String>(texts.into_iter().map(|_| vec![1.0; dimension]).collect())
+        };
+
+        let error = SemanticIndex::build(project.path(), &files, &mut embed, 16)
+            .expect_err("unsupported dimensions should be rejected during build");
+        assert!(
+            error.contains(&format!("invalid embedding dimension: {dimension}"))
+                && error.contains("supported range is 1..=4096"),
+            "error should include dimension and supported range: {error}"
+        );
+    }
+}
+
+#[test]
+fn from_bytes_accepts_and_rejects_dimension_boundaries() {
+    let index = SemanticIndex::from_bytes(&build_empty_v6_bytes(4096), Path::new("/"))
+        .expect("4096 dimensions should deserialize");
+    assert_eq!(index.dimension(), 4096);
+
+    for dimension in [0u32, 4097] {
+        let error = SemanticIndex::from_bytes(&build_empty_v6_bytes(dimension), Path::new("/"))
+            .expect_err("unsupported dimension should be rejected");
+        assert!(
+            error.contains(&format!("invalid embedding dimension: {dimension}"))
+                && error.contains("supported range is 1..=4096"),
+            "error should include supported range: {error}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Closes #49

## Summary
Raises the embedding dimension cap from 1024 to 4096 so larger models like
`text-embedding-3-large` (3072) can be indexed through the external backends.
The cache format and all defaults stay the same.

## What changed
- `semantic_index.rs`: `MAX_DIMENSION` goes from 1024 to 4096. Dimension
  checking is consolidated into one `validate_embedding_dimension()` that runs
  both when a backend returns a batch and when a cache is read back.
- Tests: build, persist, reload, and search at 4096; reject 0 and 4097 on both
  build and deserialization.

## Why just the cap and one check
This PR intentionally stays small: a constant change plus a single boundary
check. Bigger questions like aggregate memory ceilings and corrupt-cache
hardening are left out so they can be handled on their own if you want them.

## Validation
- `cargo fmt --check`
- `cargo test -p agent-file-tools --test semantic_validation_test`
- `cargo test -p agent-file-tools semantic_index`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the embedding dimension cap to 4096 to support high‑dimensional models like `text-embedding-3-large` (3072) and common 4096‑d local models. Cache format and defaults are unchanged.

- **New Features**
  - Increase `MAX_DIMENSION` from 1024 to 4096.
  - Allow 4096‑d embeddings during build and read; reject 0 and >4096 with clear errors.

- **Refactors**
  - Add `validate_embedding_dimension()` and use it in batch validation and deserialization.

<sup>Written for commit 32f7f25609b310f2e0e320882bd0d8d3ab8c9e8d. Summary will update on new commits. <a href="https://cubic.dev/pr/cortexkit/aft/pull/55?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

