### PR TITLE
fix(edit_match): prefer literal paths over glob

### DIFF
--- a/crates/aft/src/commands/edit_match.rs
+++ b/crates/aft/src/commands/edit_match.rs
@@ -82,8 +82,12 @@ pub fn handle_edit_match(req: &RawRequest, ctx: &AppContext) -> Response {
     // sequences before the string reaches us. Adding unescape_str on top caused
     // double-interpretation that corrupted source code with literal escapes.
 
-    // Detect glob pattern
-    if is_glob_pattern(file) {
+    // Detect glob pattern. Prefer the literal interpretation when the path
+    // already exists on disk, even if its name contains glob metacharacters
+    // such as `[`, `]`, `*`, `?`, or `{`. This prevents files in directories
+    // with brackets (e.g. `src/[another]/file.rs`) from being misclassified as
+    // globs.
+    if should_treat_as_glob(file, ctx) {
         return handle_glob_edit_match(req, ctx, file, match_str, replacement, &op_id);
     }
 
@@ -366,6 +370,36 @@ fn handle_append(req: &RawRequest, ctx: &AppContext, op_id: &str) -> Response {
 /// Returns true if the file path contains glob characters.
 fn is_glob_pattern(path: &str) -> bool {
     path.contains('*') || path.contains('?') || path.contains('{') || path.contains('[')
+}
+
+/// Returns true when `file` should be treated as a glob pattern rather than a
+/// literal path. A path that exists on disk is always treated literally, even
+/// if its name contains glob metacharacters such as `[`, `]`, `*`, `?`, or `{`.
+/// This defends against directories or files with brackets in their
+/// names being misclassified as glob patterns (see issue #132).
+///
+/// Resolution mirrors `ctx.validate_path` so the literal-vs-glob decision stays
+/// consistent with the single-file path handler's interpretation.
+fn should_treat_as_glob(file: &str, ctx: &AppContext) -> bool {
+    if !is_glob_pattern(file) {
+        return false;
+    }
+    match ctx.validate_path("literal-check", Path::new(file)) {
+        Ok(candidate) => !candidate.exists(),
+        Err(resp)
+            if resp.data.get("code").and_then(|c| c.as_str()) == Some("path_outside_root") =>
+        {
+            false
+        }
+        Err(resp) => {
+            log::debug!(
+                "edit_match: validate_path failed for '{}', treating as glob: {:?}",
+                file,
+                resp.data
+            );
+            true
+        }
+    }
 }
 
 /// Handle a glob-based multi-file edit_match.

--- a/crates/aft/src/commands/edit_match.rs
+++ b/crates/aft/src/commands/edit_match.rs
@@ -393,11 +393,11 @@ fn should_treat_as_glob(file: &str, ctx: &AppContext) -> bool {
         }
         Err(resp) => {
             log::debug!(
-                "edit_match: validate_path failed for '{}', treating as glob: {:?}",
+                "edit_match: validate_path failed for '{}', deferring to single-file handler: {:?}",
                 file,
                 resp.data
             );
-            true
+            false
         }
     }
 }

--- a/crates/aft/tests/integration/edit_test.rs
+++ b/crates/aft/tests/integration/edit_test.rs
@@ -814,6 +814,150 @@ fn edit_match_no_match() {
     assert!(status.success());
 }
 
+// Regression for #132: edit_match must treat literal paths with brackets as
+// single-file edits, not glob patterns. Brackets (`[]`) are glob metacharacters,
+// so the old character-detection heuristic misclassified real file paths.
+#[test]
+fn edit_match_handles_brackets_in_literal_path() {
+    let mut aft = AftProcess::spawn();
+    let dir = tempfile::tempdir().unwrap();
+    let subdir = dir.path().join("[another]");
+    fs::create_dir_all(&subdir).unwrap();
+    let target = subdir.join("file.ts");
+    fs::write(&target, "const value = OLD;\n").unwrap();
+
+    let req = serde_json::json!({
+        "id": "em-brackets",
+        "command": "edit_match",
+        "file": target.display().to_string(),
+        "match": "OLD",
+        "replacement": "NEW"
+    });
+    let resp = aft.send(&serde_json::to_string(&req).unwrap());
+
+    assert_eq!(
+        resp["success"], true,
+        "edit_match should succeed for path with brackets: {:?}",
+        resp
+    );
+    assert_eq!(resp["replacements"], 1);
+    let content = fs::read_to_string(&target).unwrap();
+    assert!(
+        content.contains("NEW"),
+        "replacement should apply: {}",
+        content
+    );
+    assert!(
+        !content.contains("OLD"),
+        "original text should be gone: {}",
+        content
+    );
+
+    let status = aft.shutdown();
+    assert!(status.success());
+}
+
+// Sanity check: parentheses are also called out in the issue, but they are
+// not glob metacharacters, so they were never misclassified. This test only
+// ensures literal paths containing them remain single-file edits.
+#[test]
+fn edit_match_handles_parentheses_in_literal_path() {
+    let mut aft = AftProcess::spawn();
+    let dir = tempfile::tempdir().unwrap();
+    let subdir = dir.path().join("(something)");
+    fs::create_dir_all(&subdir).unwrap();
+    let target = subdir.join("file.ts");
+    fs::write(&target, "const value = OLD;\n").unwrap();
+
+    let req = serde_json::json!({
+        "id": "em-parens",
+        "command": "edit_match",
+        "file": target.display().to_string(),
+        "match": "OLD",
+        "replacement": "NEW"
+    });
+    let resp = aft.send(&serde_json::to_string(&req).unwrap());
+
+    assert_eq!(
+        resp["success"], true,
+        "edit_match should succeed for path with parentheses: {:?}",
+        resp
+    );
+    assert_eq!(resp["replacements"], 1);
+    let content = fs::read_to_string(&target).unwrap();
+    assert!(
+        content.contains("NEW"),
+        "replacement should apply: {}",
+        content
+    );
+    assert!(
+        !content.contains("OLD"),
+        "original text should be gone: {}",
+        content
+    );
+
+    let status = aft.shutdown();
+    assert!(status.success());
+}
+
+// Regression for #132: relative paths with brackets must also be treated as
+// literal single-file edits when resolved against the configured project root.
+#[test]
+fn edit_match_handles_brackets_in_relative_literal_path() {
+    let mut aft = AftProcess::spawn();
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let subdir = root.join("[another]");
+    fs::create_dir_all(&subdir).unwrap();
+    let target = subdir.join("file.ts");
+    fs::write(&target, "const value = OLD;\n").unwrap();
+
+    let configure = aft.send(
+        &serde_json::json!({
+            "id": "cfg-restrict",
+            "command": "configure",
+            "harness": "opencode",
+            "project_root": root.to_string_lossy(),
+            "config": user_config(serde_json::json!({ "restrict_to_project_root": true }))
+        })
+        .to_string(),
+    );
+    assert_eq!(
+        configure["success"], true,
+        "configure should succeed: {configure:?}"
+    );
+
+    let req = serde_json::json!({
+        "id": "em-brackets-relative",
+        "command": "edit_match",
+        "file": "[another]/file.ts",
+        "match": "OLD",
+        "replacement": "NEW"
+    });
+    let resp = aft.send(&serde_json::to_string(&req).unwrap());
+
+    assert_eq!(
+        resp["success"], true,
+        "edit_match should succeed for relative path with brackets: {:?}",
+        resp
+    );
+    assert_eq!(resp["replacements"], 1);
+    let content = fs::read_to_string(&target).unwrap();
+    assert!(
+        content.contains("NEW"),
+        "replacement should apply: {}",
+        content
+    );
+    assert!(
+        !content.contains("OLD"),
+        "original text should be gone: {}",
+        content
+    );
+
+    let status = aft.shutdown();
+    assert!(status.success());
+}
+
 // ============================================================================
 // batch command tests
 // ============================================================================


### PR DESCRIPTION
Fixes https://github.com/cortexkit/aft/issues/132

### What and why?
Existing paths with brackets are now treated as literal files instead of glob patterns. Falls back to glob when the path doesn't exist or validation fails.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784504360&installation_id=135454708&pr_number=133&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F133&signature=a4c8198816925803532a5e6e01cfe9c2c45445b9465f5124e4fc32820ad739cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer literal paths over globs in `edit_match` when the path exists on disk, even if it contains [ ] * ? { }. Use glob only when the path doesn’t exist.

- **Bug Fixes**
  - Added `should_treat_as_glob`: prefer literal when `validate_path` resolves an existing path; on `validate_path` errors (including `path_outside_root` and unknown), defer to the single-file flow so errors surface correctly.
  - Added regression tests for bracketed literal paths (absolute and relative) and a sanity test for parentheses.

<sup>Written for commit d3d29ebfdf090d47ae92e454683b73896d96e945. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes issue #132 by introducing `should_treat_as_glob`, which preferentially interprets a path containing glob metacharacters (`[`, `]`, `*`, `?`, `{`) as a literal file path when `validate_path` can resolve it to an existing path on disk, falling back to glob routing only when the resolved candidate does not exist.

- **`should_treat_as_glob`** replaces the old `is_glob_pattern` check at the dispatch point; it calls `validate_path` first and only returns `true` (route to glob handler) when the literal path is confirmed absent. Both `path_outside_root` errors and unknown validation errors defer to `handle_single_file_edit_match` so real errors surface properly.
- **Three new integration tests** cover absolute bracketed paths, relative bracketed paths (with project-root restriction), and a parentheses sanity-check.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrow and well-tested, and the previous thread's fail-safe concern has already been addressed.

The new `should_treat_as_glob` function correctly gates on `validate_path` before deciding literal-vs-glob, three integration tests exercise the key paths, and the earlier reviewer concern about unknown errors being silently promoted to glob has already been fixed in a follow-up commit.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/aft/src/commands/edit_match.rs | Adds `should_treat_as_glob` to prefer literal path resolution over glob matching when the file exists on disk; logic and error handling look correct. |
| crates/aft/tests/integration/edit_test.rs | Adds three integration tests covering bracketed absolute paths, relative paths with project-root restriction, and a parentheses sanity-check; coverage is appropriate for the fix. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[handle_edit_match] --> B{op == append?}
    B -->|yes| C[handle_append]
    B -->|no| D[should_treat_as_glob]
    D --> E{is_glob_pattern?}
    E -->|no| F[false → single-file]
    E -->|yes| G[ctx.validate_path]
    G -->|Ok candidate| H{candidate.exists?}
    H -->|yes| I[false → single-file]
    H -->|no| J[true → glob]
    G -->|Err path_outside_root| K[false → single-file]
    G -->|Err other| L[log debug, false → single-file]
    F --> M[handle_single_file_edit_match]
    I --> M
    K --> M
    L --> M
    J --> N[handle_glob_edit_match]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[handle_edit_match] --> B{op == append?}
    B -->|yes| C[handle_append]
    B -->|no| D[should_treat_as_glob]
    D --> E{is_glob_pattern?}
    E -->|no| F[false → single-file]
    E -->|yes| G[ctx.validate_path]
    G -->|Ok candidate| H{candidate.exists?}
    H -->|yes| I[false → single-file]
    H -->|no| J[true → glob]
    G -->|Err path_outside_root| K[false → single-file]
    G -->|Err other| L[log debug, false → single-file]
    F --> M[handle_single_file_edit_match]
    I --> M
    K --> M
    L --> M
    J --> N[handle_glob_edit_match]
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(edit\_match): fail-safe on unknown va..."](https://github.com/cortexkit/aft/commit/d3d29ebfdf090d47ae92e454683b73896d96e945) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38751598)</sub>

<!-- /greptile_comment -->