### PR TITLE
fix: prevent background scans and watcher setup on HOME root degraded mode

### DIFF
--- a/assets/aft.schema.json
+++ b/assets/aft.schema.json
@@ -375,6 +375,24 @@
       "type": "boolean",
       "default": true,
       "description": "OpenCode only: auto-refresh the cached @cortexkit/aft-opencode package when a newer channel version is published. User-scoped only — project configs cannot disable updates silently."
+    },
+    "inspect": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable codebase health inspection and background scans. Set false to disable aft_inspect and turn off Tier-2 scans entirely."
+        },
+        "tier2_idle_minutes": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 5,
+          "description": "Delay in minutes after session activity before triggering background Tier-2 scans."
+        }
+      },
+      "additionalProperties": false,
+      "description": "Codebase health inspection configuration."
     }
   },
   "additionalProperties": false

--- a/crates/aft/src/commands/configure.rs
+++ b/crates/aft/src/commands/configure.rs
@@ -439,6 +439,26 @@ fn semantic_fingerprint_config_changed(
         || previous.base_url != next.base_url
 }
 
+fn parse_inspect_config(
+    value: &serde_json::Value,
+    current: &crate::config::InspectConfig,
+) -> Result<crate::config::InspectConfig, String> {
+    let Some(obj) = value.as_object() else {
+        return Err("configure: inspect must be an object".to_string());
+    };
+
+    let mut inspect = current.clone();
+
+    if let Some(raw) = obj.get("enabled") {
+        let Some(value) = raw.as_bool() else {
+            return Err("configure: inspect.enabled must be a boolean".to_string());
+        };
+        inspect.enabled = value;
+    }
+
+    Ok(inspect)
+}
+
 fn parse_semantic_config(
     value: &serde_json::Value,
     current: &SemanticBackendConfig,
@@ -1634,6 +1654,12 @@ pub fn handle_configure(req: &RawRequest, ctx: &AppContext) -> Response {
             Err(error) => return Response::error(&req.id, "invalid_request", error),
         };
     }
+    if let Some(v) = params.get("inspect") {
+        next_config.inspect = match parse_inspect_config(v, &next_config.inspect) {
+            Ok(config) => config,
+            Err(error) => return Response::error(&req.id, "invalid_request", error),
+        };
+    }
     if let Some(raw) = params.get("max_callgraph_files") {
         // Reject invalid values explicitly so user typos surface instead of
         // being silently swallowed (Oracle v0.15.1 review blocker).
@@ -2394,7 +2420,9 @@ pub fn handle_configure(req: &RawRequest, ctx: &AppContext) -> Response {
     // Spawn file watcher for live invalidation off the configure foreground.
     // FSEvents startup can synchronously wait for seconds on very large roots;
     // configure should return while the watcher attaches in the background.
-    install_project_watcher(ctx, &canonical_cache_root);
+    if !home_match {
+        install_project_watcher(ctx, &canonical_cache_root);
+    }
 
     slog_info!("project root set: {}", root_path.display());
 
@@ -2410,7 +2438,8 @@ pub fn handle_configure(req: &RawRequest, ctx: &AppContext) -> Response {
     // On a normal project this finishes in <1 s and pushes a
     // `ConfigureWarningsFrame` for the plugin to surface; on a huge directory
     // it may take seconds-to-minutes, but configure itself returns now.
-    if ctx.progress_sender_handle().is_some() {
+    let warnings_pending = !home_match && ctx.progress_sender_handle().is_some();
+    if warnings_pending {
         let warning_tx = ctx.configure_warnings_sender();
         let warning_generation = configure_generation;
         let walk_root = root_path.clone();
@@ -2464,7 +2493,7 @@ pub fn handle_configure(req: &RawRequest, ctx: &AppContext) -> Response {
             "max_callgraph_files": config_snapshot.max_callgraph_files,
             "source_file_count_bounded": true,
             "warnings": [],
-            "warnings_pending": true,
+            "warnings_pending": warnings_pending,
             "search_index_cache_reused": search_index_cache_reused,
         }),
     );

--- a/crates/aft/src/config.rs
+++ b/crates/aft/src/config.rs
@@ -79,6 +79,18 @@ impl Default for SemanticBackendConfig {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct InspectConfig {
+    pub enabled: bool,
+}
+
+impl Default for InspectConfig {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
+}
+
 pub const DEFAULT_SEMANTIC_MODEL: &str = "all-MiniLM-L6-v2";
 
 impl Config {
@@ -153,6 +165,7 @@ pub struct Config {
     /// very large projects if you accept multi-minute per-call latency).
     pub max_callgraph_files: usize,
     pub semantic: SemanticBackendConfig,
+    pub inspect: InspectConfig,
     /// Enable Astral ty as an experimental Python LSP server (default: false).
     pub experimental_lsp_ty: bool,
     /// User-defined LSP servers registered by the OpenCode plugin.
@@ -244,6 +257,7 @@ impl Default for Config {
             // dead-code snapshots, and `aft_refactor op="move"`.
             max_callgraph_files: 5_000,
             semantic: SemanticBackendConfig::default(),
+            inspect: InspectConfig::default(),
             experimental_lsp_ty: false,
             lsp_servers: Vec::new(),
             disabled_lsp: HashSet::new(),

--- a/crates/aft/src/context.rs
+++ b/crates/aft/src/context.rs
@@ -1660,7 +1660,10 @@ impl AppContext {
     }
 
     fn start_tier2_refresh(&self, reason: Tier2TriggerReason, manager: Arc<InspectManager>) {
-        if self.is_worktree_bridge() {
+        if self.is_worktree_bridge()
+            || self.degraded_reasons.borrow().iter().any(|r| r == "home_root")
+            || !self.config().inspect.enabled
+        {
             return;
         }
         let Some(snapshot) = self.tier2_refresh_snapshot() else {


### PR DESCRIPTION
This PR fixes the high CPU/RAM usage in home-based sessions by preventing background Tier-2 scans and skipping file watcher registration and background file walks when the project root resolves to $HOME.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783489214&installation_id=135454708&pr_number=105&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F105&signature=d6327b4376272b218e86f3ec1ba4583e70e18d71a477d794c966523e2fcbb9c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent background scans and file watcher setup when the project root is the user’s HOME directory. Adds an `inspect` config to let users disable Tier‑2 scans.

- **Bug Fixes**
  - Skip project watcher and background warning generation when `home_match` is true; set `warnings_pending` accordingly.
  - Block Tier‑2 refresh when `degraded_reasons` includes `home_root`.

- **New Features**
  - Add `inspect.enabled` to config and schema; when false, Tier‑2 scans are disabled.
  - Add `inspect.tier2_idle_minutes` to the schema (default 5) for scan scheduling.

<sup>Written for commit aa13a64618adc76b4213056d7df39fe57a758436. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prevents background Tier-2 scans, file watcher registration, and the background file-walk/warning-generation from running when the project root resolves to `$HOME`, fixing CPU/RAM spikes in home-rooted sessions. It also introduces an `InspectConfig` struct (`enabled` flag) wired into the configure handler and the Tier-2 refresh guard.

- `handle_configure` now gates `install_project_watcher` and the warning-generation thread behind `!home_match`, and correctly returns `warnings_pending: false` in the response for home-root sessions.
- `start_tier2_refresh` gains two new early exits: `home_root` in the degraded-reasons list, and `inspect.enabled == false`.
- The JSON schema adds an `inspect` object with `enabled` and `tier2_idle_minutes`, but `tier2_idle_minutes` has no implementation in `InspectConfig` or `parse_inspect_config`.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge for the home-root CPU fix; one schema/implementation gap should be resolved before users rely on tier2_idle_minutes.

The core fix — skipping the watcher, warning walk, and Tier-2 scans in home-root degraded mode — is correct and well-bounded. The one concrete defect is that inspect.tier2_idle_minutes is published in the schema with a description and default value but is never read by parse_inspect_config or stored in InspectConfig, so any caller that sets it will observe no change in Tier-2 idle timing.

The gap spans assets/aft.schema.json and crates/aft/src/commands/configure.rs — either the schema entry should be removed or the parser and struct should be updated to honour the field.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/aft/src/commands/configure.rs | Adds parse_inspect_config and wires inspect into handle_configure; skips watcher install and background warning walk on home_match. tier2_idle_minutes is defined in the schema but never parsed or stored, so setting it has no runtime effect. |
| assets/aft.schema.json | Adds inspect object with enabled and tier2_idle_minutes properties. The tier2_idle_minutes field has no corresponding implementation in InspectConfig or parse_inspect_config, making it a dead documented knob. |
| crates/aft/src/config.rs | Introduces InspectConfig struct with only enabled: bool; added to Config with a default of true. Clean and self-contained. |
| crates/aft/src/context.rs | Guards start_tier2_refresh with two new early exits: home_root in degraded reasons and inspect.enabled == false. Uses an inline borrow().iter().any(...) instead of the cloning degraded_reasons() helper, which is correct and efficient on the hot ticker path. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[handle_configure called] --> B{home_match?}
    B -- Yes --> C[Push 'home_root' to degraded_reasons]
    C --> D[Skip walk / set source_file_count = max+1]
    D --> E[Skip rebuild_gitignore]
    E --> F[ctx.set_degraded_reasons]
    F --> G[Skip install_project_watcher]
    G --> H[warnings_pending = false]
    H --> I[Return response immediately]
    B -- No --> J[Walk project files]
    J --> K[rebuild_gitignore]
    K --> L[install_project_watcher]
    L --> M{progress_sender present?}
    M -- Yes --> N[Spawn background warning walk thread]
    N --> O[warnings_pending = true]
    M -- No --> P[warnings_pending = false]
    O --> I
    P --> I

    subgraph Watcher tick path
        Q[tick_tier2_refresh_scheduler_at] --> R[start_tier2_refresh]
        R --> S{is_worktree_bridge?}
        S -- Yes --> T[return / no scan]
        S -- No --> U{home_root in degraded_reasons?}
        U -- Yes --> T
        U -- No --> V{inspect.enabled?}
        V -- No --> T
        V -- Yes --> W[Submit Tier-2 scan]
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(degraded-home-mode): prevent backgro..."](https://github.com/cortexkit/aft/commit/aa13a64618adc76b4213056d7df39fe57a758436) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36145638)</sub>

<!-- /greptile_comment -->