### PR TITLE
fix(windows): keep Windows ONNX, storage, and file-replacement fixes

### DIFF
--- a/crates/aft/src/commands/configure.rs
+++ b/crates/aft/src/commands/configure.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::{Component, Path, PathBuf};
 use std::process::Command;
@@ -1356,6 +1357,19 @@ pub fn handle_configure(req: &RawRequest, ctx: &AppContext) -> Response {
             &canonical_cache_root,
         ));
     if let Some(storage_dir) = next_config.storage_dir.clone() {
+        // Ensure the storage root directory exists so subsystems (trust,
+        // backups, checkpoints, DB, persistence) can create their sub-trees
+        // without a separate create_dir_all per subsystem. On fresh installs
+        // this directory hasn't been created yet, and every subsystem
+        // currently creates its own subdirectory lazily — but the root must
+        // exist for status/diagnostics to report a valid path.
+        if let Err(err) = fs::create_dir_all(&storage_dir) {
+            slog_warn!(
+                "failed to create storage directory {}: {}",
+                storage_dir.display(),
+                err
+            );
+        }
         ctx.backup().borrow_mut().set_storage_dir_for_harness(
             storage_dir,
             harness,

--- a/crates/aft/src/semantic_index.rs
+++ b/crates/aft/src/semantic_index.rs
@@ -969,7 +969,6 @@ fn extract_version_from_filename(name: &str) -> Option<String> {
     re.find(name).map(|m| m.as_str().to_string())
 }
 
-#[cfg(any(test, target_os = "linux", target_os = "macos"))]
 fn suggest_removal_command(lib_path: &str) -> String {
     if lib_path.starts_with("/usr/local/lib")
         || lib_path == "libonnxruntime.so"
@@ -990,7 +989,6 @@ fn suggest_removal_command(lib_path: &str) -> String {
 /// stability — the auto-fix recommendation must always come first because
 /// it's the only safe option, and the system-rm step must remain present
 /// because some users prefer the system-wide cleanup path.
-#[cfg(any(test, target_os = "linux", target_os = "macos"))]
 pub(crate) fn format_ort_version_mismatch(version: &str, lib_name: &str) -> String {
     format!(
         "ONNX Runtime version mismatch: found v{} at '{}', but AFT requires v1.20+. \

--- a/crates/aft/src/semantic_index.rs
+++ b/crates/aft/src/semantic_index.rs
@@ -797,7 +797,8 @@ pub fn pre_validate_onnx_runtime() -> Result<(), String> {
         let lib_name = dylib_path.as_deref().unwrap_or("onnxruntime.dll");
 
         // Use kernel32 LoadLibraryExW for the validation — built-in, no
-        // crate dependency required.
+        // crate dependency required. GetModuleFileNameW resolves the loaded
+        // DLL path for version probing via the version.dll API.
         #[link(name = "kernel32")]
         extern "system" {
             fn LoadLibraryExW(
@@ -806,6 +807,48 @@ pub fn pre_validate_onnx_runtime() -> Result<(), String> {
                 dwFlags: u32,
             ) -> *mut std::ffi::c_void;
             fn FreeLibrary(hLibModule: *mut std::ffi::c_void) -> i32;
+            fn GetModuleFileNameW(
+                hModule: *mut std::ffi::c_void,
+                lpFilename: *mut u16,
+                nSize: u32,
+            ) -> u32;
+        }
+
+        #[link(name = "version")]
+        extern "system" {
+            fn GetFileVersionInfoSizeW(
+                lptstrFilename: *const u16,
+                lpdwHandle: *mut u32,
+            ) -> u32;
+            fn GetFileVersionInfoW(
+                lptstrFilename: *const u16,
+                dwHandle: u32,
+                dwLen: u32,
+                lpData: *mut std::ffi::c_void,
+            ) -> i32;
+            fn VerQueryValueW(
+                pBlock: *mut std::ffi::c_void,
+                lpSubBlock: *const u16,
+                lplpBuffer: *mut *mut std::ffi::c_void,
+                puLen: *mut u32,
+            ) -> i32;
+        }
+
+        #[repr(C)]
+        struct VS_FIXEDFILEINFO {
+            dw_signature: u32,
+            dw_struc_version: u32,
+            dw_file_version_ms: u32,   // HIWORD major, LOWORD minor
+            dw_file_version_ls: u32,   // HIWORD build, LOWORD revision
+            dw_product_version_ms: u32,
+            dw_product_version_ls: u32,
+            dw_file_flags_mask: u32,
+            dw_file_flags: u32,
+            dw_file_os: u32,
+            dw_file_type: u32,
+            dw_file_subtype: u32,
+            dw_file_date_ms: u32,
+            dw_file_date_ls: u32,
         }
 
         unsafe {
@@ -824,7 +867,58 @@ pub fn pre_validate_onnx_runtime() -> Result<(), String> {
                     lib_name, err
                 ));
             }
+
+            // Probe the file version from PE resources so we can reject
+            // outdated DLLs (e.g. v1.9.x) before the ort crate panics.
+            let mut detected_major: u32 = 0;
+            let mut detected_minor: u32 = 0;
+            let mut path_buf = [0u16; 260];
+            let path_len = GetModuleFileNameW(handle, path_buf.as_mut_ptr(), 260);
+            if path_len > 0 {
+                let mut dummy_handle: u32 = 0;
+                let info_size =
+                    GetFileVersionInfoSizeW(path_buf.as_ptr(), &mut dummy_handle);
+                if info_size > 0 {
+                    let mut info = vec![0u8; info_size as usize];
+                    if GetFileVersionInfoW(
+                        path_buf.as_ptr(),
+                        0,
+                        info_size,
+                        info.as_mut_ptr() as *mut std::ffi::c_void,
+                    ) != 0
+                    {
+                        let sub_block = "\\\0".encode_utf16().collect::<Vec<u16>>();
+                        let mut vs_info: *mut std::ffi::c_void =
+                            std::ptr::null_mut();
+                        let mut vs_len: u32 = 0;
+                        if VerQueryValueW(
+                            info.as_mut_ptr() as *mut std::ffi::c_void,
+                            sub_block.as_ptr(),
+                            &mut vs_info,
+                            &mut vs_len,
+                        ) != 0
+                            && !vs_info.is_null()
+                        {
+                            let fixed = vs_info as *const VS_FIXEDFILEINFO;
+                            detected_major = (*fixed).dw_file_version_ms >> 16;
+                            detected_minor =
+                                (*fixed).dw_file_version_ms & 0xFFFF;
+                        }
+                    }
+                }
+            }
+
             FreeLibrary(handle);
+
+            // Version compatibility check (mirrors the Linux/macOS path).
+            // If version could not be detected (detected_major == 0) we let
+            // the load succeed — the ort crate will diagnose further.
+            if detected_major != 0
+                && (detected_major != 1 || detected_minor < 20)
+            {
+                let ver = format!("{}.{}", detected_major, detected_minor);
+                return Err(format_ort_version_mismatch(&ver, lib_name));
+            }
         }
     }
 

--- a/crates/aft/src/semantic_index.rs
+++ b/crates/aft/src/semantic_index.rs
@@ -30,7 +30,9 @@ const F32_BYTES: usize = std::mem::size_of::<f32>();
 const HEADER_BYTES_V1: usize = 9;
 const HEADER_BYTES_V2: usize = 13;
 const ONNX_RUNTIME_INSTALL_HINT: &str =
-    "ONNX Runtime not found. Install via: brew install onnxruntime (macOS) or apt install libonnxruntime (Linux).";
+    "ONNX Runtime not found. Install via: brew install onnxruntime (macOS), \
+     apt install libonnxruntime (Linux), or place onnxruntime.dll in your PATH (Windows). \
+     AFT can auto-download ONNX Runtime — run `npx @cortexkit/aft doctor` to diagnose.";
 
 const SEMANTIC_INDEX_VERSION_V1: u8 = 1;
 const SEMANTIC_INDEX_VERSION_V2: u8 = 2;
@@ -788,8 +790,42 @@ pub fn pre_validate_onnx_runtime() -> Result<(), String> {
 
     #[cfg(target_os = "windows")]
     {
-        // On Windows, skip pre-validation — let ort handle LoadLibrary
-        let _ = dylib_path;
+        // Validate ONNX Runtime availability on Windows by loading the DLL
+        // via LoadLibraryExW before the ort crate attempts its own LoadLibrary.
+        // This way we can produce a friendly error (with installation hints)
+        // instead of a raw LoadLibrary failure from deep inside fastembed.
+        let lib_name = dylib_path.as_deref().unwrap_or("onnxruntime.dll");
+
+        // Use kernel32 LoadLibraryExW for the validation — built-in, no
+        // crate dependency required.
+        #[link(name = "kernel32")]
+        extern "system" {
+            fn LoadLibraryExW(
+                lpLibFileName: *const u16,
+                hFile: *mut std::ffi::c_void,
+                dwFlags: u32,
+            ) -> *mut std::ffi::c_void;
+            fn FreeLibrary(hLibModule: *mut std::ffi::c_void) -> i32;
+        }
+
+        unsafe {
+            use std::os::windows::ffi::OsStrExt;
+            let wide: Vec<u16> = std::ffi::OsStr::new(lib_name)
+                .encode_wide()
+                .chain(std::iter::once(0))
+                .collect();
+
+            let handle = LoadLibraryExW(wide.as_ptr(), std::ptr::null_mut(), 0);
+            if handle.is_null() {
+                let err = std::io::Error::last_os_error();
+                return Err(format!(
+                    "ONNX Runtime not found. LoadLibraryExW('{}') failed: {}. \
+                     Run `npx @cortexkit/aft doctor` to diagnose.",
+                    lib_name, err
+                ));
+            }
+            FreeLibrary(handle);
+        }
     }
 
     Ok(())

--- a/packages/aft-bridge/src/downloader.ts
+++ b/packages/aft-bridge/src/downloader.ts
@@ -269,7 +269,9 @@ export async function downloadBinary(version?: string): Promise<string | null> {
       chmodSync(tmpPath, 0o755);
     }
 
-    // Atomic rename — unlink first on Windows where renameSync fails if target exists
+    // Replace binary — on Windows renameSync fails (EEXIST) when the target
+    // exists, so unlink first. This creates a brief window where no binary
+    // exists at binaryPath — callers should handle a missing binary gracefully.
     if (process.platform === "win32" && existsSync(binaryPath)) {
       try {
         unlinkSync(binaryPath);

--- a/packages/aft-bridge/src/downloader.ts
+++ b/packages/aft-bridge/src/downloader.ts
@@ -269,7 +269,14 @@ export async function downloadBinary(version?: string): Promise<string | null> {
       chmodSync(tmpPath, 0o755);
     }
 
-    // Atomic rename
+    // Atomic rename — unlink first on Windows where renameSync fails if target exists
+    if (process.platform === "win32" && existsSync(binaryPath)) {
+      try {
+        unlinkSync(binaryPath);
+      } catch {
+        // best-effort; renameSync will surface the error if unlink fails
+      }
+    }
     renameSync(tmpPath, binaryPath);
 
     log(`AFT binary ready at ${binaryPath}`);

--- a/packages/aft-bridge/src/onnx-runtime.ts
+++ b/packages/aft-bridge/src/onnx-runtime.ts
@@ -459,34 +459,86 @@ function findSystemOnnxRuntime(libName?: string): string | null {
       "/usr/local/lib",
     );
   } else if (process.platform === "win32") {
-    // Windows users often install ONNX Runtime via Scoop or a manual zip and
-    // put the directory containing `onnxruntime.dll` on PATH. We only consider
-    // absolute PATH entries (never the current directory or relative paths).
-    // Returning one of those directories means the plugin may pass it to Rust
-    // as the ORT DLL directory; that mirrors Windows loader semantics for a
-    // user-controlled PATH while avoiding accidental current-dir DLL loads.
-    // Doctor-only probes may be looser, but the bridge path can become a real
-    // load path and should stay conservative.
-    searchPaths.push(...pathEntriesForPlatform());
+    // Common Windows install locations for ONNX Runtime
+    const programFiles = process.env.ProgramFiles ?? "C:\\Program Files";
+    const programFilesX86 = process.env["ProgramFiles(x86)"] ?? "C:\\Program Files (x86)";
+    searchPaths.push(
+      join(programFiles, "onnxruntime", "lib"),
+      join(programFiles, "Microsoft ONNX Runtime", "lib"),
+      join(programFiles, "Microsoft Machine Learning", "lib"),
+      join(programFilesX86, "onnxruntime", "lib"),
+      // Windows NuGet package layout:
+      //   <user>\.nuget\packages\microsoft.ml.onnxruntime\<version>\runtimes\win-{x64,arm64}\native\
+      // Scan all installed versions since we don't know which one is present.
+      ...(() => {
+        const nugetPaths: string[] = [];
+        const userProfile = process.env.USERPROFILE ?? "";
+        if (!userProfile) return nugetPaths;
+        const nugetPackageDir = join(userProfile, ".nuget", "packages", "microsoft.ml.onnxruntime");
+        if (!existsSync(nugetPackageDir)) return nugetPaths;
+        try {
+          for (const entry of readdirSync(nugetPackageDir, { withFileTypes: true })) {
+            if (!entry.isDirectory()) continue;
+            // Skip well-known non-version entries
+            if (entry.name === "__globalPackagesFolder" || entry.name.startsWith(".")) continue;
+            nugetPaths.push(
+              join(nugetPackageDir, entry.name, "runtimes", "win-x64", "native"),
+              join(nugetPackageDir, entry.name, "runtimes", "win-arm64", "native"),
+            );
+          }
+        } catch {
+          // best-effort scan
+        }
+        return nugetPaths;
+      })(),
+    );
+    // Also search PATH directories for onnxruntime.dll
+    const pathEnv = process.env.PATH ?? "";
+    for (const dir of pathEnv.split(";")) {
+      const trimmed = dir.trim();
+      if (!trimmed) continue;
+      searchPaths.push(trimmed);
+    }
   }
 
+  // Deduplicate paths while preserving order.
+  // On case-insensitive filesystems (Windows, macOS) normalize casing for
+  // comparison; on Linux the raw path casing is the authority.
+  const normalizeCase = process.platform === "win32" || process.platform === "darwin";
   const seen = new Set<string>();
-  for (const dir of searchPaths) {
-    if (seen.has(dir)) continue;
-    seen.add(dir);
-    if (!directoryContainsLibrary(dir, libName)) continue;
+  const uniquePaths = searchPaths.filter((p) => {
+    let key = resolve(p).replace(/[/\\]+$/, "");
+    if (normalizeCase) key = key.toLowerCase();
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
 
-    // Reject system installs that the Rust pre-validator will refuse. Without
-    // this filter, a stale distro package (e.g. libonnxruntime1.9 on Ubuntu
-    // 22.04) shadows our auto-downloaded v1.24 forever and semantic search
-    // stays "failed" until the user hand-deletes the system library.
-    const version = detectOnnxVersion(dir, libName);
-    if (version && !isOnnxVersionCompatible(version)) {
-      warn(
-        `Skipping system ONNX Runtime at ${dir} (v${version}); AFT requires ` +
-          `v${REQUIRED_ORT_MAJOR}.${REQUIRED_ORT_MIN_MINOR}+. Falling through to AFT-managed download.`,
-      );
-      continue;
+  for (const dir of uniquePaths) {
+    if (!existsSync(join(dir, libName))) continue;
+
+    // Skip the version check for PATH entries — version-suffixed filenames
+    // are less common on Windows and we want PATH discovery to succeed.
+    let skipVersionCheck = false;
+    if (process.platform === "win32") {
+      // Only do version check for common install paths, not arbitrary PATH entries
+      const isCommonPath = dir.includes("Program Files") || dir.includes("onnxruntime");
+      if (!isCommonPath) skipVersionCheck = true;
+    }
+
+    if (!skipVersionCheck) {
+      // Reject system installs that the Rust pre-validator will refuse. Without
+      // this filter, a stale distro package (e.g. libonnxruntime1.9 on Ubuntu
+      // 22.04) shadows our auto-downloaded v1.24 forever and semantic search
+      // stays "failed" until the user hand-deletes the system library.
+      const version = detectOnnxVersion(dir, libName);
+      if (version && !isOnnxVersionCompatible(version)) {
+        warn(
+          `Skipping system ONNX Runtime at ${dir} (v${version}); AFT requires ` +
+            `v${REQUIRED_ORT_MAJOR}.${REQUIRED_ORT_MIN_MINOR}+. Falling through to AFT-managed download.`,
+        );
+        continue;
+      }
     }
 
     return dir;

--- a/packages/aft-bridge/src/onnx-runtime.ts
+++ b/packages/aft-bridge/src/onnx-runtime.ts
@@ -511,7 +511,12 @@ function findSystemOnnxRuntime(libName?: string): string | null {
   });
 
   for (const dir of uniquePaths) {
-    if (!existsSync(join(dir, libName))) continue;
+    const libPath = join(dir, libName);
+    if (process.platform === "win32") {
+      if (!directoryContainsLibrary(dir, libName)) continue;
+    } else if (!existsSync(libPath)) {
+      continue;
+    }
 
     // Skip the version check for PATH entries — version-suffixed filenames
     // are less common on Windows and we want PATH discovery to succeed.

--- a/packages/aft-bridge/src/onnx-runtime.ts
+++ b/packages/aft-bridge/src/onnx-runtime.ts
@@ -492,13 +492,9 @@ function findSystemOnnxRuntime(libName?: string): string | null {
         return nugetPaths;
       })(),
     );
-    // Also search PATH directories for onnxruntime.dll
-    const pathEnv = process.env.PATH ?? "";
-    for (const dir of pathEnv.split(";")) {
-      const trimmed = dir.trim();
-      if (!trimmed) continue;
-      searchPaths.push(trimmed);
-    }
+    // Also include absolute PATH entries (reuses the existing helper that
+    // validates absolute paths, rejects null bytes, strips quotes, excludes ".").
+    searchPaths.push(...pathEntriesForPlatform());
   }
 
   // Deduplicate paths while preserving order.

--- a/packages/aft-bridge/src/resolver.ts
+++ b/packages/aft-bridge/src/resolver.ts
@@ -1,5 +1,5 @@
 import { execSync } from "node:child_process";
-import { chmodSync, copyFileSync, existsSync, mkdirSync, renameSync } from "node:fs";
+import { chmodSync, copyFileSync, existsSync, mkdirSync, renameSync, unlinkSync } from "node:fs";
 import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -54,6 +54,14 @@ function copyToVersionedCache(npmBinaryPath: string, knownVersion?: string): str
     copyFileSync(npmBinaryPath, tmpPath);
     if (process.platform !== "win32") {
       chmodSync(tmpPath, 0o755);
+    }
+    // Atomic rename — unlink first on Windows where renameSync fails if target exists
+    if (process.platform === "win32" && existsSync(cachedPath)) {
+      try {
+        unlinkSync(cachedPath);
+      } catch {
+        // best-effort; renameSync will surface the error if unlink fails
+      }
     }
     renameSync(tmpPath, cachedPath);
     log(`Copied npm binary to versioned cache: ${cachedPath}`);

--- a/packages/aft-bridge/src/resolver.ts
+++ b/packages/aft-bridge/src/resolver.ts
@@ -55,7 +55,7 @@ function copyToVersionedCache(npmBinaryPath: string, knownVersion?: string): str
     if (process.platform !== "win32") {
       chmodSync(tmpPath, 0o755);
     }
-    // Atomic rename — unlink first on Windows where renameSync fails if target exists
+    // Best-effort replace — unlink first on Windows where renameSync fails if target exists
     if (process.platform === "win32" && existsSync(cachedPath)) {
       try {
         unlinkSync(cachedPath);

--- a/packages/aft-cli/src/lib/diagnostics.ts
+++ b/packages/aft-cli/src/lib/diagnostics.ts
@@ -1,4 +1,4 @@
-import { closeSync, existsSync, openSync, readSync, statSync } from "node:fs";
+import { closeSync, existsSync, mkdirSync, openSync, readSync, statSync } from "node:fs";
 import type { HarnessAdapter } from "../adapters/types.js";
 import { type BinaryCacheInfo, getBinaryCacheInfo } from "./binary-cache.js";
 import { probeBinaryVersion } from "./binary-probe.js";
@@ -112,6 +112,18 @@ async function diagnoseHarness(adapter: HarnessAdapter): Promise<HarnessDiagnost
   const storage = adapter.getStorageDir();
   const logPath = adapter.getLogFile();
   const pluginCache = adapter.getPluginCacheInfo();
+
+  // Ensure the storage directory exists so diagnostics report useful info
+  // instead of "(not created)" on fresh installs. The storage directory is
+  // normally created lazily by the bridge on first tool call, but the doctor
+  // command is a read-only diagnostic that should still display it.
+  if (!existsSync(storage)) {
+    try {
+      mkdirSync(storage, { recursive: true });
+    } catch {
+      // best-effort — diagnostics can still report the path as (not created)
+    }
+  }
 
   const describeStorage =
     "describeStorageSubtrees" in adapter &&

--- a/packages/aft-cli/src/lib/onnx.ts
+++ b/packages/aft-cli/src/lib/onnx.ts
@@ -82,11 +82,16 @@ export function findSystemOnnxRuntime(): string | null {
       join(programFiles, "Microsoft Machine Learning", "lib"),
       join(programFilesX86, "onnxruntime", "lib"),
     );
-    // Also search PATH for onnxruntime.dll via raw string split
+    // Also include absolute PATH entries. Use the same filters that the bridge
+    // version's pathEntriesForPlatform() applies: absolute-path check, null-byte
+    // rejection, "." exclusion, quote-stripping.
+    const delimiter = ";";
     const pathEnv = process.env.PATH ?? "";
-    for (const dir of pathEnv.split(";")) {
+    for (const dir of pathEnv.split(delimiter)) {
       const trimmed = dir.trim();
-      if (trimmed) searchPaths.push(trimmed);
+      if (!trimmed || trimmed === "." || trimmed.includes("\0")) continue;
+      if (!isAbsolute(trimmed)) continue;
+      searchPaths.push(trimmed);
     }
   }
 

--- a/packages/aft-cli/src/lib/onnx.ts
+++ b/packages/aft-cli/src/lib/onnx.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync, readlinkSync, realpathSync, statSync } from "node:fs";
-import { isAbsolute, join, win32 } from "node:path";
+import { isAbsolute, join, resolve, win32 } from "node:path";
 
 export const ONNX_RUNTIME_VERSION = "1.24.4";
 
@@ -59,22 +59,50 @@ function directoryContainsLibrary(dir: string, libName: string): boolean {
 
 export function findSystemOnnxRuntime(): string | null {
   const libName = getOnnxLibraryName();
-  const searchPaths =
-    process.platform === "darwin"
-      ? ["/opt/homebrew/lib", "/usr/local/lib"]
-      : process.platform === "linux"
-        ? ["/usr/lib", "/usr/lib/x86_64-linux-gnu", "/usr/lib/aarch64-linux-gnu", "/usr/local/lib"]
-        : process.platform === "win32"
-          ? pathEntriesForPlatform()
-          : [];
+  const searchPaths: string[] = [];
 
+  if (process.platform === "darwin") {
+    searchPaths.push("/opt/homebrew/lib", "/usr/local/lib");
+  } else if (process.platform === "linux") {
+    searchPaths.push(
+      "/usr/lib",
+      "/usr/lib/x86_64-linux-gnu",
+      "/usr/lib/aarch64-linux-gnu",
+      "/usr/local/lib",
+    );
+  } else if (process.platform === "win32") {
+    // Start with absolute PATH entries (via pathEntriesForPlatform) to
+    // discover Scoop/manual-zip installs, then add common install paths.
+    searchPaths.push(...pathEntriesForPlatform());
+    const programFiles = process.env.ProgramFiles ?? "C:\\Program Files";
+    const programFilesX86 = process.env["ProgramFiles(x86)"] ?? "C:\\Program Files (x86)";
+    searchPaths.push(
+      join(programFiles, "onnxruntime", "lib"),
+      join(programFiles, "Microsoft ONNX Runtime", "lib"),
+      join(programFiles, "Microsoft Machine Learning", "lib"),
+      join(programFilesX86, "onnxruntime", "lib"),
+    );
+    // Also search PATH for onnxruntime.dll via raw string split
+    const pathEnv = process.env.PATH ?? "";
+    for (const dir of pathEnv.split(";")) {
+      const trimmed = dir.trim();
+      if (trimmed) searchPaths.push(trimmed);
+    }
+  }
+
+  // Deduplicate paths.
+  // On case-insensitive filesystems (Windows, macOS) normalize casing for
+  // comparison; on Linux the raw path casing is the authority.
+  const normalizeCase = process.platform === "win32" || process.platform === "darwin";
   const seen = new Set<string>();
-  for (const path of searchPaths) {
-    if (seen.has(path)) continue;
-    seen.add(path);
+  for (const dir of searchPaths) {
+    let key = resolve(dir).replace(/[/\\]+$/, "");
+    if (normalizeCase) key = key.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
     // Doctor only probes for presence here; the plugin's actual load path uses
     // the hardened bridge resolver in packages/aft-bridge/src/onnx-runtime.ts.
-    if (directoryContainsLibrary(path, libName)) return path;
+    if (directoryContainsLibrary(dir, libName)) return dir;
   }
   return null;
 }


### PR DESCRIPTION
Rebased on latest `cortexkit/main` (post-v0.31.1) per maintainer review.

## Dropped (shipped in v0.31.1 or conflicting)

- `findHighestCachedVersion` + `compareSemver` in `resolver.ts` — superseded by v0.31.1 skew detection
- `opencode.ts` `getStorageDir` rewrite — upstream already routes through `getCortexKitStorageRoot`
- `doctor.ts` issue bullets + `log.success` outro — equivalent shipped in v0.31.1

## Kept (7 files, +201/-44)

| File | Change | Rationale |
|---|---|---|
| `crates/aft/src/semantic_index.rs` | `pre_validate_onnx_runtime` validates via `LoadLibraryExW` on Windows + updated install hint | Catches missing/broken DLL before `ort` crate panics |
| `crates/aft/src/commands/configure.rs` | `fs::create_dir_all(storage_dir)` during configure | Ensures root exists before subsystems create subtrees |
| `packages/aft-bridge/src/onnx-runtime.ts` | NuGet cache scan + `%PATH%` discovery + case-insensitive dedup + PATH-entry version-skip | Discovers ONNX from common Windows install locations |
| `packages/aft-cli/src/lib/onnx.ts` | Same Win32 discovery for doctor | Mirror of bridge resolver for diagnostic output |
| `packages/aft-bridge/src/downloader.ts` | `unlinkSync` before `renameSync` on Windows | Fixes EEXIST crash on Windows file replacement |
| `packages/aft-bridge/src/resolver.ts` | `unlinkSync` before `renameSync` in `copyToVersionedCache` | Same EEXIST fix for npm-platform-binary cache path |
| `packages/aft-cli/src/lib/diagnostics.ts` | Best-effort `mkdirSync` for storage dir | Clearer doctor output on fresh installs |

## Verification

- `npx tsc --noEmit` in `packages/aft-bridge` and `packages/aft-cli` — clean
- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Windows reliability: pre-validates and version-checks `onnxruntime.dll`, hardens ONNX discovery, and fixes file replacement crashes. Also ensures the storage directory exists during configure and diagnostics.

- **Bug Fixes**
  - Windows: pre-validate and version-check `onnxruntime.dll` via `LoadLibraryExW` + `GetFileVersionInfoW`; clearer errors and stale DLL rejection; updated install hint with `npx @cortexkit/aft doctor`.
  - Windows: unlink before `renameSync` to prevent EEXIST when replacing binaries in `downloader.ts` and `resolver.ts`.
  - Ensure storage dir exists: `create_dir_all` in Rust configure; best‑effort `mkdirSync` in CLI diagnostics.
  - Security/CI: reuse `pathEntriesForPlatform()` in the bridge and require absolute PATH entries in the CLI; fix Windows build for `format_ort_version_mismatch` and Linux case‑sensitive path checks.

- **New Features**
  - Windows ONNX discovery: scan NuGet cache (`%USERPROFILE%\.nuget\packages\microsoft.ml.onnxruntime\...`), common Program Files paths, and absolute `%PATH%`; case‑insensitive dedup; skip version checks for PATH entries while still filtering stale installs elsewhere.

<sup>Written for commit d0a323114d5571eb141028733aac9857013f903b. Summary will update on new commits. <a href="https://cubic.dev/pr/cortexkit/aft/pull/66?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



