### PR TITLE
fix(aft-bridge): align PATH defaults to plugin

### DIFF
--- a/crates/aft/src/bash_background/mod.rs
+++ b/crates/aft/src/bash_background/mod.rs
@@ -159,7 +159,7 @@ pub fn storage_dir(configured: Option<&std::path::Path>) -> PathBuf {
     if let Some(dir) = std::env::var_os("AFT_CACHE_DIR") {
         return PathBuf::from(dir).join("aft");
     }
-    // Default to the CortexKit shared data root — the SAME location the
+    // Default to the CortexKit shared data root - the SAME location the
     // plugins inject as `storage_dir` on every configure. Before this, the
     // fallback was the pre-migration `~/.cache/aft`, which only plugin-less
     // invocations ever hit; once the daemon-supervised module became such an

--- a/crates/aft/src/cli/warmup.rs
+++ b/crates/aft/src/cli/warmup.rs
@@ -50,6 +50,12 @@ pub fn run(args: Vec<OsString>) -> Result<(), WarmupError> {
         );
     }
 
+    // Resolve ONNX Runtime from the plugin-managed cache so `aft warmup`
+    // can build the semantic index without the plugin setting ORT_DYLIB_PATH.
+    if args.areas.semantic {
+        try_set_ort_dylib_path(&storage_dir);
+    }
+
     let ctx = AppContext::new(Box::new(TreeSitterProvider::new()), Config::default());
     configure(&ctx, &root, &storage_dir, args.areas, args.force)?;
 
@@ -249,9 +255,30 @@ fn warmup_storage_dir() -> PathBuf {
     if let Some(value) = std::env::var_os("AFT_STORAGE_DIR") {
         return PathBuf::from(value);
     }
-    // Same CortexKit shared data root the plugins inject — warming here must
+    // Same CortexKit shared data root the plugins inject - warming here must
     // land in the storage universe real sessions will read from.
     aft::bash_background::storage_dir(None)
+}
+
+/// Set `ORT_DYLIB_PATH` from a cached ONNX Runtime library if not already set.
+fn try_set_ort_dylib_path(storage_dir: &std::path::Path) {
+    if std::env::var_os("ORT_DYLIB_PATH").is_some() {
+        return;
+    }
+    let lib_name = if cfg!(target_os = "macos") {
+        "libonnxruntime.dylib"
+    } else if cfg!(target_os = "windows") {
+        "onnxruntime.dll"
+    } else {
+        "libonnxruntime.so"
+    };
+    let ort_dir = storage_dir.join("onnxruntime").join("1.24.4");
+    for candidate in [ort_dir.join(lib_name), ort_dir.join("lib").join(lib_name)] {
+        if candidate.is_file() {
+            std::env::set_var("ORT_DYLIB_PATH", &candidate);
+            break;
+        }
+    }
 }
 
 /// Build the `configure` params for a warmup run.
@@ -898,5 +925,34 @@ mod tests {
         let err = WarmupArgs::parse(args(&["--root", "/tmp/x", "--only"])).unwrap_err();
         assert_eq!(err.exit_code(), 2);
         assert!(err.to_string().contains("--only requires a value"));
+    }
+
+    #[test]
+    fn try_set_ort_dylib_path_finds_cached_library() {
+        use std::sync::Mutex;
+        static LOCK: Mutex<()> = Mutex::new(());
+        let _guard = LOCK.lock().unwrap();
+        std::env::remove_var("ORT_DYLIB_PATH");
+
+        let temp = tempfile::tempdir().unwrap();
+        let lib_name = if cfg!(target_os = "macos") {
+            "libonnxruntime.dylib"
+        } else if cfg!(target_os = "windows") {
+            "onnxruntime.dll"
+        } else {
+            "libonnxruntime.so"
+        };
+        let ort_dir = temp.path().join("onnxruntime").join("1.24.4");
+        std::fs::create_dir_all(&ort_dir).unwrap();
+        let lib_path = ort_dir.join(lib_name);
+        std::fs::write(&lib_path, b"fake").unwrap();
+
+        try_set_ort_dylib_path(temp.path());
+
+        assert_eq!(
+            std::env::var_os("ORT_DYLIB_PATH"),
+            Some(lib_path.as_os_str().to_owned())
+        );
+        std::env::remove_var("ORT_DYLIB_PATH");
     }
 }


### PR DESCRIPTION
Fixes https://github.com/cortexkit/aft/issues/128

### What is this about?
Three functions defaulted to `~/.cache/aft` instead of the plugin's `~/.local/share/cortexkit/aft`, causing standalone `aft warmup` to write to a different path than the plugin. The fallback now mirrors `resolveCortexKitStorageRoot()` from the plugin.

`warmup.rs` also never set `ORT_DYLIB_PATH`, so semantic index warmup failed with `dlopen('libonnxruntime.so')`. Now resolves the cached library from `<storage_dir>/onnxruntime/1.24.4/` (and `lib/` subdir) if `ORT_DYLIB_PATH` is not already set.

### Hint
Currently, the version of _onnxruntime_ was hardcoded, so I didn't change this.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784422205&installation_id=135454708&pr_number=127&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F127&signature=27d171a773963b3d7aab30ad86ecbef3948d34678c7e3373fe474b8089532af4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns standalone storage defaults with the plugin so both use the same `cortexkit/aft` path. Also fixes semantic warmup by setting `ORT_DYLIB_PATH` from the cached ONNX Runtime when needed to avoid dlopen errors.

- **Bug Fixes**
  - Unified storage fallbacks to match the plugin’s `resolveCortexKitStorageRoot()`: prefer `XDG_DATA_HOME`; on Windows use `LOCALAPPDATA`/`APPDATA`; else `~/.local/share/cortexkit/aft` (Windows: `AppData/Local/cortexkit/aft`). Applied in `bash_background::storage_dir`, `warmup_storage_dir`, and `search_index::resolve_cache_dir`.
  - `aft warmup --semantic` now sets `ORT_DYLIB_PATH` if unset by locating the cached library under `<storage_dir>/onnxruntime/1.24.4/` (also checks `lib/`). Adds a unit test. Prevents `dlopen('libonnxruntime.*')`/missing DLL errors.

<sup>Written for commit 2c567b7e9ee81e0990ecac9708a30c6ff49ad80f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds `try_set_ort_dylib_path` to `aft warmup` so that standalone semantic warmup can find the ONNX Runtime library cached by the plugin without requiring `ORT_DYLIB_PATH` to be pre-set. A cosmetic comment change (em dash → hyphen) in `bash_background/mod.rs` is the only other diff.

- **`try_set_ort_dylib_path`**: probes `<storage_dir>/onnxruntime/1.24.4/` (and its `lib/` subdirectory) for the platform-appropriate library name and sets `ORT_DYLIB_PATH` if found; called only when `--semantic` is in scope, before `configure` runs.
- **Path alignment**: `warmup_storage_dir` already delegated to `bash_background::storage_dir(None)`; the underlying function resolves to `XDG_DATA_HOME`/`~/.local/share/cortexkit/aft` (or Windows `LOCALAPPDATA/cortexkit/aft`), matching `resolveCortexKitStorageRoot()` in the plugin.
- **Test coverage**: a new unit test verifies the happy-path probe using a temp directory with a synthetic library file and a static `Mutex` to avoid env-var races between parallel test threads.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge for users whose plugin has already downloaded the ONNX Runtime; the fix is a no-op when ORT_DYLIB_PATH is already set.

When aft warmup --semantic is run on a machine where the plugin has never downloaded the ONNX Runtime, try_set_ort_dylib_path silently exits without setting ORT_DYLIB_PATH and the subsequent configure call will still hit the same dlopen failure the PR intended to fix.

crates/aft/src/cli/warmup.rs — specifically the silent-return branch in try_set_ort_dylib_path when neither candidate path exists.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/aft/src/bash_background/mod.rs | Cosmetic comment change only — em dash replaced with hyphen, no functional change. |
| crates/aft/src/cli/warmup.rs | Adds try_set_ort_dylib_path to probe the plugin-cached ONNX Runtime library and set ORT_DYLIB_PATH before configure runs. Version string 1.24.4 is hardcoded and the function silently no-ops when the library is absent (both already flagged in prior review threads). |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant RunFn as run()
    participant WSD as warmup_storage_dir
    participant BSD as bash_background storage_dir
    participant TSOD as try_set_ort_dylib_path
    participant Cfg as configure

    User->>RunFn: aft warmup --semantic --root path
    RunFn->>WSD: resolve storage dir
    WSD->>BSD: storage_dir(None)
    BSD-->>WSD: XDG_DATA_HOME or ~/.local/share/cortexkit/aft
    WSD-->>RunFn: storage_dir PathBuf

    RunFn->>RunFn: set FASTEMBED_CACHE_DIR if unset
    RunFn->>TSOD: try_set_ort_dylib_path(storage_dir)
    alt ORT_DYLIB_PATH already set
        TSOD-->>RunFn: return (no-op)
    else not set
        TSOD->>TSOD: "probe onnxruntime/1.24.4/libonnxruntime.*"
        TSOD->>TSOD: "probe onnxruntime/1.24.4/lib/libonnxruntime.*"
        alt library file found
            TSOD-->>RunFn: set ORT_DYLIB_PATH
        else not found
            TSOD-->>RunFn: return silently (no diagnostic)
        end
    end

    RunFn->>Cfg: configure(ctx, root, storage_dir, areas, force)
    Cfg-->>RunFn: Result
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant RunFn as run()
    participant WSD as warmup_storage_dir
    participant BSD as bash_background storage_dir
    participant TSOD as try_set_ort_dylib_path
    participant Cfg as configure

    User->>RunFn: aft warmup --semantic --root path
    RunFn->>WSD: resolve storage dir
    WSD->>BSD: storage_dir(None)
    BSD-->>WSD: XDG_DATA_HOME or ~/.local/share/cortexkit/aft
    WSD-->>RunFn: storage_dir PathBuf

    RunFn->>RunFn: set FASTEMBED_CACHE_DIR if unset
    RunFn->>TSOD: try_set_ort_dylib_path(storage_dir)
    alt ORT_DYLIB_PATH already set
        TSOD-->>RunFn: return (no-op)
    else not set
        TSOD->>TSOD: "probe onnxruntime/1.24.4/libonnxruntime.*"
        TSOD->>TSOD: "probe onnxruntime/1.24.4/lib/libonnxruntime.*"
        alt library file found
            TSOD-->>RunFn: set ORT_DYLIB_PATH
        else not found
            TSOD-->>RunFn: return silently (no diagnostic)
        end
    end

    RunFn->>Cfg: configure(ctx, root, storage_dir, areas, force)
    Cfg-->>RunFn: Result
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["fix: align standalone storage dir fallba..."](https://github.com/cortexkit/aft/commit/2c567b7e9ee81e0990ecac9708a30c6ff49ad80f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38562786)</sub>

<!-- /greptile_comment -->