### PR TITLE
fix(compress): pipe-aware dispatch and shell-boundary guards

### DIFF
--- a/crates/aft/src/compress/cargo.rs
+++ b/crates/aft/src/compress/cargo.rs
@@ -56,6 +56,9 @@ fn cargo_subcommand(command: &str) -> Option<String> {
         if token.starts_with('-') {
             continue;
         }
+        if crate::compress::is_shell_boundary(token) {
+            return None;
+        }
         return Some(token.to_string());
     }
     None
@@ -269,5 +272,20 @@ mod tests {
         assert!(!result.text.contains("---- case_20 stdout ----"));
         assert!(result.had_inner_drop);
         assert!(!result.offset_hint_eligible);
+    }
+
+    #[test]
+    fn cargo_subcommand_returns_none_for_pipe_before_subcommand() {
+        assert_eq!(cargo_subcommand("cargo --verbose | grep error"), None);
+    }
+
+    #[test]
+    fn cargo_subcommand_returns_subcommand_when_before_pipe() {
+        assert_eq!(cargo_subcommand("cargo test | grep FAIL").as_deref(), Some("test"));
+    }
+
+    #[test]
+    fn cargo_subcommand_unaffected_without_metacharacters() {
+        assert_eq!(cargo_subcommand("cargo test --release").as_deref(), Some("test"));
     }
 }

--- a/crates/aft/src/compress/git.rs
+++ b/crates/aft/src/compress/git.rs
@@ -74,6 +74,9 @@ fn git_subcommand(command: &str) -> Option<String> {
         if token.starts_with('-') || token.contains('=') {
             continue;
         }
+        if crate::compress::is_shell_boundary(token) {
+            return None;
+        }
         return Some(token.to_string());
     }
     None
@@ -98,6 +101,9 @@ fn git_subcommand_after(command: &str, subcommand: &str) -> Option<String> {
         }
         if token.starts_with('-') || token.contains('=') {
             continue;
+        }
+        if crate::compress::is_shell_boundary(token) {
+            return None;
         }
         return Some(token.to_string());
     }
@@ -939,5 +945,46 @@ mod tests {
         assert!(compressed.contains("UNIQUE_BODY_MARKER_needle_xyz"));
         assert!(!compressed.contains("... more commits"));
         assert!(compressed.len() < raw.len());
+    }
+
+    #[test]
+    fn git_subcommand_returns_none_for_pipe_before_subcommand() {
+        assert_eq!(git_subcommand("git --no-pager | grep log"), None);
+    }
+
+    #[test]
+    fn git_subcommand_returns_subcommand_when_before_pipe() {
+        assert_eq!(git_subcommand("git log | grep fix").as_deref(), Some("log"));
+    }
+
+    #[test]
+    fn git_subcommand_returns_none_for_redirect_before_subcommand() {
+        assert_eq!(git_subcommand("git --no-pager > out.log"), None);
+    }
+
+    #[test]
+    fn git_subcommand_unaffected_without_metacharacters() {
+        assert_eq!(git_subcommand("git log --oneline").as_deref(), Some("log"));
+    }
+
+    #[test]
+    fn git_subcommand_after_returns_none_for_pipe() {
+        assert_eq!(git_subcommand_after("git stash | grep outputs", "stash"), None);
+    }
+
+    #[test]
+    fn git_subcommand_after_returns_action_when_before_pipe() {
+        assert_eq!(
+            git_subcommand_after("git stash list | grep wip", "stash").as_deref(),
+            Some("list")
+        );
+    }
+
+    #[test]
+    fn git_subcommand_after_unaffected_without_metacharacters() {
+        assert_eq!(
+            git_subcommand_after("git stash drop", "stash").as_deref(),
+            Some("drop")
+        );
     }
 }

--- a/crates/aft/src/compress/go.rs
+++ b/crates/aft/src/compress/go.rs
@@ -119,7 +119,11 @@ fn looks_like_golangci_json_root(output: &str) -> bool {
 }
 
 fn go_subcommand(command: &str) -> Option<String> {
-    command.split_whitespace().nth(1).map(|s| s.to_string())
+    command
+        .split_whitespace()
+        .nth(1)
+        .filter(|s| !crate::compress::is_shell_boundary(s))
+        .map(|s| s.to_string())
 }
 
 fn compress_test(output: &str) -> String {
@@ -550,5 +554,20 @@ src/bar.go:3:8: ineffectual assignment (ineffassign)
         assert!(compressed.contains("fail_test.go:10"));
         assert!(compressed.contains("FAIL\texample.com/pkg\t0.999s"));
         assert!(compressed.len() * 10 < raw.len());
+    }
+
+    #[test]
+    fn go_subcommand_returns_none_for_pipe_as_second_token() {
+        assert_eq!(go_subcommand("go | grep x"), None);
+    }
+
+    #[test]
+    fn go_subcommand_returns_subcommand_when_before_pipe() {
+        assert_eq!(go_subcommand("go test | grep FAIL").as_deref(), Some("test"));
+    }
+
+    #[test]
+    fn go_subcommand_unaffected_without_metacharacters() {
+        assert_eq!(go_subcommand("go build ./...").as_deref(), Some("build"));
     }
 }

--- a/crates/aft/src/compress/mod.rs
+++ b/crates/aft/src/compress/mod.rs
@@ -623,7 +623,95 @@ pub fn normalize_command_for_dispatch(command: &str) -> Option<String> {
     }
 
     if changed {
+        if let Some(last) = split_on_top_level_pipe(&current) {
+            return Some(last);
+        }
         Some(current)
+    } else {
+        split_on_top_level_pipe(command)
+    }
+}
+
+/// Returns true if the token is a shell metacharacter that acts as a
+/// command boundary (`|`, `;`, `&&`, `||`, `>`, `<`). Subcommand parsers
+/// use this to avoid returning these as subcommand names.
+pub fn is_shell_boundary(token: &str) -> bool {
+    matches!(token, "|" | ";" | "&&" | "||" | ">" | "<")
+}
+
+/// Quote-aware splitter that returns the last stage after a top-level `|`.
+/// Handles single quotes, double quotes, and backslash escapes. Bails
+/// (returns `None`) on backticks, `$()` command substitution, and
+/// process substitution `<(` / `>(` so callers fall back to generic handling.
+fn split_on_top_level_pipe(command: &str) -> Option<String> {
+    let bytes = command.as_bytes();
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escaped = false;
+    let mut last_pipe_end = 0;
+
+    let mut i = 0;
+    while i < bytes.len() {
+        let ch = bytes[i];
+
+        if escaped {
+            escaped = false;
+            i += 1;
+            continue;
+        }
+
+        if ch == b'\\' && !in_single {
+            escaped = true;
+            i += 1;
+            continue;
+        }
+
+        if in_single {
+            if ch == b'\'' {
+                in_single = false;
+            }
+            i += 1;
+            continue;
+        }
+
+        if in_double {
+            if ch == b'"' {
+                in_double = false;
+            } else if ch == b'`' || (ch == b'$' && i + 1 < bytes.len() && bytes[i + 1] == b'(') {
+                return None;
+            }
+            i += 1;
+            continue;
+        }
+
+        if ch == b'\'' {
+            in_single = true;
+        } else if ch == b'"' {
+            in_double = true;
+        } else if ch == b'`' {
+            return None;
+        } else if ch == b'$' && i + 1 < bytes.len() && bytes[i + 1] == b'(' {
+            return None;
+        } else if (ch == b'<' || ch == b'>') && i + 1 < bytes.len() && bytes[i + 1] == b'(' {
+            return None;
+        } else if ch == b'|' {
+            if i + 1 < bytes.len() && bytes[i + 1] == b'|' {
+                i += 2;
+                continue;
+            }
+            last_pipe_end = i + 1;
+        }
+
+        i += 1;
+    }
+
+    if last_pipe_end > 0 {
+        let last_stage = command[last_pipe_end..].trim();
+        if last_stage.is_empty() {
+            None
+        } else {
+            Some(last_stage.to_string())
+        }
     } else {
         None
     }
@@ -1395,5 +1483,75 @@ mod normalize_command_tests {
             compress_with_registry("timeout 30 cargo build", output, &empty_registry());
         // CargoCompressor for build/check/run preserves the structure.
         assert!(compressed.contains("Compiling") || compressed.contains("Finished"));
+    }
+
+    #[test]
+    fn normalize_splits_pipe_and_takes_last_stage() {
+        assert_eq!(
+            normalize_command_for_dispatch("git log | grep fix").as_deref(),
+            Some("grep fix")
+        );
+    }
+
+    #[test]
+    fn normalize_cd_prefix_then_pipe_takes_last_stage() {
+        assert_eq!(
+            normalize_command_for_dispatch("cd /repo && git log | grep fix").as_deref(),
+            Some("grep fix")
+        );
+    }
+
+    #[test]
+    fn normalize_no_pipe_returns_none() {
+        assert_eq!(normalize_command_for_dispatch("git log"), None);
+    }
+
+    #[test]
+    fn normalize_quoted_pipe_not_split() {
+        assert_eq!(normalize_command_for_dispatch("grep \"a|b\" file.txt"), None);
+    }
+
+    #[test]
+    fn normalize_command_substitution_bails() {
+        assert_eq!(
+            normalize_command_for_dispatch("echo $(cmd | cmd) | grep x"),
+            None
+        );
+    }
+
+    #[test]
+    fn normalize_double_pipe_not_split() {
+        assert_eq!(normalize_command_for_dispatch("git log || echo fail"), None);
+    }
+
+    #[test]
+    fn normalize_multi_pipe_returns_last_stage() {
+        assert_eq!(
+            normalize_command_for_dispatch("git log | grep fix | head -5").as_deref(),
+            Some("head -5")
+        );
+    }
+
+    #[test]
+    fn normalize_process_substitution_bails() {
+        assert_eq!(
+            normalize_command_for_dispatch("cat <(echo a | cat) | grep x"),
+            None
+        );
+    }
+
+    #[test]
+    fn piped_cargo_test_grep_preserves_failed() {
+        let grep_output = "test foo ... FAILED\n";
+        let compressed = compress_with_registry(
+            "cargo test | grep FAIL",
+            grep_output,
+            &empty_registry(),
+        );
+        assert!(
+            compressed.text.contains("FAILED"),
+            "grep-filtered FAILED must survive, got: {}",
+            compressed.text
+        );
     }
 }


### PR DESCRIPTION
Fixes #137

## Summary

`normalize_command_for_dispatch` did not split on `|`, causing piped commands to dispatch to the wrong compressor. `cargo test | grep FAIL` matched `CargoCompressor`, which dropped the grep-filtered output entirely (data loss). Additionally, `git_subcommand`, `cargo_subcommand`, and `go_subcommand` returned `|` as the subcommand when it appeared before any real subcommand.

## Problem

The TypeScript pipe-strip layer only strips pipelines for recognized test/build runners (bun, cargo, npm, etc.). Commands like `git log | grep fix` or `cargo test | grep FAIL` pass through unstripped. The Rust compressor dispatcher matches by head token only -- `command_head("git log | grep fix")` returns `"git"`, so `GitCompressor` claims the command. `git_subcommand` walks tokens and returns the first non-flag token after `git`, but does not stop at `|`.

The cargo compressor expects multi-line cargo test output. A single grep-filtered line like `test foo ... FAILED` does not match the expected format and is dropped entirely. The agent sees empty output.

## Changes

- Add `split_on_top_level_pipe` to `compress/mod.rs`: quote-aware splitter that returns the last pipeline stage for dispatch. Bails on backticks, `$()`, and `<()`/`>()` to avoid mis-splitting inner pipes.
- Add `is_shell_boundary` shared helper to `compress/mod.rs`: returns true for `|`, `;`, `&&`, `||`, `>`, `<`.
- Apply `is_shell_boundary` guard in `git_subcommand` (git.rs), `cargo_subcommand` (cargo.rs), and `go_subcommand` (go.rs).

## Verification

- `cargo test -- compress::git::tests compress::cargo::tests compress::go::tests compress::normalize_command_tests` -- 61 passed, 0 failed
- `cargo check --workspace` -- clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784876954&installation_id=135454708&pr_number=140&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F140&signature=21e8e144b92eb396eaa305aa240314342e7b0a34ff9c61e0644395de558751b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mis-dispatch for piped commands and prevents dropped output by making the dispatcher pipe-aware and guarding subcommand parsing at shell boundaries. Piped cases like `cargo test | grep FAIL` now dispatch correctly and keep filtered lines.

- **Bug Fixes**
  - Route dispatch to the last pipeline stage with a quote-aware `split_on_top_level_pipe`; bails on backticks, `$()`, and process substitution.
  - Add `is_shell_boundary` (`|`, `;`, `&&`, `||`, `>`, `<`) and apply it in `git_subcommand`, `git_subcommand_after`, `cargo_subcommand`, and `go_subcommand` to avoid treating these as subcommands.
  - Ensure piped outputs (e.g., `cargo test | grep FAIL`) are not dropped and are compressed correctly.

<sup>Written for commit 31ebeddf321f1c787965edf5c3a3dca426bb48b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a dispatch bug where piped commands like `cargo test | grep FAIL` were routed to the wrong compressor (e.g., `CargoCompressor`), which dropped the grep-filtered output entirely. It also prevents `git_subcommand`, `cargo_subcommand`, and `go_subcommand` from returning `|` or other shell metacharacters as the subcommand name.

- Adds `split_on_top_level_pipe` to `compress/mod.rs`: a quote-aware splitter that returns the last pipeline stage for dispatch and bails conservatively on backticks, `$()`, and process substitution.
- Adds `is_shell_boundary` helper and applies it as an early-return guard in all four subcommand walkers.
- Wires `split_on_top_level_pipe` into `normalize_command_for_dispatch` so both prefixed and bare piped commands correctly resolve to their last pipeline stage before compressor matching.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is narrowly scoped to the dispatch and subcommand-parsing layer, all changed code paths have dedicated tests, and the conservative bail-out strategy in split_on_top_level_pipe ensures ambiguous inputs fall back to the pre-existing generic handler rather than misdispatching.

The pipe-splitting logic is quote-aware, handles || vs | correctly, and explicitly bails on command substitution and process substitution. The is_shell_boundary guard is applied consistently across all four subcommand walkers including git_subcommand_after. Twenty-one new tests cover the core scenarios. No regressions are introduced to simple non-piped commands.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/aft/src/compress/mod.rs | Adds split_on_top_level_pipe and is_shell_boundary, wired into normalize_command_for_dispatch. Logic is sound with 11 new test cases. |
| crates/aft/src/compress/git.rs | Adds is_shell_boundary guard to git_subcommand and git_subcommand_after with dedicated tests. |
| crates/aft/src/compress/cargo.rs | Adds is_shell_boundary guard to cargo_subcommand with three new tests. |
| crates/aft/src/compress/go.rs | Adds is_shell_boundary guard to go_subcommand via .filter() with three new tests. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/aft/src/compress/git.rs`, line 85-107 ([link](https://github.com/cortexkit/aft/blob/6508e74f3f7d94b22a6b496faa1dba338e6ac053/crates/aft/src/compress/git.rs#L85-L107)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`git_subcommand_after` missing `is_shell_boundary` guard**

   `git_subcommand_after` walks tokens looking for the argument that follows a subcommand (e.g., the action after `stash`), but it has no `is_shell_boundary` stop. For a command like `git stash | grep outputs` that reaches `git_subcommand_after` through the `$()` bail-out path in `split_on_top_level_pipe`, the function would skip `stash`, then return `Some("|")` as the "action". In practice this path requires the bail-out to be triggered (e.g., `git stash $(cmd | cmd)`), so it's not a common scenario, but the guard was applied to every other subcommand walker and the omission is inconsistent.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(compress): pipe-aware dispatch and s..."](https://github.com/cortexkit/aft/commit/31ebeddf321f1c787965edf5c3a3dca426bb48b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39490719)</sub>

<!-- /greptile_comment -->