### PR TITLE
feat(plugin): support callgraph_store in schema and configure overrides

### DIFF
--- a/packages/opencode-plugin/src/config.ts
+++ b/packages/opencode-plugin/src/config.ts
@@ -286,6 +286,8 @@ export const AftConfigSchema = z
     search_index: z.boolean().optional(),
     /** Enable semantic search. Default: false. */
     semantic_search: z.boolean().optional(),
+    /** Enable the persisted callgraph store substrate. Default: true. */
+    callgraph_store: z.boolean().optional(),
     /** Codebase health inspection config. Enabled by default; set inspect.enabled=false to hide aft_inspect. */
     inspect: InspectConfigSchema.optional(),
     /**
@@ -452,6 +454,7 @@ export function resolveProjectOverridesForConfigure(config: AftConfig): Record<s
   // Indexed search and semantic search — both are per-project opt-ins.
   if (config.search_index !== undefined) overrides.search_index = config.search_index;
   if (config.semantic_search !== undefined) overrides.semantic_search = config.semantic_search;
+  if (config.callgraph_store !== undefined) overrides.callgraph_store = config.callgraph_store;
 
   // Bash / LSP / semantic / max_callgraph_files — all flow through dedicated
   // resolvers because they have their own merge / project-safety rules.


### PR DESCRIPTION
Expose the missing 'callgraph_store' configuration property in the TypeScript plugin. This allows users to disable the persistent call-graph store substrate in their configuration to prevent heavy CPU and RAM spikes on large directories.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784227273&installation_id=135454708&pr_number=121&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F121&signature=92b4cd93ed95339bb9c9eb132efe444e664c33a32e66c73616070084f9a48b28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose `callgraph_store` in the plugin config and pass it through `configure` overrides. This lets users disable the persisted call-graph store to avoid CPU/RAM spikes on large repos.

- **New Features**
  - Added optional `callgraph_store` (default: true) to the config schema.
  - Forwarded `callgraph_store` to `configure` overrides.

<sup>Written for commit 1d83b04683e7be75d31f7d635a8b9d1daa68a7d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

