### PR TITLE
config: update build-linux-x64 use cross

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,11 +199,7 @@ jobs:
 
   build-linux-x64:
     name: Build Linux x64
-    # Build on Ubuntu 22.04 to link against GLIBC 2.35 — compatible with
-    # Ubuntu 22.04 LTS (supported until 2027), Pop!OS 22.04, Debian 12+,
-    # and any distro with GLIBC >= 2.35. Using ubuntu-latest (24.04) would
-    # require GLIBC 2.39 and break older LTS users.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: [unit, e2e]
     steps:
       - uses: actions/checkout@v5
@@ -216,16 +212,19 @@ jobs:
 
       - name: Sync versions from tag
         run: node scripts/version-sync.mjs --from-tag
+      
+      - name: Install cross
+        run: cargo install cross --version 0.2.5 --locked
 
-      # Native x64 build on Ubuntu runner — no cross-compilation needed.
-      # Uses gnu target (not musl) so dlopen works for ONNX Runtime loading.
+      # Use gnu target (not musl) so dlopen works for ONNX Runtime loading.
+      # musl produces static binaries where dlopen is a stub that always fails.
       - name: Build
-        run: cargo build --release
+        run: cross build --release --target x86_64-unknown-linux-gnu
 
       - uses: actions/upload-artifact@v4
         with:
           name: linux-x64
-          path: target/release/aft
+          path: target/x86_64-unknown-linux-gnu/release/aft
           if-no-files-found: error
 
   build-win32-x64:


### PR DESCRIPTION
Fixes #118


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784187362&installation_id=135454708&pr_number=119&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F119&signature=47690b2bee203521e070ee165cac8216bf7c2834d793b4067b58cd0212bfb84b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Linux x64 release build to `cross` using the gnu target. This gives consistent, containerized builds and keeps dlopen working for ONNX Runtime.

- **Refactors**
  - Use `ubuntu-latest` runner.
  - Install `cross` 0.2.5 and build with `cross build --release --target x86_64-unknown-linux-gnu`.
  - Upload artifact from target/x86_64-unknown-linux-gnu/release/aft.

<sup>Written for commit d420e34eb5c193302038bcb163eb67f125337f15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

