### PR TITLE
feat(aft): add aft_check command for on-demand type checker validation

### DIFF
--- a/crates/aft/src/commands/check.rs
+++ b/crates/aft/src/commands/check.rs
@@ -1,0 +1,65 @@
+//! Handler for the `check` command: on-demand type checker validation.
+
+use std::path::Path;
+
+use crate::context::AppContext;
+use crate::format;
+use crate::protocol::{RawRequest, Response};
+
+/// Handle a `check` request.
+///
+/// Params:
+///   - `file` (string, required) - absolute path to the file to check
+///
+/// Returns: `{ file, error_count, errors?, skipped_reason? }`
+pub fn handle_check(req: &RawRequest, ctx: &AppContext) -> Response {
+    let config = ctx.config();
+
+    if !config.check.enabled {
+        return Response::error(
+            &req.id,
+            "invalid_request",
+            "check: tool is disabled (set check.enabled=true in config)",
+        );
+    }
+
+    let file = match req.params.get("file").and_then(|v| v.as_str()) {
+        Some(f) => f,
+        None => {
+            return Response::error(
+                &req.id,
+                "invalid_request",
+                "check: missing required param 'file'",
+            );
+        }
+    };
+
+    let path = match ctx.validate_path(&req.id, Path::new(file)) {
+        Ok(p) => p,
+        Err(resp) => return resp,
+    };
+
+    if !path.is_file() {
+        return Response::error(
+            &req.id,
+            "invalid_request",
+            format!("check: path must be a file: {}", path.display()),
+        );
+    }
+
+    let (errors, skip_reason) = format::validate_full(&path, &config);
+
+    let mut result = serde_json::json!({
+        "file": file,
+        "error_count": errors.len(),
+    });
+
+    if !errors.is_empty() {
+        result["errors"] = serde_json::json!(errors);
+    }
+    if let Some(reason) = skip_reason {
+        result["skipped_reason"] = serde_json::json!(reason);
+    }
+
+    Response::success(&req.id, result)
+}

--- a/crates/aft/src/commands/mod.rs
+++ b/crates/aft/src/commands/mod.rs
@@ -17,6 +17,7 @@ pub mod batch;
 pub mod call_tree;
 pub mod callers;
 pub mod callgraph_store_adapter;
+pub mod check;
 pub mod checkpoint;
 pub mod configure;
 pub mod conflicts;

--- a/crates/aft/src/config.rs
+++ b/crates/aft/src/config.rs
@@ -101,6 +101,12 @@ pub struct InspectConfig {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
+pub struct CheckConfig {
+    pub enabled: bool,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
 pub struct InspectDuplicatesConfig {
     pub expected_mirrors: Vec<[String; 2]>,
 }
@@ -206,6 +212,7 @@ pub struct Config {
     pub search_index_max_file_size: u64,
     pub semantic: SemanticBackendConfig,
     pub inspect: InspectConfig,
+    pub check: CheckConfig,
     pub backup: BackupConfig,
     /// Enable Astral ty as an experimental Python LSP server (default: false).
     pub experimental_lsp_ty: bool,
@@ -288,6 +295,7 @@ impl Default for Config {
             search_index_max_file_size: 1_048_576,
             semantic: SemanticBackendConfig::default(),
             inspect: InspectConfig::default(),
+            check: CheckConfig::default(),
             backup: BackupConfig::default(),
             experimental_lsp_ty: false,
             lsp_servers: Vec::new(),

--- a/crates/aft/src/config_resolve.rs
+++ b/crates/aft/src/config_resolve.rs
@@ -12,8 +12,8 @@ use serde::{Deserialize, Deserializer};
 use serde_json::{Map, Value};
 
 use crate::config::{
-    BackupConfig, Config, InspectConfig, SemanticBackend, SemanticBackendConfig, UserServerDef,
-    MAX_SEMANTIC_QUERY_TIMEOUT_MS, MIN_SEMANTIC_QUERY_TIMEOUT_MS,
+    BackupConfig, CheckConfig, Config, InspectConfig, SemanticBackend, SemanticBackendConfig,
+    UserServerDef, MAX_SEMANTIC_QUERY_TIMEOUT_MS, MIN_SEMANTIC_QUERY_TIMEOUT_MS,
 };
 use crate::jsonc::strip_jsonc;
 
@@ -91,6 +91,7 @@ pub struct RawAftConfig {
     #[serde(deserialize_with = "deserialize_opt_usize")]
     pub callgraph_chunk_size: Option<usize>,
     pub inspect: Option<RawInspect>,
+    pub check: Option<RawCheck>,
     pub backup: Option<RawBackup>,
     pub bash: Option<RawBash>,
     pub experimental: Option<RawExperimental>,
@@ -368,6 +369,18 @@ impl RawInspect {
     }
 }
 
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct RawCheck {
+    pub enabled: Option<bool>,
+}
+
+impl RawCheck {
+    fn is_empty(&self) -> bool {
+        self.enabled.is_none()
+    }
+}
+
 /// Only `expected_mirrors` survives here: `lower_bound`, `discard_cost`, and
 /// `anonymize` were accepted-but-never-read knobs (the scanner hardcodes its
 /// cost bounds and anonymization rules), so they were removed from the schema
@@ -573,6 +586,9 @@ fn merge_trusted_config(base: &mut RawAftConfig, override_config: RawAftConfig) 
     if override_config.inspect.is_some() {
         base.inspect = override_config.inspect;
     }
+    if override_config.check.is_some() {
+        base.check = override_config.check;
+    }
     if override_config.backup.is_some() {
         base.backup = override_config.backup;
     }
@@ -640,6 +656,7 @@ fn merge_project_config(base: &mut RawAftConfig, project: RawAftConfig) {
     base.experimental = merge_experimental_config(base.experimental.clone(), project.experimental);
     base.bash = merge_bash_config(base.bash.clone(), project.bash);
     base.inspect = merge_inspect_config(base.inspect.clone(), project.inspect);
+    base.check = merge_check_config(base.check.clone(), project.check);
 }
 
 fn merge_formatter_map(
@@ -855,6 +872,18 @@ fn merge_inspect_config(
     (!inspect.is_empty()).then_some(inspect)
 }
 
+fn merge_check_config(
+    base: Option<RawCheck>,
+    override_check: Option<RawCheck>,
+) -> Option<RawCheck> {
+    let Some(override_check) = override_check else {
+        return base;
+    };
+    let mut check = base.unwrap_or_default();
+    check.enabled = override_check.enabled.or(check.enabled);
+    (!check.is_empty()).then_some(check)
+}
+
 fn merge_inspect_duplicates(
     base: Option<RawInspectDuplicates>,
     override_duplicates: Option<RawInspectDuplicates>,
@@ -998,6 +1027,7 @@ fn apply_resolved_config(raw: &RawAftConfig, config: &mut Config) {
     }
     config.semantic = resolve_semantic_config(raw.semantic.as_ref());
     config.inspect = resolve_inspect_config(raw.inspect.as_ref());
+    config.check = resolve_check_config(raw.check.as_ref());
     config.backup = resolve_backup_config(raw.backup.as_ref());
     resolve_lsp_config(raw, config);
     resolve_bash_fields(raw, config);
@@ -1054,6 +1084,16 @@ fn resolve_inspect_config(raw: Option<&RawInspect>) -> InspectConfig {
         inspect.duplicates.expected_mirrors = expected_mirrors;
     }
     inspect
+}
+
+fn resolve_check_config(raw: Option<&RawCheck>) -> CheckConfig {
+    let mut check = CheckConfig::default();
+    if let Some(raw) = raw {
+        if let Some(enabled) = raw.enabled {
+            check.enabled = enabled;
+        }
+    }
+    check
 }
 
 fn resolve_backup_config(raw: Option<&RawBackup>) -> BackupConfig {
@@ -2032,5 +2072,29 @@ mod tests {
             result.config.formatter.get("rust").map(String::as_str),
             Some("rustfmt")
         );
+    }
+
+    #[test]
+    fn check_config_defaults_to_disabled() {
+        let result = resolve_config(&[tier("user", r#"{ "tool_surface": "all" }"#)]);
+        assert!(!result.config.check.enabled);
+    }
+
+    #[test]
+    fn check_config_enabled_via_user_tier() {
+        let result = resolve_config(&[tier(
+            "user",
+            r#"{ "check": { "enabled": true } }"#,
+        )]);
+        assert!(result.config.check.enabled);
+    }
+
+    #[test]
+    fn check_config_project_tier_overrides_user() {
+        let result = resolve_config(&[
+            tier("user", r#"{ "check": { "enabled": true } }"#),
+            tier("project", r#"{ "check": { "enabled": false } }"#),
+        ]);
+        assert!(!result.config.check.enabled);
     }
 }

--- a/crates/aft/src/main.rs
+++ b/crates/aft/src/main.rs
@@ -703,6 +703,7 @@ fn dispatch(req: RawRequest, ctx: &AppContext) -> Response {
         "inline_symbol" => aft::commands::inline_symbol::handle_inline_symbol(&req, ctx),
         "inspect" => aft::commands::inspect::handle_inspect(&req, ctx),
         "inspect_tier2_run" => aft::commands::inspect::handle_inspect_tier2_run(&req, ctx),
+        "check" => aft::commands::check::handle_check(&req, ctx),
         "git_conflicts" => aft::commands::conflicts::handle_git_conflicts(ctx, &req),
         "ast_search" => aft::commands::ast_search::handle_ast_search(&req, ctx),
         "ast_replace" => aft::commands::ast_replace::handle_ast_replace(&req, ctx),

--- a/crates/aft/src/subc_format.rs
+++ b/crates/aft/src/subc_format.rs
@@ -257,6 +257,7 @@ fn is_core_agent_tool(bare_name: &str) -> bool {
             | "import"
             | "refactor"
             | "safety"
+            | "check"
     )
 }
 
@@ -314,6 +315,7 @@ pub fn format_response_with_context(
         "import" => format_import(data, ctx),
         "refactor" => format_refactor(data, ctx),
         "safety" => format_safety(data, ctx),
+        "check" => format_check_response(data),
         _ => unreachable!("core agent tools are exhaustive"),
     }
 }
@@ -911,6 +913,47 @@ fn format_edit_response(data: &Value) -> String {
     append_lsp_error_lines(&mut result, data, false);
     append_lsp_server_notes(&mut result, data);
     result
+}
+
+fn format_check_response(data: &Value) -> String {
+    let file = data
+        .get("file")
+        .and_then(Value::as_str)
+        .unwrap_or("(unknown)");
+    let count = data
+        .get("error_count")
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as usize;
+
+    if let Some(reason) = data.get("skipped_reason").and_then(Value::as_str) {
+        return format!("Checked {file} - validation skipped ({reason}).");
+    }
+
+    if count == 0 {
+        return format!("Checked {file} - no errors found.");
+    }
+
+    let mut output = format!("Checked {file} - {count} error(s):\n");
+    if let Some(errors) = data.get("errors").and_then(Value::as_array) {
+        let lines = errors
+            .iter()
+            .map(|e| {
+                let line = e
+                    .get("line")
+                    .and_then(Value::as_u64)
+                    .map(|n| n.to_string())
+                    .unwrap_or_else(|| "undefined".to_string());
+                let message = e
+                    .get("message")
+                    .and_then(Value::as_str)
+                    .unwrap_or("undefined");
+                format!("  Line {line}: {message}")
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        output.push_str(&lines);
+    }
+    output
 }
 
 fn format_glob_skip_reasons_note(reasons: Option<&Value>) -> Option<String> {
@@ -2774,5 +2817,55 @@ mod status_memory_tests {
         );
         assert!(rendered.contains("/repo: 3.0 MiB (semantic 2.0 MiB, trigram 1.0 MiB"));
         assert!(!rendered.contains("\"memory\""));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn temp_file(name: &str) -> String {
+        let dir = tempfile::tempdir().expect("tempdir");
+        dir.path().join(name).to_string_lossy().into_owned()
+    }
+
+    #[test]
+    fn format_check_response_with_errors() {
+        let file = temp_file("check_test.py");
+        let data = json!({
+            "file": file,
+            "error_count": 2,
+            "errors": [
+                { "line": 1, "message": "F401: `os` imported but unused" },
+                { "line": 2, "message": "F401: `sys` imported but unused" }
+            ]
+        });
+        let text = format_check_response(&data);
+        assert!(text.contains("check_test.py"));
+        assert!(text.contains("2 error(s)"));
+        assert!(text.contains("Line 1: F401"));
+        assert!(text.contains("Line 2: F401"));
+    }
+
+    #[test]
+    fn format_check_response_no_errors() {
+        let file = temp_file("check_test.py");
+        let data = json!({ "file": file, "error_count": 0 });
+        let text = format_check_response(&data);
+        assert!(text.contains("no errors found"));
+    }
+
+    #[test]
+    fn format_check_response_skipped() {
+        let file = temp_file("check_test.py");
+        let data = json!({
+            "file": file,
+            "error_count": 0,
+            "skipped_reason": "no_checker_configured"
+        });
+        let text = format_check_response(&data);
+        assert!(text.contains("validation skipped"));
+        assert!(text.contains("no_checker_configured"));
     }
 }

--- a/crates/aft/src/subc_translate.rs
+++ b/crates/aft/src/subc_translate.rs
@@ -195,6 +195,7 @@ pub fn subc_translate_with_context(
         "outline" => translate_outline(agent_args, project_root),
         "zoom" => translate_zoom(agent_args, project_root),
         "inspect" => translate_inspect(agent_args, project_root),
+        "check" => translate_check(agent_args, project_root),
         "callgraph" => translate_callgraph(agent_args, project_root),
         "conflicts" => translate_conflicts(agent_args),
         "ast_search" => translate_ast_search(agent_args),
@@ -1582,6 +1583,23 @@ fn translate_inspect(args: &Value, project_root: &Path) -> Result<Translated, Tr
 
     Ok(Translated {
         command: "inspect".into(),
+        args: out,
+    })
+}
+
+fn translate_check(args: &Value, project_root: &Path) -> Result<Translated, TranslateError> {
+    let map_in = agent_args_map(args);
+    let file_path = map_in
+        .get("filePath")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| invalid_request("'filePath' is required"))?;
+
+    let mut out = Map::new();
+    insert_resolved_file(&mut out, project_root, file_path);
+
+    Ok(Translated {
+        command: "check".into(),
         args: out,
     })
 }

--- a/packages/opencode-plugin/src/config.ts
+++ b/packages/opencode-plugin/src/config.ts
@@ -327,6 +327,8 @@ export const AftConfigSchema = z.preprocess(
       callgraph_chunk_size: z.number().optional(),
       /** Codebase health inspection config. Enabled by default; set inspect.enabled=false to hide aft_inspect. */
       inspect: InspectConfigSchema.optional(),
+      /** On-demand type checker validation. Disabled by default; set check.enabled=true to expose aft_check. */
+      check: z.object({ enabled: z.boolean().optional() }).optional(),
       /** Undo backup config. User-only: project config cannot disable or shrink a user's safety net. */
       backup: BackupConfigSchema.optional(),
       /**
@@ -497,6 +499,7 @@ export function resolveProjectOverridesForConfigure(config: AftConfig): Record<s
   Object.assign(overrides, resolveLspConfigForConfigure(config));
   if (config.semantic !== undefined) overrides.semantic = config.semantic;
   if (config.inspect !== undefined) overrides.inspect = config.inspect;
+  if (config.check !== undefined) overrides.check = config.check;
   if (config.backup !== undefined) overrides.backup = config.backup;
 
   return overrides;
@@ -1241,6 +1244,7 @@ const PROJECT_SAFE_TOP_LEVEL_FIELDS = new Set<keyof AftConfig>([
   "callgraph_store",
   "callgraph_chunk_size",
   "inspect",
+  "check",
   "experimental",
   // Graduated bash family (v0.27.2). Same reasoning as `experimental`:
   // project-settable so users can opt out per-repo (e.g. `bash: false` in

--- a/packages/opencode-plugin/src/index.ts
+++ b/packages/opencode-plugin/src/index.ts
@@ -81,6 +81,7 @@ import { signalSyncWatchAbort } from "./sync-watch-abort.js";
 import { instrumentToolMap } from "./tool-perf.js";
 import { astTools } from "./tools/ast.js";
 import { bashToolDescription } from "./tools/bash.js";
+import { createCheckTool } from "./tools/check.js";
 import { conflictTools } from "./tools/conflicts.js";
 import { aftPrefixedTools, hoistedTools } from "./tools/hoisted.js";
 import { importTools } from "./tools/imports.js";
@@ -1013,6 +1014,8 @@ async function initializePluginForDirectory(input: Parameters<Plugin>[0]) {
     ...(surface !== "minimal" && astTools(ctx)),
     ...(surface !== "minimal" && aftConfig.semantic_search === true && semanticTools(ctx)),
     ...(inspectToolSurfaceEnabled(aftConfig) && inspectTools(ctx)),
+    ...(aftConfig.check?.enabled === true &&
+      Object.keys(aftConfig.checker ?? {}).length > 0 && { aft_check: createCheckTool(ctx) }),
     // Indexed search tools: recommended+ and opt-in
     ...(surface !== "minimal" && aftConfig.search_index === true && searchTools(ctx)),
     ...refactoringTools(ctx),

--- a/packages/opencode-plugin/src/tools/check.ts
+++ b/packages/opencode-plugin/src/tools/check.ts
@@ -1,0 +1,36 @@
+import type { ToolDefinition } from "@opencode-ai/plugin";
+import { tool } from "@opencode-ai/plugin";
+import type { PluginContext } from "../types.js";
+import { callToolCall, resolvePathArg } from "./_shared.js";
+import { assertExternalDirectoryPermission } from "./permissions.js";
+
+const z = tool.schema;
+
+type ToolArg = ToolDefinition["args"][string];
+
+function arg(schema: unknown): ToolArg {
+  return schema as ToolArg;
+}
+
+export function createCheckTool(ctx: PluginContext): ToolDefinition {
+  return {
+    description:
+      "Run the configured type checker (e.g. ruff, tsc, pyright) on a single file and return validation errors. " +
+      "Use this AFTER completing a batch of edits to verify correctness, not after every intermediate edit. " +
+      "The checker is determined by the `checker` config or auto-detected from project config files. " +
+      "Returns error count and per-error details (line, message).",
+    args: {
+      filePath: arg(z.string().describe("Absolute or project-relative path to the file to check.")),
+    },
+    execute: async (args, context) => {
+      const resolved = await resolvePathArg(ctx, context, args.filePath as string);
+      const denial = await assertExternalDirectoryPermission(ctx, context, resolved);
+      if (denial) return denial;
+      const result = await callToolCall(ctx, context, "check", { filePath: resolved });
+      if (result.success === false) {
+        throw new Error((result.message as string) || "check failed");
+      }
+      return result.text;
+    },
+  };
+}

--- a/packages/pi-plugin/src/config.ts
+++ b/packages/pi-plugin/src/config.ts
@@ -1142,6 +1142,7 @@ const PROJECT_SAFE_TOP_LEVEL_FIELDS = new Set<keyof AftConfig>([
   "callgraph_store",
   "callgraph_chunk_size",
   "inspect",
+  "check",
   "experimental",
   // Graduated bash family (v0.27.2). Same reasoning as `experimental`:
   // project-settable so users can opt out per-repo (e.g. `bash: false` in a


### PR DESCRIPTION
Adds a new `aft_check` tool that runs the configured type checker (ruff, tsc, pyright, etc.) on a single file and returns validation errors. Intended for use after completing a batch of edits, not after every intermediate edit.

Changes:
- `commands/check.rs`: new command handler calling `validate_full`; gates on `config.check.enabled`; uses `ctx.validate_path()` for project-root enforcement and `is_file()` check to reject directories
- `subc_translate.rs`: `translate_check` maps `filePath` to `file`
- `subc_format.rs`: `format_check_response` renders check results (error count, per-error line/message, skip reason)
- `config.rs` + `config_resolve.rs`: `CheckConfig` with `check.enabled` (default false); tool is only registered when enabled and `checker` config is non-empty
- `opencode-plugin`: tool definition, config schema, registration gated on `check.enabled === true` AND non-empty `checker` config; `check.ts` uses `resolvePathArg` + `assertExternalDirectoryPermission` for path safety

Config: set `"check": { "enabled": true }` and `"checker": { "python": "ruff" }` in `aft.jsonc` to enable. Default is disabled.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786395484&installation_id=135454708&pr_number=158&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F158&signature=97333d530047ff0558de488632ff689a1c4f2700796544ec18f49a67b68db6de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>

<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `aft_check`, an on-demand single-file validation that runs the configured checker (ruff, tsc, pyright, etc.) and returns errors. The tool appears only when `check.enabled` is true and a checker is configured, including project-level config.

- **New Features**
  - New `check` command returns `{ file, error_count, errors?, skipped_reason? }`; validates file under project root and rejects directories.
  - Output is a short summary with per-error lines or a skip reason.
  - Translator maps `filePath` to an absolute `file`; formatter renders `check` responses with tests.
  - `opencode-plugin`: adds `aft_check` tool and `check` schema; registers only when `check.enabled` is true and `checker` has entries; resolves paths and enforces external directory permission; preserves project-level `check` via allowlist and `resolveProjectOverridesForConfigure`.
  - Config: `check` is merged across tiers and resolved so the setting reaches the runtime.

- **Migration**
  - Enable via config: `"check": { "enabled": true }`.
  - Configure a checker (e.g., `"checker": { "python": "ruff" }`); auto-detection alone will not expose the tool.
  - Call `aft_check` with `filePath` to validate a specific file after a batch of edits.

<sup>Written for commit 7a15da8c885ddbb035c5a4a803939a131ba43e02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds an opt-in `aft_check` tool for single-file checker validation. The main changes are:

- New Rust `check` command that validates one file with the configured checker.
- New OpenCode `aft_check` tool and registration gate.
- Config support for `check.enabled` across schema, merge, and runtime configure paths.
- Response translation and formatting for checker errors and skipped checks.
</details>


<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- Project-level `check.enabled` is now preserved for tool registration.
- The runtime configure path now forwards `check` to the Rust config resolver.



<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/opencode-plugin/src/config.ts | Adds `check` to the plugin schema, project-safe config merge, and runtime configure overrides. |
| packages/opencode-plugin/src/index.ts | Registers `aft_check` when `check.enabled` is true and an explicit checker map is configured. |
| packages/opencode-plugin/src/tools/check.ts | Adds the OpenCode wrapper that resolves and permission-checks the requested file before calling `check`. |
| crates/aft/src/commands/check.rs | Adds the Rust command handler for gated single-file checker validation. |
| crates/aft/src/config_resolve.rs | Adds raw, merged, and resolved config handling for `check.enabled`. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/opencode-plugin/src/config.ts`, line 1230-1261 ([link](https://github.com/cortexkit/aft/blob/948fb2c43bc2b7882826dea968f66a94a00524d7/packages/opencode-plugin/src/config.ts#L1230-L1261))

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Project check dropped**

   Project-level `check.enabled` is still lost before the plugin decides whether to register `aft_check`. The schema accepts `check`, and the Rust resolver preserves project values, but this merge can still drop it.

2. `packages/opencode-plugin/src/config.ts`, line 1230-1261 ([link](https://github.com/cortexkit/aft/blob/4d69d6f18e154614d19f21138c8fd620e91dad30/packages/opencode-plugin/src/config.ts#L1230-L1261)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Project check dropped**
   Project-level `check.enabled` is still dropped before the plugin decides whether to register `aft_check`. The Rust resolver now merges `check`, but OpenCode registers tools from the TypeScript-merged `aftConfig`. Since `check` is not in this project-safe allowlist and there is no separate merge for it, a project config with `check.enabled: true` and a non-empty `checker` map can still reach `index.ts` with `aftConfig.check` unset. The result is that `aft_check` remains hidden even though the project explicitly enabled it.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (8): Last reviewed commit: ["feat(aft): add aft\_check command for on-..."](https://github.com/cortexkit/aft/commit/7a15da8c885ddbb035c5a4a803939a131ba43e02) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43554844)</sub>

<!-- /greptile_comment -->