### PR TITLE
fix(bridge): make bridge timeout and hang threshold configurable

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -139,6 +139,19 @@ The schema is identical across harnesses. Only file location differs.
   // call-graph navigation on bigger projects.
   "max_callgraph_files": 5000,
 
+  // Request timeout in milliseconds passed to each bridge. The `aft` binary
+  // can take 60-120s to start on slow filesystems (WSL2 / DrvFs / network
+  // mounts); the previous 30000 default caused immediate configure timeouts
+  // followed by repeated bridge respawns ("works, drops, comes back" pattern).
+  // Default: 120000. USER-only. Must be a positive integer.
+  "configure_timeout_ms": 120000,
+
+  // Number of consecutive silent request timeouts tolerated before tearing
+  // down and respawning the bridge. Higher values are safer on slow
+  // filesystems; lower values recycle stale bridges faster. Default: 10.
+  // USER-only. Must be a positive integer.
+  "hang_timeout_threshold": 10,
+
   // Language servers used for post-edit diagnostics.
   //
   // Built-in servers (auto-registered when their binary is on PATH):

--- a/packages/aft-bridge/src/bridge.ts
+++ b/packages/aft-bridge/src/bridge.ts
@@ -7,8 +7,8 @@ import { error, getActiveLogger, getLogFilePath, log, warn } from "./active-logg
 import type { Logger, LogMeta } from "./logger.js";
 import type { BgCompletion, StatusCompression } from "./protocol.js";
 
-const DEFAULT_BRIDGE_TIMEOUT_MS = 30_000;
-const BRIDGE_HANG_TIMEOUT_THRESHOLD = 2;
+const DEFAULT_BRIDGE_TIMEOUT_MS = 120_000;
+const BRIDGE_HANG_TIMEOUT_THRESHOLD = 10;
 const SEMANTIC_TIMEOUT_SAFETY_MARGIN_MS = 5_000;
 const MAX_STDOUT_BUFFER = 64 * 1024 * 1024; // 64MB
 
@@ -155,8 +155,16 @@ class BridgeReplacedDuringVersionCheck extends Error {
 }
 
 export interface BridgeOptions {
-  /** Request timeout in milliseconds. Default: 30000 */
+  /** Request timeout in milliseconds. Default: 120000 */
   timeoutMs?: number;
+  /**
+   * Number of consecutive silent timeouts tolerated before tearing down the
+   * bridge. Default: 10. Higher values are safer on slow filesystems (WSL2 /
+   * DrvFs) where the `aft` binary may take 60-120s to start; lower values
+   * recycle stale bridges faster on fast filesystems. See
+   * `BRIDGE_HANG_TIMEOUT_THRESHOLD` and `handleTimeout`.
+   */
+  hangTimeoutThreshold?: number;
   /**
    * Extra environment variables to set on the spawned `aft` child process,
    * applied on top of the inherited `process.env` at spawn time. Use this to
@@ -298,6 +306,7 @@ export class BinaryBridge {
   private _restartCount = 0;
   private _shuttingDown = false;
   private timeoutMs: number;
+  private hangTimeoutThreshold: number;
   private maxRestarts: number;
   private configured = false;
   private _configurePromise: Promise<void> | null = null;
@@ -338,6 +347,7 @@ export class BinaryBridge {
     this.binaryPath = binaryPath;
     this.cwd = cwd;
     this.timeoutMs = options?.timeoutMs ?? DEFAULT_BRIDGE_TIMEOUT_MS;
+    this.hangTimeoutThreshold = options?.hangTimeoutThreshold ?? BRIDGE_HANG_TIMEOUT_THRESHOLD;
     this.maxRestarts = options?.maxRestarts ?? 3;
     this.configOverrides = clampSemanticTimeout(configOverrides ?? {}, this.timeoutMs);
     this.minVersion = options?.minVersion;
@@ -633,7 +643,7 @@ export class BinaryBridge {
           const consecutiveTimeouts = this.consecutiveRequestTimeouts + 1;
           this.consecutiveRequestTimeouts = consecutiveTimeouts;
           const keepWarm =
-            childActiveSinceRequest || consecutiveTimeouts < BRIDGE_HANG_TIMEOUT_THRESHOLD;
+            childActiveSinceRequest || consecutiveTimeouts < this.hangTimeoutThreshold;
           const restartSuffix = keepWarm ? " — bridge kept warm" : " — restarting bridge";
           const timeoutMsg = `Request "${command}" (id=${id}) timed out after ${effectiveTimeoutMs}ms${restartSuffix}`;
           if (requestSessionId) {

--- a/packages/aft-bridge/src/pool.ts
+++ b/packages/aft-bridge/src/pool.ts
@@ -142,6 +142,7 @@ export class BridgePool {
     this.projectConfigLoader = options.projectConfigLoader;
     this.bridgeOptions = {
       timeoutMs: options.timeoutMs,
+      hangTimeoutThreshold: options.hangTimeoutThreshold,
       maxRestarts: options.maxRestarts,
       minVersion: options.minVersion,
       onVersionMismatch: options.onVersionMismatch,

--- a/packages/opencode-plugin/src/__tests__/config.test.ts
+++ b/packages/opencode-plugin/src/__tests__/config.test.ts
@@ -242,6 +242,75 @@ describe("loadAftConfig", () => {
     expect(result.stderr).toContain("Ignoring auto_update from project config");
   });
 
+  // WSL2 / DrvFs fix: slow `aft` binary startup (~95-104s) exceeded the
+  // 30s default bridge timeout, causing repeated bridge respawns. The new
+  // `configure_timeout_ms` and `hang_timeout_threshold` fields are user-only
+  // (they govern bridge lifecycle, not project behavior) and must follow
+  // the same strict allowlist as `auto_update` / `max_callgraph_files`.
+  test("user config can set configure_timeout_ms and hang_timeout_threshold", () => {
+    const fixture = createConfigFixture();
+    writeFileSync(
+      fixture.userConfigPath,
+      JSON.stringify({ configure_timeout_ms: 120000, hang_timeout_threshold: 10 }),
+    );
+    writeFileSync(fixture.projectConfigPath, JSON.stringify({}));
+
+    const result = runConfigLoader(fixture.projectDirectory, {
+      HOME: join(fixture.root, "home"),
+      XDG_CONFIG_HOME: fixture.xdgConfigHome,
+    });
+
+    const config = JSON.parse(result.stdout) as Record<string, unknown>;
+    expect(config.configure_timeout_ms).toBe(120000);
+    expect(config.hang_timeout_threshold).toBe(10);
+    expect(result.stderr).not.toContain("configure_timeout_ms from project config");
+    expect(result.stderr).not.toContain("hang_timeout_threshold from project config");
+  });
+
+  test("project config cannot set configure_timeout_ms (strict allowlist)", () => {
+    const fixture = createConfigFixture();
+    writeFileSync(fixture.userConfigPath, JSON.stringify({}));
+    writeFileSync(fixture.projectConfigPath, JSON.stringify({ configure_timeout_ms: 60000 }));
+
+    const result = runConfigLoader(fixture.projectDirectory, {
+      HOME: join(fixture.root, "home"),
+      XDG_CONFIG_HOME: fixture.xdgConfigHome,
+    });
+
+    const config = JSON.parse(result.stdout) as Record<string, unknown>;
+    expect(config.configure_timeout_ms).toBeUndefined();
+    expect(result.stderr).toContain("Ignoring configure_timeout_ms from project config");
+  });
+
+  test("project config cannot set hang_timeout_threshold (strict allowlist)", () => {
+    const fixture = createConfigFixture();
+    writeFileSync(fixture.userConfigPath, JSON.stringify({}));
+    writeFileSync(fixture.projectConfigPath, JSON.stringify({ hang_timeout_threshold: 5 }));
+
+    const result = runConfigLoader(fixture.projectDirectory, {
+      HOME: join(fixture.root, "home"),
+      XDG_CONFIG_HOME: fixture.xdgConfigHome,
+    });
+
+    const config = JSON.parse(result.stdout) as Record<string, unknown>;
+    expect(config.hang_timeout_threshold).toBeUndefined();
+    expect(result.stderr).toContain("Ignoring hang_timeout_threshold from project config");
+  });
+
+  test("AftConfigSchema rejects non-positive configure_timeout_ms", () => {
+    expect(() => AftConfigSchema.parse({ configure_timeout_ms: 0 })).toThrow();
+    expect(() => AftConfigSchema.parse({ configure_timeout_ms: -1 })).toThrow();
+    expect(() => AftConfigSchema.parse({ configure_timeout_ms: 1.5 })).toThrow();
+    expect(AftConfigSchema.parse({ configure_timeout_ms: 120000 })).toBeDefined();
+  });
+
+  test("AftConfigSchema rejects non-positive hang_timeout_threshold", () => {
+    expect(() => AftConfigSchema.parse({ hang_timeout_threshold: 0 })).toThrow();
+    expect(() => AftConfigSchema.parse({ hang_timeout_threshold: -1 })).toThrow();
+    expect(() => AftConfigSchema.parse({ hang_timeout_threshold: 2.5 })).toThrow();
+    expect(AftConfigSchema.parse({ hang_timeout_threshold: 10 })).toBeDefined();
+  });
+
   // v0.27.2 bash graduation: nested `experimental.bash.*` legacy values are
   // migrated to the top-level `bash` block during load, and the resulting
   // in-memory config exposes them under `bash.*`. The user's on-disk file

--- a/packages/opencode-plugin/src/config.ts
+++ b/packages/opencode-plugin/src/config.ts
@@ -293,6 +293,20 @@ export const AftConfigSchema = z
     max_callgraph_files: z.number().int().positive().optional(),
     /** Auto-refresh OpenCode's cached @cortexkit/aft-opencode package when a newer channel version exists. */
     auto_update: z.boolean().optional(),
+    /**
+     * Request timeout in milliseconds passed to each bridge. Default: 120000.
+     * Set higher on slow filesystems (WSL2 / DrvFs / network mounts) where the
+     * `aft` binary may take 60-120s to start and the 30s default causes the
+     * bridge to time out and recycle repeatedly. Must be a positive integer.
+     */
+    configure_timeout_ms: z.number().int().positive().optional(),
+    /**
+     * Number of consecutive silent request timeouts tolerated before tearing
+     * down and respawning the bridge. Default: 10. Higher values are safer on
+     * slow filesystems; lower values recycle stale bridges faster. Must be a
+     * positive integer.
+     */
+    hang_timeout_threshold: z.number().int().positive().optional(),
   })
   .strict();
 
@@ -1201,6 +1215,8 @@ function getStrippedTopLevelKeys(override: AftConfig): string[] {
   if (override.url_fetch_allow_private !== undefined) stripped.push("url_fetch_allow_private");
   if (override.max_callgraph_files !== undefined) stripped.push("max_callgraph_files");
   if (override.auto_update !== undefined) stripped.push("auto_update");
+  if (override.configure_timeout_ms !== undefined) stripped.push("configure_timeout_ms");
+  if (override.hang_timeout_threshold !== undefined) stripped.push("hang_timeout_threshold");
   return stripped;
 }
 

--- a/packages/opencode-plugin/src/index.ts
+++ b/packages/opencode-plugin/src/index.ts
@@ -439,6 +439,18 @@ async function initializePluginForDirectory(input: Parameters<Plugin>[0]) {
   } = {
     errorPrefix: "[aft-plugin]",
     minVersion: PLUGIN_VERSION,
+    // Per-bridge timeouts. `aft` binary startup is slow on WSL2 / DrvFs
+    // (~95-104s) and the bridge default of 30s causes an immediate
+    // configure timeout, followed by a second timeout, and then the
+    // bridge is torn down and respawned — producing the "AFT works,
+    // then drops, then comes back" cycle. Threading these from
+    // `aftConfig` lets users tune the bridge without rebuilding.
+    ...(aftConfig.configure_timeout_ms !== undefined && {
+      timeoutMs: aftConfig.configure_timeout_ms,
+    }),
+    ...(aftConfig.hang_timeout_threshold !== undefined && {
+      hangTimeoutThreshold: aftConfig.hang_timeout_threshold,
+    }),
     // Per-project configure overrides — fixes OpenCode Desktop /
     // `opencode serve` mode where one plugin instance serves many projects.
     // Without this, every bridge inherits the project config visible at


### PR DESCRIPTION
## Summary

The AFT bridge had two hardcoded constants that combined into a "se cae y vuelve" failure mode on slow filesystems (WSL/DrvFs, NFS, network mounts):

- `DEFAULT_BRIDGE_TIMEOUT_MS = 30000` — per-request timeout for bridge calls.
- `BRIDGE_HANG_TIMEOUT_THRESHOLD = 2` — after 2 consecutive timeouts, the bridge kills the child process and respawns.

On WSL/DrvFs the `aft` binary takes **~95-104s** to start and respond to its first configure call. With a 30s default timeout, the very first request on a freshly-spawned bridge times out, the bridge is kept warm for one more attempt, that second attempt also times out, then the bridge is recycled — which on WSL triggers another ~100s respawn. The user observes: AFT works, then stops working, then works again, indefinitely.

This patch makes both knobs configurable from `aft.jsonc` so users on slow filesystems can size them appropriately, and threads the configuration through the entire chain (Zod schema → `loadAftConfig` → `poolOptions` → `BridgePool` → `BinaryBridge`).

## Changes

| File | What |
|------|------|
| `packages/opencode-plugin/src/config.ts` | Add `configure_timeout_ms` and `hang_timeout_threshold` to `AftConfigSchema` (both `.int().positive().optional()`); add to `PROJECT_SAFE_TOP_LEVEL_FIELDS` exclusion list (they're user-only — they govern bridge lifecycle, not project behavior) |
| `packages/opencode-plugin/src/index.ts` | Thread both fields into `poolOptions` when constructing the `BridgePool` |
| `packages/aft-bridge/src/bridge.ts` | Add `hangTimeoutThreshold` to `BridgeOptions`; read it in the `BinaryBridge` constructor; use `this.hangTimeoutThreshold` in the `keepWarm` decision instead of the module constant |
| `packages/aft-bridge/src/pool.ts` | Forward `hangTimeoutThreshold` from `PoolOptions` to each bridge's constructor |
| `packages/opencode-plugin/src/__tests__/config.test.ts` | 5 new tests covering: user config can set the new fields; project config cannot set them (strict allowlist); schema rejects non-positive values |
| `docs/config.md` | Document both fields with the WSL/DrvFs recipe and a recommended starting value |

## Reproduction (WSL/DrvFs)

1. Install AFT plugin on WSL2 with the project on a DrvFs mount (`/mnt/c/...`).
2. Run any AFT command (e.g. `aft context`).
3. Observe in logs: `bridge timeout after 30000ms` repeated, then `bridge process exited`, then a new binary spawn that itself takes ~100s.

Before this fix, the only workaround was the workaround branch in this PR's working tree: edit the plugin's `dist/index.js` directly after every npm update.

After this fix, the user adds to `~/.config/opencode/aft.jsonc`:

```jsonc
{
  "configure_timeout_ms": 120000,
  "hang_timeout_threshold": 10
}
```

and the bridge stops recycling.

## Test results

- `packages/aft-bridge`: 122 pass, 3 skip, 24 fail — **identical to upstream main**. The 24 pre-existing failures (`storage migration`, `BinaryBridge transport`, `findSystemOnnxRuntime`) reproduce on `main` and are unrelated — they require a built `aft` binary and Windows-specific ONNX runtime detection that this environment doesn't have.
- `packages/opencode-plugin` config tests: **50/50 pass** (45 pre-existing + 5 new).
- `tsc --noEmit` on both modified packages: **clean**.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Documentation only

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782923505&installation_id=135454708&pr_number=80&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F80&signature=4a3f3d38aa26a0426a4a5fdcfefff292a4e18d154470e5c15c35155867f33eb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make AFT bridge timeouts configurable to stop restart loops on slow filesystems (WSL/DrvFs). Defaults are raised to 120s for request timeout and 10 for hang threshold so the bridge stays warm during slow startup.

- **Bug Fixes**
  - Add `configure_timeout_ms` and `hang_timeout_threshold` to `AftConfigSchema` (user-only, positive ints).
  - Thread both fields from config through pool options into `BinaryBridge`; use `hangTimeoutThreshold` in keep-warm logic.
  - Update `aft-bridge` defaults to `120_000` ms and `10`.
  - Project configs cannot set these fields; tests cover allowlist and validation.
  - Document the fields and WSL guidance in `docs/config.md`.

<sup>Written for commit 87001818b45466a3bcc76a06fce29f03d9525001. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/80?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

