### PR TITLE
Skip device file paths in permission scans

### DIFF
--- a/crates/aft/src/bash_permissions/scan.rs
+++ b/crates/aft/src/bash_permissions/scan.rs
@@ -335,6 +335,12 @@ fn path_arg_target(arg: &str, cwd: &Path) -> PathArgTarget {
     } else {
         cwd.join(path)
     };
+    // Check before canonicalization: on Linux /dev/stderr etc. are symlinks
+    // (/proc/self/fd/2 -> /dev/pts/0) that no longer match the allowlist
+    // once resolved.
+    if is_device_file(&resolved) {
+        return PathArgTarget::None;
+    }
     PathArgTarget::Path(resolve_existing(&resolved))
 }
 
@@ -449,6 +455,23 @@ fn push_xargs_ask(asks: &mut Vec<PermissionAsk>, seen: &mut HashSet<String>, tok
     push_bash_ask(asks, seen, tokens[index..].join(" "), &tokens[index..]);
 }
 
+fn is_device_file(path: &Path) -> bool {
+    let Some(s) = path.to_str() else {
+        return false;
+    };
+    matches!(
+        s,
+        "/dev/null"
+            | "/dev/zero"
+            | "/dev/random"
+            | "/dev/urandom"
+            | "/dev/stdin"
+            | "/dev/stdout"
+            | "/dev/stderr"
+            | "/dev/tty"
+    ) || s.starts_with("/dev/fd/")
+}
+
 fn push_external_path(
     asks: &mut Vec<PermissionAsk>,
     seen: &mut HashSet<String>,
@@ -521,5 +544,75 @@ mod tests {
         let path = arg_path("./file.log", &scan_cwd).unwrap();
 
         assert_eq!(path, normalize_path(&scan_cwd.join("file.log")));
+    }
+
+    #[test]
+    fn device_paths_are_skipped_before_canonicalization() {
+        // On Linux /dev/stderr is a symlink chain ending at the TTY (or a
+        // pipe inode under CI), so the device check must run on the raw
+        // path — after canonicalize it no longer matches the allowlist.
+        for arg in ["/dev/stderr", "/dev/stdin", "/dev/stdout", "/dev/fd/2"] {
+            let target = path_arg_target(arg, Path::new("/tmp"));
+            assert!(
+                matches!(target, PathArgTarget::None),
+                "expected {arg} to be skipped as a device path"
+            );
+        }
+    }
+
+    #[test]
+    fn dev_null_redirect_does_not_trigger_permission_ask() {
+        let temp = tempfile::tempdir().unwrap();
+        let project_root = temp.path().join("project");
+        std::fs::create_dir_all(&project_root).unwrap();
+
+        let ctx = AppContext::new(
+            Box::new(crate::parser::TreeSitterProvider::new()),
+            crate::config::Config {
+                project_root: Some(project_root.clone()),
+                bash_permissions: true,
+                ..crate::config::Config::default()
+            },
+        );
+
+        let asks = scan_with_cwd("echo test 2>/dev/null", &ctx, &project_root);
+
+        let external_asks: Vec<_> = asks
+            .iter()
+            .filter(|ask| matches!(ask.kind, PermissionKind::ExternalDirectory))
+            .collect();
+        assert!(
+            external_asks.is_empty(),
+            "Expected no external directory asks for /dev/null redirect, got: {:?}",
+            external_asks
+        );
+    }
+
+    #[test]
+    fn dev_stderr_redirect_does_not_trigger_permission_ask() {
+        let temp = tempfile::tempdir().unwrap();
+        let project_root = temp.path().join("project");
+        std::fs::create_dir_all(&project_root).unwrap();
+
+        let ctx = AppContext::new(
+            Box::new(crate::parser::TreeSitterProvider::new()),
+            crate::config::Config {
+                project_root: Some(project_root.clone()),
+                bash_permissions: true,
+                ..crate::config::Config::default()
+            },
+        );
+
+        let asks = scan_with_cwd("some-command 2>/dev/stderr", &ctx, &project_root);
+
+        let external_asks: Vec<_> = asks
+            .iter()
+            .filter(|ask| matches!(ask.kind, PermissionKind::ExternalDirectory))
+            .collect();
+        assert!(
+            external_asks.is_empty(),
+            "Expected no external directory asks for /dev/stderr redirect, got: {:?}",
+            external_asks
+        );
     }
 }


### PR DESCRIPTION
/dev/null, /dev/stderr, and similar device-file paths triggered
unnecessary ExternalDirectory permission asks on shell redirects. Filter
them out in push_external_path so redirects like 2>/dev/null flow
without interruption.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783607337&installation_id=135454708&pr_number=107&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F107&signature=c1fa79800afda876a0f171a01233dbe397e4f9c1e44fce31dfd2fb9ba290325b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip device-file paths in bash permission scans so redirects like 2>/dev/null and >/dev/stderr no longer trigger ExternalDirectory prompts.

- **Bug Fixes**
  - Run device-path check in `path_arg_target` before canonicalization using `is_device_file`; skip `/dev/null`, `/dev/zero`, `/dev/random`, `/dev/urandom`, `/dev/stdin`, `/dev/stdout`, `/dev/stderr`, `/dev/tty`, and `/dev/fd/*` to avoid symlink-resolved TTY paths.
  - Added tests for pre-canonicalization skipping and to ensure `/dev/null` and `/dev/stderr` redirects don’t create permission asks.

<sup>Written for commit fb4b8671a91c955d8a7f2d3e8a3a7a2eaba95f03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes spurious `ExternalDirectory` permission prompts triggered by shell redirects to device files like `2>/dev/null` and `>/dev/stderr`. The fix adds an `is_device_file` predicate and applies it in `path_arg_target` **before** `resolve_existing`/`canonicalize` is called, directly addressing the root cause.

- The device-file check is correctly placed in `path_arg_target` (before canonicalization), so Linux symlinks like `/dev/stderr → /proc/self/fd/2 → /dev/pts/0` are caught at their raw path before `canonicalize` resolves them to a form the allowlist would miss.
- Both code paths that ultimately call `push_external_path` — command path-arguments and redirect targets — go through `path_arg_target`, so the allowlist is applied consistently.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the device-file guard is placed at the correct point in the call chain, before canonicalization, and both consumers of path_arg_target benefit from it automatically.

The previous reviewer concern about symlink resolution has been addressed: the check now runs on the raw, pre-canonicalize path in path_arg_target, and both code paths that feed push_external_path route through that function. The logic is straightforward, the tests directly exercise the two cases mentioned in the PR description, and the change is narrowly scoped to the permission scan.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/aft/src/bash_permissions/scan.rs | Adds is_device_file predicate and inserts the check in path_arg_target before resolve_existing/canonicalize is called; both command path-arg and redirect code paths already funnel through path_arg_target, so the guard is applied consistently. Two tests cover the /dev/null and /dev/stderr redirect cases. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["path_arg_target(arg, cwd)"] --> B{is dynamic?}
    B -- yes --> C[PathArgTarget::Dynamic]
    B -- no --> D{glob prefix?}
    D -- none --> E[PathArgTarget::None]
    D -- prefix --> F["resolve relative path"]
    F --> G{is_device_file?\n/dev/null, /dev/stderr,\n/dev/fd/*, etc.}
    G -- yes --> E
    G -- no --> H["resolve_existing / canonicalize"]
    H --> I[PathArgTarget::Path]

    I --> J{caller}
    J -- path args --> K[push_external_path]
    J -- redirects\ncollect_redirection_targets --> K
    K --> L{starts_with project_root?}
    L -- yes --> M[skip]
    L -- no --> N[ExternalDirectory ask]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(bash\_permissions): skip device file ..."](https://github.com/cortexkit/aft/commit/fb4b8671a91c955d8a7f2d3e8a3a7a2eaba95f03) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36458133)</sub>

<!-- /greptile_comment -->