### PR TITLE
feat: make bridge startup timeout and hang threshold configurable via aft.jsonc

### DIFF
--- a/packages/aft-bridge/src/bridge.ts
+++ b/packages/aft-bridge/src/bridge.ts
@@ -157,6 +157,8 @@ class BridgeReplacedDuringVersionCheck extends Error {
 export interface BridgeOptions {
   /** Request timeout in milliseconds. Default: 30000 */
   timeoutMs?: number;
+  /** Number of consecutive request timeouts before the bridge restarts. Default: 2 */
+  hangTimeoutThreshold?: number;
   /**
    * Extra environment variables to set on the spawned `aft` child process,
    * applied on top of the inherited `process.env` at spawn time. Use this to
@@ -338,6 +340,7 @@ export class BinaryBridge {
     this.binaryPath = binaryPath;
     this.cwd = cwd;
     this.timeoutMs = options?.timeoutMs ?? DEFAULT_BRIDGE_TIMEOUT_MS;
+    this.hangTimeoutThreshold = options?.hangTimeoutThreshold ?? BRIDGE_HANG_TIMEOUT_THRESHOLD;
     this.maxRestarts = options?.maxRestarts ?? 3;
     this.configOverrides = clampSemanticTimeout(configOverrides ?? {}, this.timeoutMs);
     this.minVersion = options?.minVersion;
@@ -633,7 +636,7 @@ export class BinaryBridge {
           const consecutiveTimeouts = this.consecutiveRequestTimeouts + 1;
           this.consecutiveRequestTimeouts = consecutiveTimeouts;
           const keepWarm =
-            childActiveSinceRequest || consecutiveTimeouts < BRIDGE_HANG_TIMEOUT_THRESHOLD;
+            childActiveSinceRequest || consecutiveTimeouts < this.hangTimeoutThreshold;
           const restartSuffix = keepWarm ? " — bridge kept warm" : " — restarting bridge";
           const timeoutMsg = `Request "${command}" (id=${id}) timed out after ${effectiveTimeoutMs}ms${restartSuffix}`;
           if (requestSessionId) {

--- a/packages/opencode-plugin/src/config.ts
+++ b/packages/opencode-plugin/src/config.ts
@@ -293,6 +293,10 @@ export const AftConfigSchema = z
     max_callgraph_files: z.number().int().positive().optional(),
     /** Auto-refresh OpenCode's cached @cortexkit/aft-opencode package when a newer channel version exists. */
     auto_update: z.boolean().optional(),
+    /** Bridge startup timeout in milliseconds. Default: 30000. Raise for slow environments (WSL/DrvFs). */
+    configure_timeout_ms: z.number().int().positive().optional(),
+    /** Consecutive request timeouts before bridge restart. Default: 2. Raise for slow environments. */
+    hang_timeout_threshold: z.number().int().positive().optional(),
   })
   .strict();
 

--- a/packages/opencode-plugin/src/index.ts
+++ b/packages/opencode-plugin/src/index.ts
@@ -561,6 +561,8 @@ async function initializePluginForDirectory(input: Parameters<Plugin>[0]) {
       );
     },
   };
+  poolOptions.timeoutMs = aftConfig.configure_timeout_ms;
+  poolOptions.hangTimeoutThreshold = aftConfig.hang_timeout_threshold;
   const pool = new BridgePool(binaryPath, poolOptions, configOverrides);
   pool.setConfigureOverride("harness", "opencode");
   const ctx: PluginContext = {


### PR DESCRIPTION
## Problem

WSL/DrvFs environments have slow filesystem startup (95s+ cold start measured with total 2721
drwxr-xr-x 1 herjarsa 197121     0 Jun  3 16:27 .
drwxr-xr-x 1 herjarsa 197121     0 Jun  3 17:02 ..
drwxr-xr-x 1 herjarsa 197121     0 Jun  3 16:27 .alfonso
drwxr-xr-x 1 herjarsa 197121     0 Jun  3 16:27 .bg-shell
drwxr-xr-x 1 herjarsa 197121     0 Jun  3 16:27 .cargo
-rw-r--r-- 1 herjarsa 197121   373 Jun  3 16:27 .dockerignore
drwxr-xr-x 1 herjarsa 197121     0 Jun  3 17:02 .git
drwxr-xr-x 1 herjarsa 197121     0 Jun  3 16:27 .github
-rw-r--r-- 1 herjarsa 197121  2340 Jun  3 16:27 .gitignore
drwxr-xr-x 1 herjarsa 197121     0 Jun  3 16:27 .gsd
drwxr-xr-x 1 herjarsa 197121     0 Jun  3 16:27 .opencode
-rw-r--r-- 1 herjarsa 197121 25392 Jun  3 16:27 ARCHITECTURE.md
drwxr-xr-x 1 herjarsa 197121     0 Jun  3 16:27 assets
drwxr-xr-x 1 herjarsa 197121     0 Jun  3 16:27 benchmarks
-rw-r--r-- 1 herjarsa 197121  1861 Jun  3 16:27 biome.json
-rw-r--r-- 1 herjarsa 197121 87780 Jun  3 16:27 bun.lock
-rw-r--r-- 1 herjarsa 197121 98740 Jun  3 16:27 Cargo.lock
-rw-r--r-- 1 herjarsa 197121   517 Jun  3 16:27 Cargo.toml
drwxr-xr-x 1 herjarsa 197121     0 Jun  3 16:27 crates
drwxr-xr-x 1 herjarsa 197121     0 Jun  3 16:27 docs
-rw-r--r-- 1 herjarsa 197121  1090 Jun  3 16:27 LICENSE
-rw-r--r-- 1 herjarsa 197121   895 Jun  3 16:27 Makefile
-rw-r--r-- 1 herjarsa 197121  2306 Jun  3 16:27 package.json
drwxr-xr-x 1 herjarsa 197121     0 Jun  3 16:27 packages
-rw-r--r-- 1 herjarsa 197121 17668 Jun  3 16:27 README.md
-rw-r--r-- 1 herjarsa 197121   110 Jun  3 16:27 rustfmt.toml
drwxr-xr-x 1 herjarsa 197121     0 Jun  3 16:27 scripts
-rw-r--r-- 1 herjarsa 197121 15938 Jun  3 16:27 STRUCTURE.md
drwxr-xr-x 1 herjarsa 197121     0 Jun  3 16:27 tests
-rw-r--r-- 1 herjarsa 197121   386 Jun  3 16:27 tsconfig.base.json
-rw-r--r-- 1 herjarsa 197121   292 Jun  3 16:27 tsconfig.json timing). The AFT bridge binary hits the hardcoded 30s `DEFAULT_BRIDGE_TIMEOUT_MS` timeout and enters a restart loop:

```
[aft-plugin] [aft] Bridge started (binary: ~/.cache/opencode/.../aft)
[aft-plugin] [aft] Request timed out after 30000ms — bridge kept warm
... (repeats, bridge never fully initializes)
```

The hardcoded `BRIDGE_HANG_TIMEOUT_THRESHOLD = 2` also causes premature restarts — WSL needs more tolerance.

## Solution

Add two new optional fields to `aft.jsonc`:

- `configure_timeout_ms`: bridge startup timeout (default: 30000)
- `hang_timeout_threshold`: consecutive timeouts before restart (default: 2)

### WSL config example:
```json
{
  "configure_timeout_ms": 120000,
  "hang_timeout_threshold": 10
}
```

## Changes

### `packages/aft-bridge/src/bridge.ts`
- Add `hangTimeoutThreshold?: number` to `BridgeOptions` interface
- Store instance-level `this.hangTimeoutThreshold` in `BinaryBridge` constructor
- Use `this.hangTimeoutThreshold` instead of `BRIDGE_HANG_TIMEOUT_THRESHOLD` constant in keepWarm logic

### `packages/opencode-plugin/src/config.ts`
- Add `configure_timeout_ms` and `hang_timeout_threshold` to `AftConfigSchema`

### `packages/opencode-plugin/src/index.ts`
- Pass `aftConfig.configure_timeout_ms` and `aftConfig.hang_timeout_threshold` through poolOptions to BridgePool

## Backward Compatible

Both fields are optional with safe defaults. Existing `aft.jsonc` files work unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783090992&installation_id=135454708&pr_number=90&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F90&signature=e412b36cd30a5a628c87ec1abd1a67219c1dc89a5338f2478f9517ccb0a28378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the bridge startup timeout and hang restart threshold configurable via `aft.jsonc` to prevent restart loops on slow filesystems (e.g., WSL/DrvFs). Defaults are unchanged, so no config changes are required.

- **New Features**
  - Added `configure_timeout_ms` to control bridge timeout (default: 30000 ms).
  - Added `hang_timeout_threshold` for consecutive timeouts before restart (default: 2). Values are read from `aft.jsonc` and passed through the plugin to the bridge.

<sup>Written for commit 7a175d13b9895d6d20ad913918a9d6cc51d3fd54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/90?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes the bridge startup timeout and hang-restart threshold configurable via `aft.jsonc` to address restart loops on slow filesystems like WSL/DrvFs. Both new fields are optional with unchanged defaults, so existing configs continue to work without modification.

- **`bridge.ts`**: Adds `hangTimeoutThreshold` to `BridgeOptions` and stores it as an instance field on `BinaryBridge`, replacing the hardcoded constant in the keep-warm logic.
- **`config.ts`**: Extends `AftConfigSchema` with `configure_timeout_ms` and `hang_timeout_threshold` as optional positive integers.
- **`index.ts`**: Wires the new config fields into `poolOptions`, though the two assignments are duplicated verbatim (copy-paste artifact on lines 564–567).
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — the logic change is correct and backward-compatible; only a duplicate assignment pair needs cleanup.

The bridge.ts and config.ts changes are clean. The only real flaw is a copy-paste duplication in index.ts that repeats both poolOptions assignments verbatim; it has no behavioral effect but is dead code that should be removed before merging.

packages/opencode-plugin/src/index.ts — duplicate assignment pair on lines 564–567.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/aft-bridge/src/bridge.ts | Adds `hangTimeoutThreshold` to `BridgeOptions` and stores it as an instance field in `BinaryBridge`; the constant `BRIDGE_HANG_TIMEOUT_THRESHOLD` is replaced by the instance value in keep-warm logic. Clean implementation. |
| packages/opencode-plugin/src/config.ts | Adds `configure_timeout_ms` and `hang_timeout_threshold` as optional positive integers to `AftConfigSchema`. Schema additions are correct and backward-compatible. |
| packages/opencode-plugin/src/index.ts | Passes config values through to `poolOptions`, but the two assignments are copy-pasted twice (lines 564–567), resulting in redundant dead code. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Config as aft.jsonc
    participant Plugin as opencode-plugin/index.ts
    participant Pool as BridgePool
    participant Bridge as BinaryBridge

    Config->>Plugin: configure_timeout_ms, hang_timeout_threshold
    Plugin->>Pool: poolOptions.timeoutMs, poolOptions.hangTimeoutThreshold
    Pool->>Bridge: new BinaryBridge(options)
    Bridge->>Bridge: "this.timeoutMs = options.timeoutMs ?? DEFAULT_BRIDGE_TIMEOUT_MS"
    Bridge->>Bridge: "this.hangTimeoutThreshold = options.hangTimeoutThreshold ?? BRIDGE_HANG_TIMEOUT_THRESHOLD"

    Note over Bridge: On request timeout
    Bridge->>Bridge: consecutiveTimeouts++
    alt "consecutiveTimeouts < this.hangTimeoutThreshold OR childActiveSinceRequest"
        Bridge->>Bridge: Keep warm (no restart)
    else
        Bridge->>Bridge: Restart bridge
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: make bridge startup timeout and ha..."](https://github.com/cortexkit/aft/commit/e44ef331b8599a1bfc2576c243880a7a696bec6d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35394441)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->