### PR TITLE
fix(aft-bridge): prevent bridge death-spiral when multiple windows share a bridge

### DIFF
--- a/packages/aft-bridge/src/bridge.ts
+++ b/packages/aft-bridge/src/bridge.ts
@@ -8,7 +8,7 @@ import type { Logger, LogMeta } from "./logger.js";
 import type { BgCompletion, StatusCompression } from "./protocol.js";
 
 const DEFAULT_BRIDGE_TIMEOUT_MS = 30_000;
-const BRIDGE_HANG_TIMEOUT_THRESHOLD = 2;
+const BRIDGE_HANG_TIMEOUT_THRESHOLD = 20;
 const SEMANTIC_TIMEOUT_SAFETY_MARGIN_MS = 5_000;
 const MAX_STDOUT_BUFFER = 64 * 1024 * 1024; // 64MB
 
@@ -633,7 +633,7 @@ export class BinaryBridge {
           const consecutiveTimeouts = this.consecutiveRequestTimeouts + 1;
           this.consecutiveRequestTimeouts = consecutiveTimeouts;
           const keepWarm =
-            childActiveSinceRequest || consecutiveTimeouts < BRIDGE_HANG_TIMEOUT_THRESHOLD;
+            childActiveSinceRequest || consecutiveTimeouts < BRIDGE_HANG_TIMEOUT_THRESHOLD || this.isAlive();
           const restartSuffix = keepWarm ? " — bridge kept warm" : " — restarting bridge";
           const timeoutMsg = `Request "${command}" (id=${id}) timed out after ${effectiveTimeoutMs}ms${restartSuffix}`;
           if (requestSessionId) {

--- a/packages/aft-bridge/src/pool.ts
+++ b/packages/aft-bridge/src/pool.ts
@@ -4,7 +4,7 @@ import { error, getActiveLogger, log } from "./active-logger.js";
 import { BinaryBridge, type BridgeOptions } from "./bridge.js";
 import type { Logger, LogMeta } from "./logger.js";
 
-const DEFAULT_IDLE_TIMEOUT_MS = Infinity; // keep alive as long as the host is running
+const DEFAULT_IDLE_TIMEOUT_MS = 30 * 60 * 1000; // 30 min instead of Infinity
 const DEFAULT_MAX_POOL_SIZE = 8;
 const CLEANUP_INTERVAL_MS = 60 * 1000; // check every minute
 


### PR DESCRIPTION
## Problem

The Rust `aft` process is **single-threaded** — it processes ONE request at a time. When N OpenCode windows share one bridge (same project), requests queue up and time out sequentially. With `BRIDGE_HANG_TIMEOUT_THRESHOLD=2`, after just 2 consecutive timeouts the bridge is killed with SIGKILL, aborting ALL pending requests from ALL windows simultaneously. This creates a death-spiral: bridge restarts, all windows retry, queue fills up again, time out again, bridge killed again.

## Changes

### 1. `bridge.ts`: Raise `BRIDGE_HANG_TIMEOUT_THRESHOLD` from 2 → 20
Before: after 2 consecutive timeouts (60s with 30s default), bridge is SIGKILLed.
After: 20 consecutive timeouts (600s) must elapse before bridge is considered hung.

### 2. `bridge.ts`: Add `this.isAlive()` to keepWarm predicate
**The key fix.** If the child Rust process is still running (just busy), `isAlive()` returns true and the bridge is NEVER killed by timeout. Pending requests get "bridge busy, retry" instead of triggering a full restart cascade.

### 3. `pool.ts`: Change idle timeout from `Infinity` → 30 min
Bridges for unused projects auto-cleanup after 30 min, freeing Rust process, LSP servers, file watchers, and search indexes.

## Root Cause
The Rust main loop in `crates/aft/src/main.rs` uses `recv_timeout(250ms)` and processes requests serially. When N windows share one bridge, timeouts cascade. The existing logic correctly detects this but the threshold was too aggressive (2) and the `isAlive()` check was missing — a busy-but-alive process should never be killed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783344288&installation_id=135454708&pr_number=100&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F100&signature=8a7a0afc4444dd0ed05f4d93dc425509fdb4410fa32e1fad80542b38282d3158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents bridge restart death-spirals when multiple windows share a project bridge. Busy Rust processes are kept alive, timeouts are more tolerant, and unused bridges auto-clean after 30 minutes.

- **Bug Fixes**
  - `bridge.ts`: Add `this.isAlive()` to the keep-warm check so a busy-but-running process isn’t killed; pending requests get “bridge busy, retry.”
  - `bridge.ts`: Raise `BRIDGE_HANG_TIMEOUT_THRESHOLD` from 2 to 20 to avoid premature SIGKILL during backlogs.
  - `pool.ts`: Set default idle timeout to 30 minutes (was `Infinity`) to free resources for unused projects.

<sup>Written for commit 062377ce47e67536a784c97cfa5bcb978c155ad3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR addresses a bridge death-spiral caused by multiple windows sharing a single Rust bridge process: consecutive timeouts triggered a SIGKILL that aborted all pending requests, which then flooded the restarted bridge and repeated the cycle.

- **`bridge.ts`**: Raises `BRIDGE_HANG_TIMEOUT_THRESHOLD` from 2 → 20 and adds `|| this.isAlive()` to the `keepWarm` predicate so a busy-but-alive child is never killed by the timeout path; however the `isAlive()` OR fully short-circuits the expression, making the threshold dead code and removing the only kill path for a genuinely deadlocked process.
- **`pool.ts`**: Replaces the previous `Infinity` idle timeout with 30 minutes, enabling automatic cleanup of bridges for unused projects; the `hasPendingRequests()` guard ensures active bridges are not evicted.
</details>

<h3>Confidence Score: 3/5</h3>

Safe to merge for the death-spiral fix, but at the cost of removing the only automatic recovery mechanism for a live-but-deadlocked bridge process.

The `|| this.isAlive()` addition unconditionally short-circuits the `keepWarm` expression whenever the child is running. The intended effect — protecting busy-but-alive bridges — is achieved, but so is the unintended effect: a process stuck in a permanent deadlock (alive, no stdout, forever) will produce 'bridge busy, retry' indefinitely because `handleTimeout` can now only be reached when the process is already dead. The threshold bump to 20 is also rendered unreachable for any live process, so that part of the description does not match the actual code path.

packages/aft-bridge/src/bridge.ts — specifically the `keepWarm` predicate at line 635 and its interaction with `handleTimeout`.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/aft-bridge/src/bridge.ts | Raises hang threshold to 20 and adds `isAlive()` to the keep-warm predicate; however `isAlive()` short-circuits the entire OR chain, making the threshold dead code and removing the only recovery path for a deadlocked-but-alive process. |
| packages/aft-bridge/src/pool.ts | Changes idle timeout from `Infinity` to 30 min; the existing cleanup guard (`hasPendingRequests()`) prevents evicting active bridges, and `lastUsed` is refreshed on every `getBridge()` call, so active multi-window projects are unaffected. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Request timer fires\ntimeout] --> B{keepBridgeOnTimeout?}
    B -- yes --> C[Reject request\nno hang escalation]
    B -- no --> D[Increment consecutiveRequestTimeouts]
    D --> E{childActiveSinceRequest?}
    E -- yes --> F[keepWarm = true]
    E -- no --> G{consecutiveTimeouts < 20?}
    G -- yes --> F
    G -- no --> H{this.isAlive?\nnew check}
    H -- true --> F
    H -- false --> I[keepWarm = false]
    F --> J[Reject with 'bridge busy — retry'\nbridge stays warm]
    I --> K[handleTimeout: SIGKILL child\nreject all pending\nschedule restart]

    style H fill:#f9c,stroke:#c66
    style K fill:#fcc,stroke:#c33
    style J fill:#cfc,stroke:#3c3
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(aft-bridge): prevent bridge death-sp..."](https://github.com/cortexkit/aft/commit/062377ce47e67536a784c97cfa5bcb978c155ad3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36008112)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->