### PR TITLE
Perl: switch to the more accurate ts-parser-perl grammar (~92% fewer parse failures)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,6 @@ dependencies = [
  "tree-sitter-lua",
  "tree-sitter-md",
  "tree-sitter-pascal",
- "tree-sitter-perl",
  "tree-sitter-php",
  "tree-sitter-python",
  "tree-sitter-r",
@@ -97,6 +96,7 @@ dependencies = [
  "tree-sitter-vue-next",
  "tree-sitter-yaml",
  "tree-sitter-zig",
+ "ts-parser-perl",
  "url",
  "which",
 ]
@@ -3541,17 +3541,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tree-sitter-perl"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79d4ae71b42e595c24c354b59905ade8162bd400ebc53ab916ea8aec54da92d"
-dependencies = [
- "cc",
- "tree-sitter",
- "tree-sitter-language",
-]
-
-[[package]]
 name = "tree-sitter-php"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3676,6 +3665,16 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "ts-parser-perl"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "720dcad2c9e8445465c98a7117574224bede0ee4168d081a37bfbad9699cd459"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "typenum"

--- a/crates/aft/Cargo.toml
+++ b/crates/aft/Cargo.toml
@@ -54,7 +54,10 @@ tree-sitter-kotlin-sg = "0.4"
 tree-sitter-swift = "0.7"
 tree-sitter-php = "0.24"
 tree-sitter-lua = "0.5"
-tree-sitter-perl = "1.1"
+# `ts-parser-perl` is the crate for github.com/tree-sitter-perl/tree-sitter-perl,
+# a substantially more accurate Perl grammar. The `package =` rename keeps the
+# `tree_sitter_perl` path working unchanged.
+tree-sitter-perl = { package = "ts-parser-perl", version = "1.1" }
 tree-sitter-pascal = "0.10.2"
 tree-sitter-r = "1.2.0"
 tree-sitter-yaml = "0.7"

--- a/crates/aft/src/calls.rs
+++ b/crates/aft/src/calls.rs
@@ -40,15 +40,7 @@ pub fn call_node_kinds(lang: LangId) -> Vec<&'static str> {
             "nullsafe_member_call_expression",
             "scoped_call_expression",
         ],
-        LangId::Perl => vec![
-            "call_expression_recursive",
-            "call_expression_with_args_with_brackets",
-            "call_expression_with_bareword",
-            "call_expression_with_spaced_args",
-            "call_expression_with_sub",
-            "call_expression_with_variable",
-            "method_invocation",
-        ],
+        LangId::Perl => vec!["function_call_expression", "method_call_expression"],
         LangId::Lua => vec!["function_call"],
         LangId::C | LangId::Cpp | LangId::Zig => vec!["call_expression"],
         LangId::CSharp => vec!["invocation_expression"],
@@ -206,6 +198,11 @@ fn callee_node<'a>(node: &tree_sitter::Node<'a>) -> Option<tree_sitter::Node<'a>
         "jsx_opening_element" | "jsx_self_closing_element" => node
             .child_by_field_name("name")
             .or_else(|| node.named_child(0)),
+        // Perl method call `$obj->method(...)`: the callee is the `method`
+        // field, not the leading invocant that `child(0)` would return.
+        "method_call_expression" => node
+            .child_by_field_name("method")
+            .or_else(|| node.child_by_field_name("function")),
         _ => node
             .child_by_field_name("function")
             .or_else(|| node.child(0)),

--- a/crates/aft/src/imports/perl.rs
+++ b/crates/aft/src/imports/perl.rs
@@ -41,19 +41,24 @@ pub(crate) fn parse_perl_imports(source: &str, tree: &Tree) -> ImportBlock {
 
 fn parse_perl_import_statement(source: &str, node: &Node) -> Option<ImportStatement> {
     match node.kind() {
-        "use_no_statement" => parse_perl_use_no_statement(source, node),
-        "use_parent_statement" => {
-            parse_perl_keyword_module_statement(source, node, PERL_USE_KIND, "parent")
+        // `use`/`no` pragmas — including `use parent ...` and `use constant ...`
+        // — all parse as a single `use_statement`. The leading `use`/`no`
+        // keyword carries the kind and the `module` field carries the pragma
+        // name ("parent", "constant", or an ordinary module), so no per-pragma
+        // special-casing is needed.
+        "use_statement" => parse_perl_use_statement(source, node),
+        // `require Foo;` parses as an expression statement wrapping a
+        // `require_expression`.
+        "expression_statement" => {
+            let require = find_direct_child(node, "require_expression")?;
+            let module_node = first_named_child(&require)?;
+            build_perl_import(source, node, &module_node, PERL_REQUIRE_KIND)
         }
-        "use_constant_statement" => {
-            parse_perl_keyword_module_statement(source, node, PERL_USE_KIND, "constant")
-        }
-        "require_statement" => parse_perl_require_statement(source, node),
         _ => None,
     }
 }
 
-fn parse_perl_use_no_statement(source: &str, node: &Node) -> Option<ImportStatement> {
+fn parse_perl_use_statement(source: &str, node: &Node) -> Option<ImportStatement> {
     let import_kind = if find_direct_child(node, PERL_USE_KIND).is_some() {
         PERL_USE_KIND
     } else if find_direct_child(node, PERL_NO_KIND).is_some() {
@@ -61,23 +66,8 @@ fn parse_perl_use_no_statement(source: &str, node: &Node) -> Option<ImportStatem
     } else {
         return None;
     };
-    let module_node = find_direct_child(node, "package_name")?;
+    let module_node = node.child_by_field_name("module")?;
     build_perl_import(source, node, &module_node, import_kind)
-}
-
-fn parse_perl_keyword_module_statement(
-    source: &str,
-    node: &Node,
-    import_kind: &str,
-    module_child_kind: &str,
-) -> Option<ImportStatement> {
-    let module_node = find_direct_child(node, module_child_kind)?;
-    build_perl_import(source, node, &module_node, import_kind)
-}
-
-fn parse_perl_require_statement(source: &str, node: &Node) -> Option<ImportStatement> {
-    let module_node = find_direct_child(node, "package_name")?;
-    build_perl_import(source, node, &module_node, PERL_REQUIRE_KIND)
 }
 
 fn build_perl_import(
@@ -93,8 +83,16 @@ fn build_perl_import(
 
     let raw_args = raw_args_after_module(source, statement, module_node)?;
     let modifiers = perl_arg_modifiers(&raw_args);
-    let raw_text = source[statement.byte_range()].to_string();
-    let byte_range = statement.byte_range();
+    // `use_statement` spans its own terminating `;`, but an `expression_statement`
+    // (e.g. `require Foo;`) does not — the `;` is a following sibling. Extend the
+    // range through it so organize/remove replaces the whole statement and leaves
+    // no stray semicolon behind.
+    let end_byte = match statement.next_sibling() {
+        Some(next) if next.kind() == ";" => next.end_byte(),
+        _ => statement.end_byte(),
+    };
+    let raw_text = source[statement.start_byte()..end_byte].to_string();
+    let byte_range = statement.start_byte()..end_byte;
     let group = classify_group_perl(&module_path);
 
     Some(ImportStatement {
@@ -148,6 +146,22 @@ fn find_direct_child<'tree>(node: &Node<'tree>, kind: &str) -> Option<Node<'tree
         loop {
             let child = cursor.node();
             if child.kind() == kind {
+                return Some(child);
+            }
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+    None
+}
+
+fn first_named_child<'tree>(node: &Node<'tree>) -> Option<Node<'tree>> {
+    let mut cursor = node.walk();
+    if cursor.goto_first_child() {
+        loop {
+            let child = cursor.node();
+            if child.is_named() {
                 return Some(child);
             }
             if !cursor.goto_next_sibling() {
@@ -272,9 +286,11 @@ mod tests {
     }
 
     /// Grammar fixture: lock the exact tree-sitter-perl node kinds this parser
-    /// depends on. The current grammar represents plain `use` and `no` pragmas
-    /// as `use_no_statement`, specialized pragmas as `use_parent_statement` /
-    /// `use_constant_statement`, and runtime requires as `require_statement`.
+    /// depends on. This grammar represents every `use`/`no` pragma (plain or
+    /// specialized like `use parent` / `use constant`) as a single
+    /// `use_statement` with a `module` field and a leading `use`/`no` keyword
+    /// token, and runtime `require` as an `expression_statement` wrapping a
+    /// `require_expression`.
     #[test]
     fn perl_grammar_node_kinds_are_stable() {
         let src = "use Foo::Bar;\nuse Foo qw(a b);\nuse parent -norequire, 'Base';\nuse constant PI => 3.14;\nrequire Foo;\nno warnings;\nno strict 'refs';\n";
@@ -298,20 +314,11 @@ mod tests {
 
         for required in [
             "source_file",
-            "use_no_statement",
-            "use_parent_statement",
-            "use_constant_statement",
-            "require_statement",
-            "package_name",
-            "word_list_qw",
-            "no_require",
-            "string_single_quoted",
-            "fat_comma",
-            "floating_point",
-            "parent",
-            "constant",
+            "use_statement",
+            "expression_statement",
+            "require_expression",
+            "package",
             "use",
-            "require",
             "no",
             ";",
         ] {

--- a/crates/aft/src/parser.rs
+++ b/crates/aft/src/parser.rs
@@ -598,17 +598,22 @@ const LUA_QUERY: &str = r#"
 const PERL_QUERY: &str = r#"
 ;; packages and subroutines
 (package_statement
-  (package_name) @package.name) @package.def
-(function_definition
-  name: (identifier) @fn.name) @fn.def
-(function_definition_without_sub
-  name: (identifier) @fn.name) @fn.def
+  name: (package) @package.name) @package.def
+(subroutine_declaration_statement
+  name: (bareword) @fn.name) @fn.def
+(method_declaration_statement
+  name: (bareword) @fn.name) @fn.def
 
-;; constants / lexical variables
-(use_constant_statement
-  constant: (identifier) @var.name) @var.def
+;; constants: `use constant NAME => ...;` — the `constant` pragma is filtered in
+;; Rust (the tree-sitter binding does not evaluate `#eq?` predicates).
+(use_statement
+  module: (package) @const.pragma
+  (list_expression (autoquoted_bareword) @const.name)) @const.def
+
+;; lexical / package variables: capture the sigil-bearing variable node so the
+;; symbol name matches `$counter`, not the bare `counter`.
 (variable_declaration
-  variable_name: (_) @var.name) @var.def
+  variable: (_) @var.name) @var.def
 "#;
 
 /// Supported language identifier.
@@ -5829,7 +5834,7 @@ fn perl_package_name(source: &str, node: &Node) -> Option<String> {
 
     loop {
         let child = cursor.node();
-        if child.kind() == "package_name" {
+        if child.kind() == "package" {
             return Some(node_text(source, &child).to_string());
         }
         if !cursor.goto_next_sibling() {
@@ -5887,6 +5892,9 @@ fn extract_perl_symbols(source: &str, root: &Node, query: &Query) -> Result<Vec<
         let mut fn_def_node = None;
         let mut var_name_node = None;
         let mut var_def_node = None;
+        let mut const_pragma_node = None;
+        let mut const_name_node = None;
+        let mut const_def_node = None;
 
         for cap in m.captures {
             let Some(&name) = capture_names.get(cap.index as usize) else {
@@ -5899,7 +5907,23 @@ fn extract_perl_symbols(source: &str, root: &Node, query: &Query) -> Result<Vec<
                 "fn.def" => fn_def_node = Some(cap.node),
                 "var.name" => var_name_node = Some(cap.node),
                 "var.def" => var_def_node = Some(cap.node),
+                "const.pragma" => const_pragma_node = Some(cap.node),
+                "const.name" => const_name_node = Some(cap.node),
+                "const.def" => const_def_node = Some(cap.node),
                 _ => {}
+            }
+        }
+
+        // `use constant NAME => ...;` defines a constant. Our grammar parses every
+        // `use`/`no` pragma as a generic `use_statement`, so gate on the pragma
+        // module text to avoid treating e.g. `use parent -norequire, ...` as a
+        // constant definition.
+        if let (Some(pragma_node), Some(name_node), Some(def_node)) =
+            (const_pragma_node, const_name_node, const_def_node)
+        {
+            if node_text(source, &pragma_node) == "constant" {
+                var_name_node = Some(name_node);
+                var_def_node = Some(def_node);
             }
         }
 


### PR DESCRIPTION
## What & why

aft's Perl support depends on the crates.io `tree-sitter-perl` crate, which is an **independent, older** Perl grammar by a different author. This PR switches to **[`ts-parser-perl`](https://crates.io/crates/ts-parser-perl)** — the crate for [`tree-sitter-perl/tree-sitter-perl`](https://github.com/tree-sitter-perl/tree-sitter-perl) — which parses real-world Perl far more accurately.

Benchmark on **8,342 real-world Perl files** (perl5 core + CPAN: DBIx-Class, Mojolicious, SpamAssassin, Bugzilla, …), files parsing with **no ERROR/MISSING nodes**:

| grammar | clean parse | failures |
|---|---|---|
| `ts-parser-perl` (this PR) | **95.4%** | 382 |
| `tree-sitter-perl` (current dep) | 40.2% | 4,983 |

(Curated 3,386-module gold corpus: 99.6% vs 73.9%.) For aft this is coverage, not just quality: an `ERROR` node makes that whole subtree untraversable, so on the ~60% of files the current grammar can't parse cleanly, the symbol/import/call extractors silently walk past everything underneath.

## Not a drop-in — the two grammars use different node names

The dependency itself is a Cargo **package-rename**, so the `tree_sitter_perl::LANGUAGE` path is unchanged:
```toml
tree-sitter-perl = { package = "ts-parser-perl", version = "1.1" }
```
But aft matches Perl node kinds directly, and those differ, so the extractors needed updating:

- **`parser.rs` `PERL_QUERY`** → `package_statement` / `subroutine_declaration_statement` / `method_declaration_statement`. `use constant` constants are captured and **gated on the pragma text in Rust** (the `tree-sitter` binding doesn't evaluate `#eq?` predicates, and `use parent -norequire, …` shares the same shape). The variable capture now keeps the sigil so the symbol is `$counter`, not `counter`.
- **`perl_package_name`** reads the `package` name node (was `package_name`) so subs inside a `package Foo;` are still classified as methods.
- **`imports/perl.rs`** — this grammar represents every `use`/`no` pragma (including `use parent` / `use constant`) as a single `use_statement` with a `use`/`no` keyword token and a `module` field, and runtime `require` as an `expression_statement` wrapping a `require_expression`. The parser was restructured accordingly. One subtlety handled: a `use_statement` spans its own `;` but an `expression_statement` does not (the `;` is a sibling), so the statement range is extended through a trailing `;` so organize/remove leave no stray semicolon.
- **`calls.rs`** → `function_call_expression` / `method_call_expression`; the method-call callee resolves via the `method` field.

## Testing

Built and ran the full `agent-file-tools` test suite locally:

- All Perl tests pass: `imports::perl::*` unit tests (including the rewritten grammar-node-kind stability fixture and `parse_perl_supported_forms` / round-trip), `outline_perl_symbols_include_packages_subroutines_constants_and_variables`, and the `import_golden_corpus` Perl scenarios (organize/add/remove) — the golden snapshots match unchanged, confirming behavior parity.
- No regressions elsewhere. (One pre-existing failure, `watcher_filter_tests::gitignore_write_rebuilds_before_filtering_same_batch_paths`, fails identically on a clean checkout of `main` in my environment — it's an inotify/gitignore timing test unrelated to this change.)

(Disclosure: I maintain `tree-sitter-perl/tree-sitter-perl`. The benchmark is reproducible — compile each grammar to a separate `.so` and parse the same corpus.)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784401780&installation_id=135454708&pr_number=126&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F126&signature=1fee4490e0c5d04936acfb7f2d185bf7e76d1f4154a8bd37106fa6e43e8f2eb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Perl parsing to `ts-parser-perl` for much higher accuracy (95.4% vs 40.2% clean parses across 8,342 files), recovering symbols/imports/calls previously lost to parse errors. This improves coverage on real-world Perl and reduces untraversable subtrees.

- **Refactors**
  - Dependencies: replace `tree-sitter-perl` with `ts-parser-perl` via Cargo package-rename; `tree_sitter_perl` path remains unchanged.
  - Symbols: update queries to `package_statement` (`package`), `subroutine_declaration_statement`, and `method_declaration_statement`; capture variables with the sigil; detect constants from `use constant NAME => ...` gated by pragma text.
  - Imports: unify all `use`/`no` as a single `use_statement` with a `module` field; parse `require Foo;` as an `expression_statement` wrapping `require_expression`; extend the statement range through a trailing `;` to avoid stray semicolons.
  - Calls: switch to `function_call_expression` and `method_call_expression`; resolve method callees via the `method` field.
  - Tests: all Perl tests pass; golden snapshots unchanged.

<sup>Written for commit 684dff3e216bd3db708001b9312ef257bb3246bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

