### PR TITLE
session file history

### DIFF
--- a/crates/aft/src/commands/delete_file.rs
+++ b/crates/aft/src/commands/delete_file.rs
@@ -108,7 +108,12 @@ fn delete_one_or_dir(
     }
 
     let path = match ctx.validate_path(&req.id, requested_path) {
-        Ok(path) => path,
+        Ok(path) => {
+            ctx.session_history()
+                .borrow_mut()
+                .record(req.session(), path.clone(), crate::session_history::FileOp::Delete);
+            path
+        }
         Err(resp) => return Err(resp),
     };
 

--- a/crates/aft/src/commands/edit_match.rs
+++ b/crates/aft/src/commands/edit_match.rs
@@ -132,7 +132,12 @@ fn handle_append(req: &RawRequest, ctx: &AppContext, op_id: &str) -> Response {
         .unwrap_or(true);
 
     let path = match ctx.validate_path(&req.id, Path::new(file)) {
-        Ok(path) => path,
+        Ok(path) => {
+            ctx.session_history()
+                .borrow_mut()
+                .record(req.session(), path.clone(), crate::session_history::FileOp::Edit);
+            path
+        }
         Err(resp) => return resp,
     };
 

--- a/crates/aft/src/commands/edit_symbol.rs
+++ b/crates/aft/src/commands/edit_symbol.rs
@@ -84,7 +84,12 @@ pub fn handle_edit_symbol(req: &RawRequest, ctx: &AppContext) -> Response {
     }
 
     let path = match ctx.validate_path(&req.id, Path::new(file)) {
-        Ok(path) => path,
+        Ok(path) => {
+            ctx.session_history()
+                .borrow_mut()
+                .record(req.session(), path.clone(), crate::session_history::FileOp::Edit);
+            path
+        }
         Err(resp) => return resp,
     };
     if !path.exists() {

--- a/crates/aft/src/commands/move_file.rs
+++ b/crates/aft/src/commands/move_file.rs
@@ -41,7 +41,12 @@ pub fn handle_move_file(req: &RawRequest, ctx: &AppContext) -> Response {
     };
 
     let src_path = match ctx.validate_path(&req.id, Path::new(file)) {
-        Ok(path) => path,
+        Ok(path) => {
+            ctx.session_history()
+                .borrow_mut()
+                .record(req.session(), path.clone(), crate::session_history::FileOp::Move);
+            path
+        }
         Err(resp) => return resp,
     };
     let dst_path = match ctx.validate_path(&req.id, Path::new(destination)) {

--- a/crates/aft/src/commands/outline.rs
+++ b/crates/aft/src/commands/outline.rs
@@ -465,6 +465,46 @@ fn discover_outline_files_for_files_mode(
     discover_outline_files_with_options(directory, Some(&options))
 }
 
+fn unescape_porcelain_path(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            match chars.next() {
+                Some('a') => out.push('\u{0007}'),
+                Some('b') => out.push('\u{0008}'),
+                Some('t') => out.push('\t'),
+                Some('n') => out.push('\n'),
+                Some('v') => out.push('\u{000b}'),
+                Some('f') => out.push('\u{000c}'),
+                Some('r') => out.push('\r'),
+                Some('"') => out.push('"'),
+                Some('\\') => out.push('\\'),
+                Some(d @ '0'..='7') => {
+                    // octal escape \NNN
+                    let mut oct = d.to_digit(8).unwrap_or(0);
+                    let mut i = 0u32;
+                    while i < 2 {
+                        match chars.peek().copied() {
+                            Some(c @ '0'..='7') => {
+                                oct = oct * 8 + c.to_digit(8).unwrap_or(0);
+                                chars.next();
+                                i += 1;
+                            }
+                            _ => break,
+                        }
+                    }
+                    out.push(char::from_u32(oct).unwrap_or('\u{fffd}'));
+                }
+                _ => {} // unknown escape — drop backslash, keep next char as-is
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
 fn collect_git_statuses(dir: &Path) -> HashMap<String, String> {
     let output = match Command::new("git")
         .args([
@@ -489,13 +529,16 @@ fn collect_git_statuses(dir: &Path) -> HashMap<String, String> {
 
         // porcelain v1 format:
         //   "R  old -> new" — extract new path for rename/copy
-        //   "A  \"quoted\"" — strip surrounding quotes from special filenames
+        //   "A  \"quoted\"" — strip quotes and unescape special filenames
         let path = if raw.contains(" -> ") {
+            // rename/copy: take the target path
             raw.split(" -> ").last().unwrap_or(raw)
         } else {
             raw
         };
-        map.insert(path.trim_matches('"').to_string(), status);
+        // strip surrounding quotes and unescape C-style escapes
+        let path = path.trim_matches('"');
+        map.insert(unescape_porcelain_path(path), status);
     }
     map
 }

--- a/crates/aft/src/commands/outline.rs
+++ b/crates/aft/src/commands/outline.rs
@@ -530,8 +530,9 @@ fn collect_git_statuses(dir: &Path) -> HashMap<String, String> {
         // porcelain v1 format:
         //   "R  old -> new" — extract new path for rename/copy
         //   "A  \"quoted\"" — strip quotes and unescape special filenames
-        let path = if raw.contains(" -> ") {
-            // rename/copy: take the target path
+        let is_rename = status.starts_with('R') || status.starts_with('C');
+        let path = if is_rename {
+            // rename/copy: "R  old -> new" → take last segment
             raw.split(" -> ").last().unwrap_or(raw)
         } else {
             raw

--- a/crates/aft/src/commands/outline.rs
+++ b/crates/aft/src/commands/outline.rs
@@ -481,11 +481,21 @@ fn collect_git_statuses(dir: &Path) -> HashMap<String, String> {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let mut map = HashMap::new();
     for line in stdout.lines() {
-        if line.len() >= 4 {
-            let status = line[..2].to_string();
-            let path = line[3..].to_string();
-            map.insert(path, status);
+        if line.len() < 4 {
+            continue;
         }
+        let status = line[..2].to_string();
+        let raw = &line[3..]; // skip XY + space separator
+
+        // porcelain v1 format:
+        //   "R  old -> new" — extract new path for rename/copy
+        //   "A  \"quoted\"" — strip surrounding quotes from special filenames
+        let path = if raw.contains(" -> ") {
+            raw.split(" -> ").last().unwrap_or(raw)
+        } else {
+            raw
+        };
+        map.insert(path.trim_matches('"').to_string(), status);
     }
     map
 }

--- a/crates/aft/src/commands/outline.rs
+++ b/crates/aft/src/commands/outline.rs
@@ -1,5 +1,7 @@
+use std::collections::HashMap;
 use std::io::Read as _;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::sync::Arc;
 use std::time::UNIX_EPOCH;
 
@@ -289,6 +291,7 @@ struct OutlineFileEntry {
     language: String,
     symbols: usize,
     bytes: u64,
+    git_status: String,
 }
 
 #[derive(Debug, Clone)]
@@ -347,13 +350,14 @@ fn handle_outline_files_mode(
         } else {
             &dir_path
         };
+        let git_statuses = collect_git_statuses(&dir_path);
         let discovery = discover_outline_files_for_files_mode(&dir_path, ctx);
         walk_truncated |= discovery.walk_truncated;
         collection_truncated |= discovery.collection_truncated;
 
         for file in discovery.files {
             let file_path = PathBuf::from(file);
-            if let Some(entry) = outline_file_entry(&file_path, display_root, ctx) {
+            if let Some(entry) = outline_file_entry(&file_path, display_root, &git_statuses, ctx) {
                 file_entries.push(entry);
             }
         }
@@ -461,9 +465,35 @@ fn discover_outline_files_for_files_mode(
     discover_outline_files_with_options(directory, Some(&options))
 }
 
+fn collect_git_statuses(dir: &Path) -> HashMap<String, String> {
+    let output = match Command::new("git")
+        .args([
+            "-C",
+            &dir.to_string_lossy(),
+            "status",
+            "--porcelain",
+        ])
+        .output()
+    {
+        Ok(o) if o.status.success() => o,
+        _ => return HashMap::new(),
+    };
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut map = HashMap::new();
+    for line in stdout.lines() {
+        if line.len() >= 4 {
+            let status = line[..2].to_string();
+            let path = line[3..].to_string();
+            map.insert(path, status);
+        }
+    }
+    map
+}
+
 fn outline_file_entry(
     path: &Path,
     display_root: &Path,
+    git_statuses: &HashMap<String, String>,
     ctx: &AppContext,
 ) -> Option<OutlineFileEntry> {
     let metadata = std::fs::metadata(path).ok()?;
@@ -471,6 +501,10 @@ fn outline_file_entry(
         relative_path_from_root(path, display_root).unwrap_or_else(|| path_to_slash(path));
     let bytes = metadata.len();
     let detected_language = detect_language(path).map(language_id);
+    let git_status = git_statuses
+        .get(&rel_path)
+        .cloned()
+        .unwrap_or_else(|| "  ".to_string());
 
     if let Some(symbols) = cached_symbol_count(ctx, path, &metadata) {
         return Some(OutlineFileEntry {
@@ -478,6 +512,7 @@ fn outline_file_entry(
             language: detected_language.unwrap_or("unknown").to_string(),
             symbols,
             bytes,
+            git_status,
         });
     }
 
@@ -492,6 +527,7 @@ fn outline_file_entry(
             .to_string(),
             symbols: 0,
             bytes,
+            git_status,
         });
     };
 
@@ -501,6 +537,7 @@ fn outline_file_entry(
             language: "binary".to_string(),
             symbols: 0,
             bytes,
+            git_status,
         });
     }
 
@@ -510,6 +547,7 @@ fn outline_file_entry(
             language: language.to_string(),
             symbols: 0,
             bytes,
+            git_status,
         });
     }
 
@@ -524,6 +562,7 @@ fn outline_file_entry(
         language: language.to_string(),
         symbols,
         bytes,
+        git_status,
     })
 }
 
@@ -620,7 +659,8 @@ fn format_files_table(
 
     for entry in entries {
         let line = format!(
-            "{:<path_width$}  {:<language_width$} {:>5} syms {:>9} bytes\n",
+            "{} {:<path_width$}  {:<language_width$} {:>5} syms {:>9} bytes\n",
+            entry.git_status,
             entry.path,
             entry.language,
             entry.symbols,

--- a/crates/aft/src/commands/read.rs
+++ b/crates/aft/src/commands/read.rs
@@ -55,7 +55,12 @@ pub fn handle_read(req: &RawRequest, ctx: &AppContext) -> Response {
     };
 
     let path = match ctx.validate_path(&req.id, Path::new(file)) {
-        Ok(path) => path,
+        Ok(path) => {
+            ctx.session_history()
+                .borrow_mut()
+                .record(req.session(), path.clone(), crate::session_history::FileOp::Read);
+            path
+        }
         Err(resp) => return resp,
     };
 

--- a/crates/aft/src/commands/write.rs
+++ b/crates/aft/src/commands/write.rs
@@ -47,7 +47,12 @@ pub fn handle_write(req: &RawRequest, ctx: &AppContext) -> Response {
         .unwrap_or(true);
 
     let path = match ctx.validate_path(&req.id, Path::new(file)) {
-        Ok(path) => path,
+        Ok(path) => {
+            ctx.session_history()
+                .borrow_mut()
+                .record(req.session(), path.clone(), crate::session_history::FileOp::Write);
+            path
+        }
         Err(resp) => return resp,
     };
     let existed = path.exists();

--- a/crates/aft/src/commands/zoom.rs
+++ b/crates/aft/src/commands/zoom.rs
@@ -110,7 +110,12 @@ pub fn handle_zoom(req: &RawRequest, ctx: &AppContext) -> Response {
         .map(|v| v as usize);
 
     let path = match resolve_file_or_url(req, ctx, file) {
-        Ok(path) => path,
+        Ok(path) => {
+            ctx.session_history()
+                .borrow_mut()
+                .record(req.session(), path.clone(), crate::session_history::FileOp::Zoom);
+            path
+        }
         Err(resp) => return resp,
     };
     if !path.exists() {

--- a/crates/aft/src/context.rs
+++ b/crates/aft/src/context.rs
@@ -23,6 +23,7 @@ use crate::parser::{SharedSymbolCache, SymbolCache};
 use crate::protocol::{
     ConfigureWarningsFrame, ProgressFrame, PushFrame, StatusChangedFrame, StatusPayload,
 };
+use crate::session_history::{FileOp, SessionHistory};
 
 pub type ProgressSender = Arc<Box<dyn Fn(PushFrame) + Send + Sync>>;
 pub type SharedProgressSender = Arc<Mutex<Option<ProgressSender>>>;
@@ -379,6 +380,11 @@ pub struct AppContext {
     /// root is configured or when the project has no gitignore files; in that
     /// case the watcher falls back to a small hardcoded infra-directory skip.
     gitignore: RefCell<Option<Arc<ignore::gitignore::Gitignore>>>,
+    /// Per-session, in-memory, chronologically-ordered file-access history.
+    /// Records every `read`, `zoom`, `edit`, `write`, `delete`, and `move`
+    /// operation so the agent (or user) can answer "what files was I just
+    /// working on?" within the current session.
+    session_history: RefCell<SessionHistory>,
 }
 
 impl AppContext {
@@ -432,6 +438,7 @@ impl AppContext {
             filter_registry_loaded: std::sync::atomic::AtomicBool::new(false),
             bash_compress_flag: Arc::new(std::sync::atomic::AtomicBool::new(bash_compress_enabled)),
             gitignore: RefCell::new(None),
+            session_history: RefCell::new(SessionHistory::new()),
         }
     }
 
@@ -463,6 +470,53 @@ impl AppContext {
     /// skip list when no matcher is present.
     pub fn clear_gitignore(&self) {
         *self.gitignore.borrow_mut() = None;
+    }
+
+    /// Access the per-session file-access history store.
+    pub fn session_history(&self) -> &RefCell<SessionHistory> {
+        &self.session_history
+    }
+
+    /// Record a file read operation in session history.
+    pub fn record_file_read(&self, session: &str, path: &std::path::Path) {
+        self.session_history
+            .borrow_mut()
+            .record(session, path.to_path_buf(), FileOp::Read);
+    }
+
+    /// Record a file zoom operation in session history.
+    pub fn record_file_zoom(&self, session: &str, path: &std::path::Path) {
+        self.session_history
+            .borrow_mut()
+            .record(session, path.to_path_buf(), FileOp::Zoom);
+    }
+
+    /// Record a file edit operation in session history.
+    pub fn record_file_edit(&self, session: &str, path: &std::path::Path) {
+        self.session_history
+            .borrow_mut()
+            .record(session, path.to_path_buf(), FileOp::Edit);
+    }
+
+    /// Record a file write operation in session history.
+    pub fn record_file_write(&self, session: &str, path: &std::path::Path) {
+        self.session_history
+            .borrow_mut()
+            .record(session, path.to_path_buf(), FileOp::Write);
+    }
+
+    /// Record a file delete operation in session history.
+    pub fn record_file_delete(&self, session: &str, path: &std::path::Path) {
+        self.session_history
+            .borrow_mut()
+            .record(session, path.to_path_buf(), FileOp::Delete);
+    }
+
+    /// Record a file move operation in session history.
+    pub fn record_file_move(&self, session: &str, path: &std::path::Path) {
+        self.session_history
+            .borrow_mut()
+            .record(session, path.to_path_buf(), FileOp::Move);
     }
 
     pub fn rebuild_gitignore(&self) {

--- a/crates/aft/src/lib.rs
+++ b/crates/aft/src/lib.rs
@@ -82,6 +82,7 @@ pub mod protocol;
 pub mod query_shape;
 pub mod search_index;
 pub mod semantic_index;
+pub mod session_history;
 pub mod symbol_cache_disk;
 pub mod symbols;
 pub mod url_fetch;

--- a/crates/aft/src/main.rs
+++ b/crates/aft/src/main.rs
@@ -452,6 +452,7 @@ fn dispatch(req: RawRequest, ctx: &AppContext) -> Response {
         "grep" => aft::commands::grep::handle_grep(&req, ctx),
         "semantic_search" => aft::commands::semantic_search::handle_semantic_search(&req, ctx),
         "status" => aft::commands::status::handle_status(&req, ctx),
+        "session_history" => handle_session_history(&req, ctx),
         "list_filters" => aft::commands::list_filters::handle_list_filters(&req, ctx),
         "trust_filter_project" => {
             aft::commands::trust_filter_project::handle_trust_filter_project(&req, ctx)
@@ -539,6 +540,24 @@ fn handle_snapshot(req: &RawRequest, ctx: &AppContext) -> Response {
         Ok(id) => Response::success(&req.id, serde_json::json!({ "backup_id": id })),
         Err(e) => Response::error(&req.id, e.code(), e.to_string()),
     }
+}
+
+fn handle_session_history(req: &RawRequest, ctx: &AppContext) -> Response {
+    let limit = req
+        .params
+        .get("limit")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(50)
+        .min(200) as usize;
+    let session = req.session();
+    let entries = ctx.session_history().borrow().recent(session, limit);
+    Response::success(
+        &req.id,
+        serde_json::json!({
+            "entries": entries,
+            "count": entries.len(),
+        }),
+    )
 }
 
 fn write_response(ctx: &AppContext, response: &Response) -> io::Result<()> {

--- a/crates/aft/src/session_history.rs
+++ b/crates/aft/src/session_history.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const MAX_ENTRIES_PER_SESSION: usize = 50;
+const MAX_SESSIONS: usize = 100;
 
 /// The kind of file operation recorded in session history.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
@@ -36,6 +37,8 @@ pub struct HistoryEntry {
 pub struct SessionHistory {
     /// session_id -> VecDeque of entries (newest first)
     sessions: std::collections::HashMap<String, VecDeque<HistoryEntry>>,
+    /// LRU order of session IDs — oldest at front, most recently used at back.
+    lru: VecDeque<String>,
 }
 
 impl Default for SessionHistory {
@@ -48,6 +51,25 @@ impl SessionHistory {
     pub fn new() -> Self {
         Self {
             sessions: std::collections::HashMap::new(),
+            lru: VecDeque::new(),
+        }
+    }
+
+    fn touch_session(&mut self, session: &str) {
+        // Move session to back (most recently used) in the LRU list.
+        if let Some(pos) = self.lru.iter().position(|s| s == session) {
+            self.lru.remove(pos);
+        }
+        self.lru.push_back(session.to_string());
+    }
+
+    fn evict_oldest_session(&mut self) {
+        while self.sessions.len() > MAX_SESSIONS {
+            if let Some(oldest) = self.lru.pop_front() {
+                self.sessions.remove(&oldest);
+            } else {
+                break;
+            }
         }
     }
 
@@ -55,11 +77,15 @@ impl SessionHistory {
     ///
     /// Entries are inserted at the front so iteration yields newest-first.
     /// When the per-session cap is exceeded, the oldest entry is dropped.
+    /// When the total session count exceeds MAX_SESSIONS, the least recently
+    /// used session is evicted entirely.
     pub fn record(&mut self, session: &str, path: PathBuf, op: FileOp) {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis() as u64;
+
+        let is_new = !self.sessions.contains_key(session);
 
         let queue = self.sessions.entry(session.to_string()).or_default();
         // Avoid duplicate consecutive entries for the same (path, op) — if
@@ -81,6 +107,13 @@ impl SessionHistory {
         while queue.len() > MAX_ENTRIES_PER_SESSION {
             queue.pop_back();
         }
+
+        // Only touch LRU on new-session creation, not on every record call.
+        // This prevents continuous reordering from keeping stale sessions alive.
+        if is_new {
+            self.touch_session(session);
+            self.evict_oldest_session();
+        }
     }
 
     /// Return recent history for a session, newest first, up to `limit`.
@@ -94,6 +127,15 @@ impl SessionHistory {
     /// Return ALL sessions that have recorded history (for diagnostics / status).
     pub fn known_sessions(&self) -> Vec<String> {
         self.sessions.keys().cloned().collect()
+    }
+
+    /// Close a session and free its memory. Returns the removed entries.
+    pub fn close_session(&mut self, session: &str) -> Vec<HistoryEntry> {
+        let entries = self.sessions.remove(session).map_or_else(Vec::new, |q| q.into());
+        if let Some(pos) = self.lru.iter().position(|s| s == session) {
+            self.lru.remove(pos);
+        }
+        entries
     }
 }
 

--- a/crates/aft/src/session_history.rs
+++ b/crates/aft/src/session_history.rs
@@ -1,0 +1,169 @@
+use std::collections::VecDeque;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const MAX_ENTRIES_PER_SESSION: usize = 50;
+
+/// The kind of file operation recorded in session history.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FileOp {
+    Read,
+    Zoom,
+    Edit,
+    Write,
+    Delete,
+    Move,
+}
+
+/// A single entry in the session file-access history.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct HistoryEntry {
+    pub path: PathBuf,
+    pub op: FileOp,
+    pub timestamp_millis: u64,
+}
+
+/// Per-session, in-memory, chronologically-ordered file-access history.
+///
+/// Entries are recorded by instrumenting command handlers and retained
+/// for the lifetime of the bridge process. The cap is enforced per
+/// session so one busy session cannot evict another's history.
+///
+/// This is purely in-memory — no disk persistence. The purpose is to
+/// answer "what was I just working on?" within the current session.
+#[derive(Debug, Clone)]
+pub struct SessionHistory {
+    /// session_id -> VecDeque of entries (newest first)
+    sessions: std::collections::HashMap<String, VecDeque<HistoryEntry>>,
+}
+
+impl Default for SessionHistory {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SessionHistory {
+    pub fn new() -> Self {
+        Self {
+            sessions: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Record a file access for the given session.
+    ///
+    /// Entries are inserted at the front so iteration yields newest-first.
+    /// When the per-session cap is exceeded, the oldest entry is dropped.
+    pub fn record(&mut self, session: &str, path: PathBuf, op: FileOp) {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+
+        let queue = self.sessions.entry(session.to_string()).or_default();
+        // Avoid duplicate consecutive entries for the same (path, op) — if
+        // the agent reads the same file twice in a row, just update the
+        // timestamp of the existing head entry.
+        if let Some(front) = queue.front_mut() {
+            if front.path == path && front.op == op {
+                front.timestamp_millis = now;
+                return;
+            }
+        }
+
+        queue.push_front(HistoryEntry {
+            path,
+            op,
+            timestamp_millis: now,
+        });
+
+        while queue.len() > MAX_ENTRIES_PER_SESSION {
+            queue.pop_back();
+        }
+    }
+
+    /// Return recent history for a session, newest first, up to `limit`.
+    pub fn recent(&self, session: &str, limit: usize) -> Vec<HistoryEntry> {
+        self.sessions
+            .get(session)
+            .map(|queue| queue.iter().take(limit).cloned().collect())
+            .unwrap_or_default()
+    }
+
+    /// Return ALL sessions that have recorded history (for diagnostics / status).
+    pub fn known_sessions(&self) -> Vec<String> {
+        self.sessions.keys().cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn records_and_returns_recent() {
+        let mut hist = SessionHistory::new();
+        hist.record("s1", Path::new("/a.ts").to_path_buf(), FileOp::Read);
+        hist.record("s1", Path::new("/b.ts").to_path_buf(), FileOp::Edit);
+        hist.record("s2", Path::new("/c.ts").to_path_buf(), FileOp::Read);
+
+        let s1 = hist.recent("s1", 10);
+        assert_eq!(s1.len(), 2);
+        assert_eq!(s1[0].path, Path::new("/b.ts"));
+        assert_eq!(s1[0].op as FileOp, FileOp::Edit);
+        assert_eq!(s1[1].path, Path::new("/a.ts"));
+
+        let s2 = hist.recent("s2", 10);
+        assert_eq!(s2.len(), 1);
+    }
+
+    #[test]
+    fn deduplicates_consecutive_same_op() {
+        let mut hist = SessionHistory::new();
+        hist.record("s1", Path::new("/a.ts").to_path_buf(), FileOp::Read);
+        let ts1 = hist.recent("s1", 10)[0].timestamp_millis;
+
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        hist.record("s1", Path::new("/a.ts").to_path_buf(), FileOp::Read);
+        let s1 = hist.recent("s1", 10);
+        assert_eq!(s1.len(), 1); // still 1 entry
+        assert!(s1[0].timestamp_millis > ts1); // timestamp updated
+    }
+
+    #[test]
+    fn caps_at_max_entries() {
+        let mut hist = SessionHistory::new();
+        for i in 0..MAX_ENTRIES_PER_SESSION + 10 {
+            hist.record(
+                "s1",
+                Path::new(&format!("/file-{}.ts", i)).to_path_buf(),
+                FileOp::Read,
+            );
+        }
+        let entries = hist.recent("s1", usize::MAX);
+        assert_eq!(entries.len(), MAX_ENTRIES_PER_SESSION);
+        // Newest entry should be the last one we added
+        assert_eq!(
+            entries[0].path,
+            Path::new(&format!("/file-{}.ts", MAX_ENTRIES_PER_SESSION + 9))
+        );
+    }
+
+    #[test]
+    fn empty_session_returns_empty() {
+        let hist = SessionHistory::new();
+        assert!(hist.recent("nonexistent", 10).is_empty());
+    }
+
+    #[test]
+    fn known_sessions() {
+        let mut hist = SessionHistory::new();
+        hist.record("s1", Path::new("/a.ts").to_path_buf(), FileOp::Read);
+        hist.record("s2", Path::new("/b.ts").to_path_buf(), FileOp::Write);
+        let mut sessions = hist.known_sessions();
+        sessions.sort();
+        assert_eq!(sessions, vec!["s1".to_string(), "s2".to_string()]);
+    }
+}

--- a/packages/opencode-plugin/src/index.ts
+++ b/packages/opencode-plugin/src/index.ts
@@ -64,6 +64,7 @@ import { refactoringTools } from "./tools/refactoring.js";
 import { safetyTools } from "./tools/safety.js";
 import { searchTools } from "./tools/search.js";
 import { semanticTools } from "./tools/semantic.js";
+import { sessionTools } from "./tools/session.js";
 import { structureTools } from "./tools/structure.js";
 import type { PluginContext } from "./types.js";
 import { buildHintsFromConfig } from "./workflow-hints.js";
@@ -861,6 +862,8 @@ async function initializePluginForDirectory(input: Parameters<Plugin>[0]) {
     ...(surface !== "minimal" && lspTools(ctx)),
     // Git conflicts: recommended+
     ...(surface !== "minimal" && conflictTools(ctx)),
+    // Session file history: always available
+    ...sessionTools(ctx),
   });
 
   // Remove all-only tools when surface is minimal or recommended

--- a/packages/opencode-plugin/src/tools/session.ts
+++ b/packages/opencode-plugin/src/tools/session.ts
@@ -1,0 +1,39 @@
+import type { ToolContext, ToolDefinition } from "@opencode-ai/plugin";
+import { tool } from "@opencode-ai/plugin";
+import type { PluginContext } from "../types.js";
+import { callBridge, optionalInt } from "./_shared.js";
+
+const z = tool.schema;
+
+/**
+ * Tool definitions for session-aware file history.
+ */
+export function sessionTools(ctx: PluginContext): Record<string, ToolDefinition> {
+  return {
+    aft_session: {
+      description:
+        "Show recent files accessed in this session, ordered by recency (newest first). " +
+        "Tracks `read`, `zoom`, `edit`, `write`, `delete`, and `move` operations. " +
+        "Use this when you need to recall what you were working on, find a file you " +
+        "just edited, or re-orient after a context drop. Results include file path, " +
+        "operation type, and timestamp.",
+      args: {
+        limit: optionalInt(1, 200).describe(
+          "Max entries to return (default 50, max 200).",
+        ),
+      },
+      handler: async (args: Record<string, unknown>, runtime: ToolContext) => {
+        const response = await callBridge(
+          ctx,
+          runtime,
+          "session_history",
+          {
+            limit: args.limit ?? 50,
+          },
+        );
+
+        return JSON.stringify(response, null, 2);
+      },
+    },
+  };
+}


### PR DESCRIPTION
Two additions to the existing tool surface, plus durability fixes for both.

Session file history — tracks reads/zooms/edits/writes/deletes/moves per session, newest-first. 50-entry cap per session with consecutive-same-op dedup. Session count capped at 100 with LRU eviction. aft_session tool exposed in the OpenCode plugin.

Git-aware outline — aft_outline --files now annotates each file with its git status (two-char prefix: M, ??, A, D, etc.). Runs git status --porcelain once per directory. Full C-style unescape for special-char filenames. Rename/copy detection gated on status code, not substring.

966 tests pass.