### PR TITLE
fix(semantic): clamp embed_text to prevent oversized YAML chunks aborting index build

### DIFF
--- a/crates/aft/src/fs_lock.rs
+++ b/crates/aft/src/fs_lock.rs
@@ -537,12 +537,21 @@ fn rename_over(from: &Path, to: &Path) -> io::Result<()> {
     match fs::rename(from, to) {
         Ok(()) => Ok(()),
         // Fall back to remove-then-rename only when the atomic replace is
-        // refused (e.g. the destination is briefly open by another handle).
-        // This preserves forward progress without the no-file window on the
-        // common path.
-        Err(_) => {
-            let _ = fs::remove_file(to);
-            fs::rename(from, to)
+        // refused AND the source temp file still exists. The destructive
+        // `remove_file(to)` must never run for a source-side failure (e.g.
+        // `from` was already consumed/lost, or an unrelated error): deleting
+        // the live destination there would leave the lock missing and trigger
+        // a terminal LockGone cascade in concurrent heartbeat readers — the
+        // exact race this function exists to avoid. When `from` is gone we
+        // cannot retry the rename anyway, so surface the original error and
+        // leave `to` intact.
+        Err(original) => {
+            if from.exists() {
+                let _ = fs::remove_file(to);
+                fs::rename(from, to)
+            } else {
+                Err(original)
+            }
         }
     }
 }

--- a/crates/aft/src/fs_lock.rs
+++ b/crates/aft/src/fs_lock.rs
@@ -536,23 +536,27 @@ fn rename_over(from: &Path, to: &Path) -> io::Result<()> {
     // heartbeat_survives_transient_malformed_and_recovers flaky on Windows CI.
     match fs::rename(from, to) {
         Ok(()) => Ok(()),
-        // Fall back to remove-then-rename only when the atomic replace is
-        // refused AND the source temp file still exists. The destructive
-        // `remove_file(to)` must never run for a source-side failure (e.g.
-        // `from` was already consumed/lost, or an unrelated error): deleting
-        // the live destination there would leave the lock missing and trigger
-        // a terminal LockGone cascade in concurrent heartbeat readers — the
-        // exact race this function exists to avoid. When `from` is gone we
-        // cannot retry the rename anyway, so surface the original error and
-        // leave `to` intact.
-        Err(original) => {
-            if from.exists() {
-                let _ = fs::remove_file(to);
-                fs::rename(from, to)
-            } else {
-                Err(original)
+        // Fall back to a copy-over (NOT remove-then-rename) when the atomic
+        // replace is refused (e.g. the destination is briefly open by another
+        // handle, or AV/indexer holds the temp source). `fs::copy` opens `to`
+        // with create+truncate and overwrites its bytes in place — the
+        // destination path never stops existing, so a concurrent heartbeat
+        // poll can never read NotFound -> LockGone (terminal). The earlier
+        // remove-then-rename fallback left a window where, if the second
+        // rename also failed, `to` was permanently deleted; copy-over closes
+        // that race class entirely. Worst case a reader observes a partially
+        // written file and gets Malformed, which is transient and retried —
+        // never fatal. Best-effort cleanup of the temp source afterward.
+        Err(original) => match fs::copy(from, to) {
+            Ok(_) => {
+                let _ = fs::remove_file(from);
+                Ok(())
             }
-        }
+            // Both the atomic replace and the copy-over failed. Leave `to`
+            // untouched (copy create+truncate only proceeds once it can open
+            // the destination) and surface the original rename error.
+            Err(_) => Err(original),
+        },
     }
 }
 

--- a/crates/aft/src/fs_lock.rs
+++ b/crates/aft/src/fs_lock.rs
@@ -527,8 +527,24 @@ fn atomic_write_lock_metadata(path: &Path, metadata: &LockMetadata) -> io::Resul
 
 #[cfg(windows)]
 fn rename_over(from: &Path, to: &Path) -> io::Result<()> {
-    let _ = fs::remove_file(to);
-    fs::rename(from, to)
+    // std::fs::rename on Windows maps to MoveFileExW with
+    // MOVEFILE_REPLACE_EXISTING, which atomically replaces an existing
+    // destination. Try that FIRST: an unconditional `remove_file(to)` before
+    // the rename opens a window where `to` does not exist, and a concurrent
+    // reader (e.g. the heartbeat poll) landing in that gap reads NotFound ->
+    // LockGone (terminal) and kills the heartbeat thread. That race made
+    // heartbeat_survives_transient_malformed_and_recovers flaky on Windows CI.
+    match fs::rename(from, to) {
+        Ok(()) => Ok(()),
+        // Fall back to remove-then-rename only when the atomic replace is
+        // refused (e.g. the destination is briefly open by another handle).
+        // This preserves forward progress without the no-file window on the
+        // common path.
+        Err(_) => {
+            let _ = fs::remove_file(to);
+            fs::rename(from, to)
+        }
+    }
 }
 
 #[cfg(not(windows))]

--- a/crates/aft/src/semantic_index.rs
+++ b/crates/aft/src/semantic_index.rs
@@ -2517,7 +2517,14 @@ fn build_embed_text(symbol: &Symbol, source: &str, file: &Path, project_root: &P
     );
 
     if let Some(sig) = &symbol.signature {
-        text.push_str(&format!(" signature:{}", sig));
+        // Cap the signature: structured parsers (e.g. YAML/Kubernetes) pack
+        // entire inline scripts (CronJob/Job `command:` bodies, multi-KB) into
+        // the signature. Appending it unbounded produces a single embed_text
+        // that overflows the embedding backend's physical batch (e.g. a
+        // llama.cpp server's 512-token cap), aborting the whole index build
+        // and silently degrading every search to lexical. 400 chars keeps the
+        // identifying head of the signature without blowing the budget.
+        text.push_str(&format!(" signature:{}", truncate_chars(sig, 400)));
     }
 
     // Add body snippet (first ~300 chars of symbol body)
@@ -2540,8 +2547,17 @@ fn build_embed_text(symbol: &Symbol, source: &str, file: &Path, project_root: &P
         text.push_str(&format!(" body:{}", snippet));
     }
 
-    text
+    // Final defense-in-depth clamp: no single embed_text may exceed the
+    // backend's per-input budget regardless of which field grew. Most
+    // backends cap a physical batch around 512 tokens; ~1600 chars stays
+    // comfortably under that for typical English/code (≈4 chars/token).
+    truncate_chars(&text, MAX_EMBED_TEXT_CHARS)
 }
+
+/// Upper bound on characters in a single chunk's `embed_text`. Keeps any one
+/// input below typical embedding-backend physical batch limits (~512 tokens)
+/// so an oversized symbol cannot abort the whole index build.
+const MAX_EMBED_TEXT_CHARS: usize = 1600;
 
 fn truncate_chars(value: &str, max_chars: usize) -> String {
     value.chars().take(max_chars).collect()
@@ -2627,11 +2643,14 @@ pub fn build_file_summary_chunk(
         start_line: 0,
         end_line: 0,
         exported: false,
-        embed_text: format!(
-            "file:{rel_path} kind:file-summary name:{} parent:{parent_dir} doc:{doc} exports:{exports}",
-            file.file_stem()
-                .map(|stem| stem.to_string_lossy().to_string())
-                .unwrap_or_default()
+        embed_text: truncate_chars(
+            &format!(
+                "file:{rel_path} kind:file-summary name:{} parent:{parent_dir} doc:{doc} exports:{exports}",
+                file.file_stem()
+                    .map(|stem| stem.to_string_lossy().to_string())
+                    .unwrap_or_default()
+            ),
+            MAX_EMBED_TEXT_CHARS,
         ),
         snippet,
     }
@@ -3832,6 +3851,31 @@ mod tests {
             chunks.is_empty(),
             "Heading symbols must be filtered out before embedding; got {} chunk(s)",
             chunks.len()
+        );
+    }
+
+    /// A symbol with an enormous signature (e.g. a YAML/Kubernetes CronJob
+    /// whose inline `command:` script is parsed into the signature) must not
+    /// produce an embed_text that overflows the embedding backend's physical
+    /// batch. Before the clamp, the unbounded `signature:` append created a
+    /// multi-KB input that aborted the whole index build and degraded every
+    /// search to lexical-only.
+    #[test]
+    fn build_embed_text_clamps_oversized_signature() {
+        let project_root = PathBuf::from("/proj");
+        let file = project_root.join("cronjob.yaml");
+        let huge_sig = "kubectl ".repeat(2000); // ~16 KB
+        let source = "apiVersion: batch/v1\nkind: CronJob\n";
+
+        let mut symbol = make_symbol(SymbolKind::Class, "cluster-janitor", 0, 1);
+        symbol.signature = Some(huge_sig);
+
+        let text = build_embed_text(&symbol, source, &file, &project_root);
+        assert!(
+            text.chars().count() <= MAX_EMBED_TEXT_CHARS,
+            "embed_text must be clamped to {} chars, got {}",
+            MAX_EMBED_TEXT_CHARS,
+            text.chars().count()
         );
     }
 

--- a/packages/aft-cli/src/commands/doctor.ts
+++ b/packages/aft-cli/src/commands/doctor.ts
@@ -26,7 +26,6 @@ import {
 import { dirSize, formatBytes } from "../lib/fs-util.js";
 import { createGitHubIssue, isGhInstalled, openBrowser } from "../lib/github.js";
 import { resolveAdaptersForCommand } from "../lib/harness-select.js";
-import { capBodyToGithubLimit, extractRecentErrors } from "../lib/issue-body.js";
 import {
   capBodyToGithubLimit,
   extractRecentErrors,

--- a/packages/aft-cli/src/commands/doctor.ts
+++ b/packages/aft-cli/src/commands/doctor.ts
@@ -26,6 +26,7 @@ import {
 import { dirSize, formatBytes } from "../lib/fs-util.js";
 import { createGitHubIssue, isGhInstalled, openBrowser } from "../lib/github.js";
 import { resolveAdaptersForCommand } from "../lib/harness-select.js";
+import { capBodyToGithubLimit, extractRecentErrors } from "../lib/issue-body.js";
 import {
   capBodyToGithubLimit,
   extractRecentErrors,


### PR DESCRIPTION
## Problem

The new YAML/Kubernetes semantic support packs entire inline `command:` scripts (CronJob/Job bodies, often multi-KB) into `symbol.signature`. `build_embed_text` capped the **body** at 300 chars but appended `signature` **unbounded** (`semantic_index.rs:2520`).

One oversized chunk exceeds the embedding backend's physical batch (e.g. a llama.cpp server's 512-token cap), which returns:

```
HTTP 500: input (550 tokens) is too large to process (current batch size: 512)
```

This **aborts the entire index build** on that single chunk, so every `aft_search` silently degrades to lexical-only fallback. The constant '550 tokens' regardless of query was the same poisoned chunk failing — not the query.

Reproduced on a real GitOps/ArgoCD repo where CronJob/Job manifests carry large inline shell scripts.

## Fix

- Cap `signature:` at 400 chars in `build_embed_text`
- Add `MAX_EMBED_TEXT_CHARS = 1600` final hard clamp on every `embed_text` (defense-in-depth for any field that grows)
- Clamp `build_file_summary_chunk` `embed_text` too (unbounded `doc:` interpolation)
- Regression test `build_embed_text_clamps_oversized_signature`

## Verification

- `cargo build` clean
- `cargo test -p agent-file-tools --lib semantic_index` → 39 passed
- Rebuilt binary live: semantic index rebuilds without the 500, search returns ranked results

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782905183&installation_id=135454708&pr_number=79&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F79&signature=f42833b9c96d93dbbccefa1352418d0bc85ae353ad4d2b0a370cd319d2492c22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamp `signature` and overall `embed_text` so oversized YAML/Kubernetes chunks no longer break semantic indexing. Also make Windows lockfile renames atomic with a safe copy-over fallback to stop heartbeat flakes.

- **Bug Fixes**
  - Clamp `signature` to 400 chars and cap all chunk `embed_text` with `MAX_EMBED_TEXT_CHARS = 1600` (incl. file-summary `doc:`); add regression test.
  - Windows: try `fs::rename` (atomic); on failure, `fs::copy(from, to)` overwrites in place so the lockfile path never disappears, preventing NotFound -> LockGone heartbeat crashes.
  - `doctor`: merge duplicate `issue-body` import and sort imports to satisfy `biome`; fixes TS2300 duplicate identifier.

<sup>Written for commit dcd520ba9f83d7f59cd8f7cb48c4682b38ef6c50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/79?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



