### PR TITLE
fix(compress): align byte-tail reads to UTF-8 boundaries

### DIFF
--- a/crates/aft/src/bash_background/buffer.rs
+++ b/crates/aft/src/bash_background/buffer.rs
@@ -79,6 +79,7 @@ impl BgBuffer {
                         if was_over_cap {
                             let keep_from = output.len().saturating_sub(max_bytes);
                             output.drain(..keep_from);
+                            output = align_start_to_utf8(output);
                         }
                         (
                             String::from_utf8_lossy(&output).into_owned(),
@@ -269,7 +270,11 @@ pub(crate) fn read_file_tail(path: &Path, max_bytes: usize) -> io::Result<(Vec<u
     }
     let mut bytes = Vec::with_capacity(read_len as usize);
     file.read_to_end(&mut bytes)?;
-    Ok((bytes, len > max_bytes as u64))
+    let truncated = len > max_bytes as u64;
+    if truncated {
+        bytes = align_start_to_utf8(bytes);
+    }
+    Ok((bytes, truncated))
 }
 
 fn read_file_bounded(path: &Path, max_bytes: usize) -> io::Result<BoundedRead> {
@@ -405,6 +410,10 @@ fn read_file_range(path: &Path, start: u64, len: u64) -> io::Result<Vec<u8>> {
     let mut limited = file.take(len);
     let mut bytes = Vec::with_capacity(len as usize);
     limited.read_to_end(&mut bytes)?;
+    if start > 0 {
+        bytes = align_start_to_utf8(bytes);
+    }
+    bytes = align_end_to_utf8(bytes);
     Ok(bytes)
 }
 
@@ -434,6 +443,7 @@ fn truncate_front(path: &Path, retain_bytes: u64) -> io::Result<bool> {
     file.seek(SeekFrom::End(-(retain_bytes as i64)))?;
     let mut tail = Vec::with_capacity(retain_bytes as usize);
     file.read_to_end(&mut tail)?;
+    let tail = align_start_to_utf8(tail);
     let tmp = path.with_extension(format!(
         "{}.tmp",
         path.extension()
@@ -443,4 +453,184 @@ fn truncate_front(path: &Path, retain_bytes: u64) -> io::Result<bool> {
     fs::write(&tmp, tail)?;
     fs::rename(&tmp, path)?;
     Ok(true)
+}
+
+fn align_start_to_utf8(mut bytes: Vec<u8>) -> Vec<u8> {
+    let mut start = 0;
+    while start < bytes.len() && (bytes[start] & 0xC0) == 0x80 {
+        start += 1;
+    }
+    if start > 0 {
+        bytes.drain(..start);
+    }
+    bytes
+}
+
+fn align_end_to_utf8(mut bytes: Vec<u8>) -> Vec<u8> {
+    while !bytes.is_empty() {
+        let last = bytes.len() - 1;
+        if bytes[last] < 0x80 {
+            break;
+        }
+        let lead_pos = if (bytes[last] & 0xC0) == 0x80 {
+            let mut pos = last;
+            while pos > 0 && (bytes[pos] & 0xC0) == 0x80 {
+                pos -= 1;
+            }
+            if (bytes[pos] & 0xC0) == 0xC0 {
+                pos
+            } else {
+                bytes.pop();
+                continue;
+            }
+        } else {
+            last
+        };
+        let lead = bytes[lead_pos];
+        debug_assert!(lead >= 0xC0, "lead byte must be >= 0xC0, got {lead:#x}");
+        let expected = if lead < 0xE0 {
+            1
+        } else if lead < 0xF0 {
+            2
+        } else {
+            3
+        };
+        if last - lead_pos >= expected {
+            break;
+        }
+        bytes.truncate(lead_pos);
+    }
+    bytes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- Regression tests for UTF-8 splitting at byte boundaries ---
+    // CORRECT behavior: read_file_tail should not split UTF-8 characters.
+    // These tests FAIL when the bug is present.
+
+    #[test]
+    fn read_file_tail_should_not_split_utf8_character() {
+        // "AAAA€" = 7 bytes (4 ASCII + 3-byte €).
+        // 2-byte tail reads bytes [5,6] = 0x82 0xAC - incomplete trailing
+        // bytes of €. from_utf8_lossy produces U+FFFD.
+        // CORRECT: no replacement character should appear.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stdout");
+        std::fs::write(&path, "AAAA€".as_bytes()).unwrap();
+        let (bytes, _truncated) = read_file_tail(&path, 2).unwrap();
+        let text = String::from_utf8_lossy(&bytes);
+        assert!(
+            !text.contains('\u{FFFD}'),
+            "read_file_tail should not produce replacement characters, got: {:?}",
+            text
+        );
+    }
+
+    #[test]
+    fn truncate_front_should_not_split_utf8_character() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stdout");
+        std::fs::write(&path, "AAAA€".as_bytes()).unwrap();
+        truncate_front(&path, 2).unwrap();
+        let bytes = std::fs::read(&path).unwrap();
+        let text = String::from_utf8_lossy(&bytes);
+        assert!(
+            !text.contains('\u{FFFD}'),
+            "truncate_front should not produce replacement characters, got: {:?}",
+            text
+        );
+    }
+
+    #[test]
+    fn read_file_tail_should_not_split_4byte_utf8() {
+        // "AAAA😀" = 4 + 4 = 8 bytes. 2-byte tail reads bytes [6,7] = incomplete.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stdout");
+        std::fs::write(&path, "AAAA😀".as_bytes()).unwrap();
+        let (bytes, _truncated) = read_file_tail(&path, 2).unwrap();
+        let text = String::from_utf8_lossy(&bytes);
+        assert!(
+            !text.contains('\u{FFFD}'),
+            "read_file_tail should not produce replacement characters for 4-byte chars, got: {:?}",
+            text
+        );
+    }
+
+    #[test]
+    fn read_file_range_end_boundary_should_not_split_utf8() {
+        // "AAAA€" = 7 bytes. read_file_range(path, 0, 5) reads bytes [0..5].
+        // byte 4 = 0xE2 (lead of €), byte 5 = 0x82 (continuation) — not included.
+        // End at byte 5 splits after the lead byte. align_end_to_utf8 should trim it.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stdout");
+        std::fs::write(&path, "AAAA€".as_bytes()).unwrap();
+        let bytes = read_file_range(&path, 0, 5).unwrap();
+        let text = String::from_utf8_lossy(&bytes);
+        assert!(
+            !text.contains('\u{FFFD}'),
+            "read_file_range should not produce replacement characters at end boundary, got: {:?}",
+            text
+        );
+    }
+
+    #[test]
+    fn ascii_content_unaffected_by_alignment() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stdout");
+        let content = b"hello world\nline two\n";
+        std::fs::write(&path, content).unwrap();
+        let (bytes, truncated) = read_file_tail(&path, 10).unwrap();
+        assert!(truncated);
+        assert_eq!(bytes, b"\nline two\n");
+    }
+
+    #[test]
+    fn read_file_range_start_boundary_should_not_split_utf8() {
+        // "Hello€World" = 5 + 3 + 5 = 13 bytes.
+        // read_file_range(path, 5, 4) reads bytes [5..9]:
+        // bytes 5-7 = € (0xE2 0x82 0xAC), byte 8 = 'W'.
+        // Start at byte 5 = 0xE2 (lead byte) — aligned, no split.
+        // End at byte 9 = 'o' — aligned, no split.
+        // But read_file_range(path, 6, 2) reads bytes [6..8]:
+        // byte 6 = 0x82 (continuation), byte 7 = 0xAC (continuation).
+        // Start at byte 6 splits inside €. align_start_to_utf8 should skip.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stdout");
+        std::fs::write(&path, b"Hello\xe2\x82\xacWorld").unwrap();
+        let bytes = read_file_range(&path, 6, 2).unwrap();
+        let text = String::from_utf8_lossy(&bytes);
+        assert!(
+            !text.contains('\u{FFFD}'),
+            "read_file_range with start>0 should not produce replacement characters, got: {:?}",
+            text
+        );
+    }
+
+    // --- Regression test for stdout/stderr interleaving ---
+    // This test documents the limitation: stdout always comes before stderr
+    // in the combined output, regardless of temporal write order.
+    // It does not assert correct interleaving (that would require a redesign)
+    // but verifies the current behavior is what we expect.
+
+    #[test]
+    fn read_tail_puts_stdout_before_stderr() {
+        // Write stdout and stderr to separate files, then verify
+        // the combined output has stdout content before stderr content.
+        let dir = tempfile::tempdir().unwrap();
+        let stdout_path = dir.path().join("stdout");
+        let stderr_path = dir.path().join("stderr");
+        std::fs::write(&stdout_path, b"stdout-line\n").unwrap();
+        std::fs::write(&stderr_path, b"stderr-line\n").unwrap();
+        let buffer = BgBuffer::new(stdout_path, stderr_path);
+        let (text, _) = buffer.read_tail(1024);
+        let stdout_pos = text.find("stdout-line").unwrap();
+        let stderr_pos = text.find("stderr-line").unwrap();
+        assert!(
+            stdout_pos < stderr_pos,
+            "stdout should come before stderr in combined output"
+        );
+    }
 }


### PR DESCRIPTION
Fixes #138

## Summary

`read_file_tail`, `truncate_front`, and `read_file_range` in `bash_background/buffer.rs` seeked to arbitrary byte offsets without UTF-8 alignment. When the offset landed inside a multi-byte sequence, `String::from_utf8_lossy` replaced the incomplete bytes with U+FFFD. The same issue affected the `BgBuffer::read_tail` combined-drain path.

## Problem

These functions read raw bytes from files at byte boundaries determined by file size and read limits. `String::from_utf8_lossy` then decodes the bytes, replacing any incomplete multi-byte sequence with U+FFFD. For a 3-byte character like the euro sign, a 2-byte tail read produces two replacement characters, corrupting the visible output.

## Changes

- Add `align_start_to_utf8`: skips leading continuation bytes (`0b10xxxxxx`) until a lead byte is found.
- Add `align_end_to_utf8`: scans backward from the end, trims incomplete trailing multi-byte sequences.
- Apply both helpers in `read_file_tail` (start only), `truncate_front` (start only), `read_file_range` (start + end), and `read_tail` drain path (start).

## Verification

- `cargo test -- bash_background::buffer::tests` -- 8 passed, 0 failed
- `cargo check --workspace` -- clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784876935&installation_id=135454708&pr_number=139&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F139&signature=e0b7c486f635459ade890952e69a56b5db8713679c48e3e9743dbda5dd1323b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns byte-based reads to UTF-8 boundaries to prevent splitting multi-byte characters and showing � in output. Fixes corrupted tails and ranges in log reads and truncation.

- **Bug Fixes**
  - Added align_start_to_utf8 and align_end_to_utf8 to skip leading continuation bytes and drop incomplete trailing sequences.
  - Applied start alignment in read_file_tail, truncate_front, and BgBuffer::read_tail combined-drain; applied start+end alignment in read_file_range.
  - Added regression tests for euro sign and 4-byte emoji; ASCII unchanged. Documented stdout-before-stderr ordering in a test.

<sup>Written for commit 5f91b16c0f1a05ba139b847f2c60b1c72d46d8f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes UTF-8 corruption in the bash background buffer's tail-read and range-read paths, where seeking to an arbitrary byte offset could land inside a multi-byte sequence and cause `String::from_utf8_lossy` to emit `U+FFFD` replacement characters.

- Adds `align_start_to_utf8` (strips leading continuation bytes) and `align_end_to_utf8` (trims incomplete trailing multi-byte sequences), and applies both helpers at every byte-level read boundary in `read_file_tail`, `truncate_front`, `read_file_range`, and the combined-drain path of `BgBuffer::read_tail`.
- Regression tests cover the 3-byte euro sign, 4-byte emoji, pure-ASCII content (no-op verification), and the combined stdout-before-stderr ordering invariant.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the alignment helpers are correct for all reachable code paths and the fix is well-tested with regression cases.

Both helpers are algorithmically correct: align_start_to_utf8 stops at the first non-continuation byte, and align_end_to_utf8 correctly counts expected continuation bytes per lead-byte class before deciding whether to truncate. The only edge-case concern (O(n) pop loop for an all-continuation-byte buffer) was already raised in a prior review. The new truncated-byte-count inaccuracy in join_head_tail_bytes is off by at most 6 bytes and is purely cosmetic.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/aft/src/bash_background/buffer.rs | Adds align_start_to_utf8 / align_end_to_utf8 helpers and applies them at every byte-level read boundary; regression tests cover 3-byte €, 4-byte emoji, ASCII, and combined stdout+stderr paths. One minor inaccuracy: truncated byte count in join_head_tail_bytes uses pre-alignment lengths rather than post-alignment slice lengths. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(compress): align byte-tail reads to ..."](https://github.com/cortexkit/aft/commit/5f91b16c0f1a05ba139b847f2c60b1c72d46d8f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39490684)</sub>

<!-- /greptile_comment -->