### PR TITLE
fix(configure): unify configure-time tool detection with shared format resolver

### DIFF
--- a/crates/aft/src/commands/configure.rs
+++ b/crates/aft/src/commands/configure.rs
@@ -857,49 +857,13 @@ fn resolve_tool_uncached(tool: &str, project_root: Option<&Path>) -> bool {
         return ruff_format_available(project_root);
     }
 
-    if let Some(root) = project_root {
-        if root.join("node_modules").join(".bin").join(tool).exists() {
-            return true;
-        }
-    }
-
-    let mut child = match std::process::Command::new(tool)
-        .arg("--version")
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-    {
-        Ok(child) => child,
-        Err(_) => return false,
-    };
-
-    let start = std::time::Instant::now();
-    let timeout = std::time::Duration::from_secs(2);
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) => return status.success(),
-            Ok(None) if start.elapsed() > timeout => {
-                let _ = child.kill();
-                let _ = child.wait();
-                return false;
-            }
-            Ok(None) => std::thread::sleep(std::time::Duration::from_millis(50)),
-            Err(_) => return false,
-        }
-    }
+    crate::format::resolve_tool_uncached(tool, project_root).is_some()
 }
 
 fn ruff_format_available(project_root: Option<&Path>) -> bool {
-    let command = if let Some(root) = project_root {
-        let local = root.join("node_modules").join(".bin").join("ruff");
-        if local.exists() {
-            local
-        } else {
-            PathBuf::from("ruff")
-        }
-    } else {
-        PathBuf::from("ruff")
+    let command = match crate::format::resolve_tool_uncached("ruff", project_root) {
+        Some(command) => command,
+        None => return false,
     };
 
     let output = match std::process::Command::new(command)
@@ -2362,6 +2326,45 @@ mod tests {
         assert_eq!(warning.kind, "formatter_not_installed");
         assert_eq!(warning.language, "typescript");
         assert_eq!(warning.tool, "oxfmt");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn configure_missing_tools_uses_shared_go_tool_resolution() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(temp.path().join("go.mod"), "module example.test\ngo 1.21\n").unwrap();
+        let bin_dir = temp.path().join("node_modules/.bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        use std::os::unix::fs::PermissionsExt;
+
+        let go = bin_dir.join("go");
+        std::fs::write(
+            &go,
+            "#!/bin/sh\nif [ \"$1\" = \"version\" ]; then exit 0; fi\nif [ \"$1\" = \"--version\" ]; then exit 2; fi\nexit 1\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&go, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let gofmt = bin_dir.join("gofmt");
+        std::fs::write(
+            &gofmt,
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then exit 2; fi\ncat >/dev/null\nexit 0\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&gofmt, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let mut languages = std::collections::HashSet::new();
+        languages.insert(crate::parser::LangId::Go);
+        let config = Config {
+            project_root: Some(temp.path().to_path_buf()),
+            ..Config::default()
+        };
+        let warnings = super::detect_missing_tools_for_languages(&languages, &config);
+
+        assert!(
+            warnings.is_empty(),
+            "expected shared Go resolver to avoid false missing-tool warnings, got {warnings:?}"
+        );
     }
 
     /// Shared mutex serializing the home-root tests below. Both tests

--- a/crates/aft/src/format.rs
+++ b/crates/aft/src/format.rs
@@ -348,9 +348,10 @@ pub(crate) fn resolve_tool_uncached(command: &str, project_root: Option<&Path>) 
     }
 
     // 2. Try PATH lookup first. This is the fast common path: spawning the
-    // tool with `--version` and waiting briefly for it to exit. When the
-    // editor (OpenCode, Pi, etc.) is launched from a login shell the PATH
-    // is usually complete, so this finds Homebrew/cargo/etc. binaries.
+    // tool with command-specific availability arguments and waiting briefly
+    // for it to exit. When the editor (OpenCode, Pi, etc.) is launched from a
+    // login shell the PATH is usually complete, so this finds Homebrew/cargo/etc.
+    // binaries.
     if let Some(path) = try_path_lookup(command) {
         return Some(path);
     }
@@ -415,8 +416,9 @@ fn windows_local_node_bin_extensions(pathext: Option<&std::ffi::OsStr>) -> Vec<S
 /// name on success (downstream `Command::new` re-resolves through PATH),
 /// or None if the spawn fails or the tool exits with non-zero status.
 fn try_path_lookup(command: &str) -> Option<PathBuf> {
+    let probe_args = path_lookup_probe_args(command);
     let mut child = Command::new(command)
-        .arg("--version")
+        .args(probe_args)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -441,6 +443,17 @@ fn try_path_lookup(command: &str) -> Option<PathBuf> {
             Ok(None) => thread::sleep(Duration::from_millis(50)),
             Err(_) => return None,
         }
+    }
+}
+
+fn path_lookup_probe_args(command: &str) -> &'static [&'static str] {
+    match command {
+        // Go uses `go version` rather than a POSIX-style `--version` flag.
+        "go" => &["version"],
+        // `gofmt` has no version flag. It exits successfully with empty stdin,
+        // which is sufficient for PATH availability probing.
+        "gofmt" => &[],
+        _ => &["--version"],
     }
 }
 
@@ -2354,6 +2367,13 @@ mod tests {
     }
 
     #[test]
+    fn path_lookup_probe_args_match_go_tool_conventions() {
+        assert_eq!(path_lookup_probe_args("go"), &["version"]);
+        assert!(path_lookup_probe_args("gofmt").is_empty());
+        assert_eq!(path_lookup_probe_args("rustfmt"), &["--version"]);
+    }
+
+    #[test]
     fn auto_format_unsupported_language() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("file.txt");
@@ -3247,10 +3267,11 @@ C:\repo\other.go:1:1: other file
 
         fs::remove_file(dir.path().join("Cargo.toml")).unwrap();
         fs::write(dir.path().join("go.mod"), "module test\ngo 1.21\n").unwrap();
-        let go_config = Config {
+        let mut go_config = Config {
             project_root: Some(dir.path().to_path_buf()),
             ..Config::default()
         };
+        go_config.checker.insert("go".to_string(), "go".to_string());
         let (go_cmd, _) =
             detect_type_checker(&dir.path().join("main.go"), LangId::Go, &go_config).unwrap();
         assert_eq!(go_cmd, bin_dir.join("go").to_string_lossy());

--- a/crates/aft/tests/integration/configure_test.rs
+++ b/crates/aft/tests/integration/configure_test.rs
@@ -88,7 +88,10 @@ fn configure_warns_for_missing_formatter_and_checker_tools() {
     std::fs::write(dir.path().join("biome.json"), "{}\n").unwrap();
 
     let path = empty_path();
-    let mut aft = AftProcess::spawn_with_env(&[("PATH", path.as_os_str())]);
+    let mut aft = AftProcess::spawn_with_env(&[
+        ("PATH", path.as_os_str()),
+        ("AFT_DISABLE_WELL_KNOWN_LOOKUP", std::ffi::OsStr::new("1")),
+    ]);
 
     let configure = aft.send(
         &json!({


### PR DESCRIPTION
## Summary

Fixes persistent false `go`/`gofmt` "not installed" startup warnings on machines where Go is installed and on PATH. This finishes the configure-time half of the unification goal described in #57, which PR #59 only delivered for the format-time path.

Closes #74

## Root cause

`crates/aft/src/commands/configure.rs::resolve_tool_uncached` kept its own tool probe that runs `<tool> --version` and treats a non-zero exit code as "not installed":

```rust
Ok(Some(status)) => return status.success(),
```

Go's toolchain breaks that assumption:

- `go` uses `go version`, not `--version` → `go --version` exits non-zero
- `gofmt` has no version flag → `gofmt --version` exits non-zero

So both are reported "not installed" even when present and on PATH. The warning text ("not found on PATH or in common install locations") is misleading — it is an exit-code false negative, not a PATH problem.

PR #59 fixed the format-time path (`format.rs`) with a shared resolver + well-known install-location fallback, but `configure.rs` (the path that emits the startup warning) was never migrated and kept its divergent `--version` probe.

## Changes

- **`format.rs::try_path_lookup`** now selects command-specific probe args via a new `path_lookup_probe_args`: `go version` for `go`, an empty/stdin probe for `gofmt`, `--version` otherwise. This removes the false negative at the source.
- **`configure.rs::resolve_tool_uncached`** delegates to `format::resolve_tool_uncached` instead of re-implementing detection, so configure-time and format-time detection share one code path (`node_modules/.bin` + PATH probe + well-known locations). The `ruff` formatter version gate now also resolves through the shared resolver.

## Tests

- `format.rs`: `path_lookup_probe_args_match_go_tool_conventions` asserts the Go/gofmt/rustfmt probe-arg contract.
- `configure.rs`: `configure_missing_tools_uses_shared_go_tool_resolution` reproduces the false warning via fake `go`/`gofmt` (`go version` ok / `go --version` fails; `gofmt` stdin ok / `gofmt --version` fails) resolved through `node_modules/.bin`, with no process-env mutation.
- Integration: `configure_warns_for_missing_formatter_and_checker_tools` now isolates the missing-tool scenario with `AFT_DISABLE_WELL_KNOWN_LOOKUP=1` so it no longer depends on host PATH.

## Verification

All run locally on macOS arm64 (Rust 1.95.0):

- `cargo fmt --check` — clean
- `cargo test -p agent-file-tools` — 978 unit + 1078 integration + extras pass (1 pre-existing ignored: `semantic_index_persists...`, needs model download)
- `cargo build -p agent-file-tools` — exit 0

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782719284&installation_id=135454708&pr_number=75&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F75&signature=86dcd62a515b234b4fb8d0cd00b67a1409f5d82a4bb00292a211dea21e770019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false "go/gofmt not installed" startup warnings by unifying configure-time tool detection with the shared format resolver. Uses command-specific probes and the same PATH/`node_modules/.bin`/well-known lookup for consistent results. Closes #74.

- **Bug Fixes**
  - `configure.rs::resolve_tool_uncached` now delegates to `format::resolve_tool_uncached`.
  - PATH probing uses command-specific args: `go version` for `go`, empty-stdin probe for `gofmt`, `--version` otherwise.
  - `ruff` formatter version check now resolves via the shared resolver.

<sup>Written for commit 764eb789adc9e174890bdcfd44dd4e27abe5db8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/75?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

