### PR TITLE
docs: fix malformed YAML table row and missing blank line in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ _Coming soon._
 | Zig | ✓ | ✓ | ✓ | ✓ | | |
 | Bash | ✓ | ✓ | | ✓ | | |
 | HTML / Markdown | ✓ | ✓ | | | | |
-| YAML (incl. Kubernetes) | ✓ | ✓ | — | — |
+| YAML (incl. Kubernetes) | ✓ | ✓ | | ✓ | | |
 | JSON | ✓ | ✓ | ✓ | | | |
 | Solidity | ✓ | ✓ | ✓ | ✓ | ✓ | |
 | Vue | ✓ | ✓ | ✓ | ✓ | ✓ | |
@@ -183,6 +183,7 @@ Every listed language works with `aft_outline`, `aft_zoom`, and `read`/`edit`/`w
 Indexes honor `.gitignore` and an optional `.aftignore` (same syntax) for paths git can't exclude, such as submodules. Naming a file explicitly in `grep` searches it even when ignored, matching ripgrep.
 
 **YAML / Kubernetes / CRDs.** YAML files are semantically indexed. Each document carrying `apiVersion` + `kind` (the Kubernetes/CRD contract, so this generalizes to any custom resource) becomes one rich symbol named `<namespace>/<Kind>/<name>` (falling back to `metadata.generateName` when no name is set). The symbol's embed text is enriched with high-signal spec fields so intent queries match: container `image`/ports, resource `cpu`/`memory` limits and requests, `volumeMounts`, env var names, RBAC `verbs`/`resources`/`apiGroups`, and Argo Workflow `entrypoint`/`templates`/`command`/`schedule`. Multi-document (`---`) streams are handled per document; plain non-k8s YAML (docker-compose, CI configs, Helm `values.yaml`) falls back to top-level keys as symbols.
+
 ---
 
 ## Architecture


### PR DESCRIPTION
## Summary

Fixes two Markdown formatting issues in the Supported languages section of `README.md`, both around the YAML row. Closes #93.

### 1. Malformed YAML table row

The `YAML (incl. Kubernetes)` row had only 5 cells while the table header defines 7 columns (Language, Outline, Edit, AST, Semantic, Imports, Refactor), and it used `—` where the rest of the table uses a blank cell to mean "not supported". This broke the row rendering.

```diff
-| YAML (incl. Kubernetes) | ✓ | ✓ | — | — |
+| YAML (incl. Kubernetes) | ✓ | ✓ | | ✓ | | |
```

The `Semantic` column is set to ✓ to match the prose immediately below the table: *"YAML files are semantically indexed."*

### 2. Missing blank line before `---`

The `**YAML / Kubernetes / CRDs.**` paragraph was immediately followed by a `---` thematic break with no blank line between them. In CommonMark, `text` directly followed by `---` renders as a setext (H2) heading instead of a horizontal rule. Added a blank line so it renders as a divider.

## Testing

Visual diff review against the existing table format; the YAML row now matches the 7-column shape used by every other row (e.g. the `Bash` row directly above).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783136588&installation_id=135454708&pr_number=94&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F94&signature=e57f7779ff8683008b4dfb698634be96217decdc9728643e706aec3ee07ccaad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the malformed YAML row in the Supported languages table and adds a missing blank line before the horizontal rule so the README renders correctly. The YAML row now has seven columns (Semantic = ✓) and uses blank cells for unsupported features, matching the rest of the table.

<sup>Written for commit 1b1bd61fa28f7480a463067f04535deff145d48b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two Markdown rendering bugs in `README.md` that were both centered on the YAML row of the Supported Languages table.

- The YAML row was missing two cells (5 of 7 columns) and used `—` em-dashes instead of empty cells; the row now has the correct 7-column shape with `✓` in the Semantic column, consistent with the prose description and the adjacent Bash row.
- A blank line was inserted between the YAML/Kubernetes paragraph and the `---` thematic break so that CommonMark parsers treat it as a horizontal rule rather than promoting the paragraph text to an H2 setext heading.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — both changes are narrow, correct documentation fixes with no code or logic impact.

The YAML row now matches the 7-column table header and the Semantic ✓ is backed directly by the prose. The blank line before --- is the standard CommonMark fix to avoid setext-heading promotion. No functional code is touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Two focused doc fixes: YAML table row expanded from 5 to 7 cells with correct Semantic ✓, and a blank line added before `---` to prevent setext-heading mis-render. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["README.md YAML table row\n(before: 5 cells, uses — dashes)"] -->|"Fix 1: expand to 7 cells\nadd Semantic ✓"| B["YAML row: 7 columns\nLanguage|Outline|Edit|AST|Semantic|Imports|Refactor"]
    C["YAML paragraph followed\ndirectly by ---\n(renders as setext H2)"] -->|"Fix 2: insert blank line"| D["Blank line separates paragraph\nfrom --- thematic break\n(renders as horizontal rule)"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: fix malformed YAML table row and m..."](https://github.com/cortexkit/aft/commit/1b1bd61fa28f7480a463067f04535deff145d48b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35540139)</sub>

<!-- /greptile_comment -->