### PR TITLE
fix: format directory outlines as text and unwrap JSON envelopes

### DIFF
--- a/crates/aft/src/subc_format.rs
+++ b/crates/aft/src/subc_format.rs
@@ -1597,8 +1597,8 @@ fn extra_honesty_note(data: &Value) -> Option<String> {
 // Mirrors packages/opencode-plugin/src/tools/reading.ts aft_outline dispatch.
 fn format_outline(response: &Response, mode: OutlineMode) -> String {
     match mode {
-        OutlineMode::Text | OutlineMode::DirectoryJson => format_outline_text(&response.data),
-        OutlineMode::Files => format_outline_files_text(&response.data),
+        OutlineMode::Text => format_outline_text(&response.data),
+        OutlineMode::Files | OutlineMode::DirectoryJson => format_outline_files_text(&response.data),
     }
 }
 
@@ -3031,5 +3031,27 @@ mod callgraph_format_tests {
 
         assert!(rendered.starts_with("1 path · 1 entry point"));
         assert!(!rendered.contains("at least"));
+    }
+}
+
+#[cfg(test)]
+mod outline_format_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn directory_outline_preserves_walk_truncation_footer() {
+        let response = Response::success(
+            "1",
+            json!({
+                "text": "src/\n  a.rs (rs)",
+                "complete": false,
+                "walk_truncated": true
+            }),
+        );
+
+        let formatted = format_outline(&response, OutlineMode::DirectoryJson);
+        assert!(formatted.contains("src/\n  a.rs (rs)"));
+        assert!(formatted.contains("⚠ Partial result: walk truncated at 200 files. Some files in this directory were not indexed."));
     }
 }

--- a/crates/aft/src/subc_format.rs
+++ b/crates/aft/src/subc_format.rs
@@ -1597,11 +1597,8 @@ fn extra_honesty_note(data: &Value) -> Option<String> {
 // Mirrors packages/opencode-plugin/src/tools/reading.ts aft_outline dispatch.
 fn format_outline(response: &Response, mode: OutlineMode) -> String {
     match mode {
-        OutlineMode::Text => format_outline_text(&response.data),
+        OutlineMode::Text | OutlineMode::DirectoryJson => format_outline_text(&response.data),
         OutlineMode::Files => format_outline_files_text(&response.data),
-        OutlineMode::DirectoryJson => {
-            serde_json::to_string_pretty(response).unwrap_or_else(|_| "{}".to_string())
-        }
     }
 }
 

--- a/packages/pi-plugin/src/__tests__/reading.test.ts
+++ b/packages/pi-plugin/src/__tests__/reading.test.ts
@@ -104,6 +104,31 @@ describe("reading tool adapters", () => {
     expect(result.content[0].text).toContain("... +2 more");
   });
 
+  test("aft_outline unwraps JSON envelope string (including whitespace-padded) in response.text", async () => {
+    const root = await tempProject();
+    await mkdir(join(root, "src"));
+    const envelope = JSON.stringify(
+      {
+        success: true,
+        text: "src/\n  index.ts (ts)\n",
+      },
+      null,
+      2,
+    );
+    const { api, tools } = makeMockApi();
+    const { bridge } = makeMockBridge(() => ({
+      success: true,
+      text: `\n${envelope}\n`,
+    }));
+    registerReadingTools(api, makePluginContext(bridge), { outline: true, zoom: false });
+
+    const result = (await executeTool(tools.get("aft_outline")!, { target: "src" }, {
+      cwd: root,
+    } as never)) as { content: Array<{ text: string }> };
+
+    expect(result.content[0].text).toBe("src/\n  index.ts (ts)\n");
+  });
+
   test("aft_zoom maps contextLines to one tool_call and preserves server partial text", async () => {
     const root = await tempProject();
     await writeFile(join(root, "src.ts"), "export function ok() {}\n");

--- a/packages/pi-plugin/src/tools/reading.ts
+++ b/packages/pi-plugin/src/tools/reading.ts
@@ -380,7 +380,18 @@ export function registerReadingTools(
           if (response.success === false) {
             throw new Error(response.text || response.message || "outline failed");
           }
-          return textResult(response.text, response);
+          let text = typeof response.text === "string" ? response.text : "";
+          if (text.startsWith("{") && text.endsWith("}")) {
+            try {
+              const parsed = JSON.parse(text);
+              if (typeof parsed.text === "string") {
+                text = parsed.text;
+              }
+            } catch {
+              // keep original text
+            }
+          }
+          return textResult(text, response);
         },
         renderCall(args, theme, context) {
           return renderOutlineCall(args, theme, context);

--- a/packages/pi-plugin/src/tools/reading.ts
+++ b/packages/pi-plugin/src/tools/reading.ts
@@ -381,7 +381,8 @@ export function registerReadingTools(
             throw new Error(response.text || response.message || "outline failed");
           }
           let text = typeof response.text === "string" ? response.text : "";
-          if (text.startsWith("{") && text.endsWith("}")) {
+          const trimmed = text.trim();
+          if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
             try {
               const parsed = JSON.parse(text);
               if (typeof parsed.text === "string") {


### PR DESCRIPTION
This fixes an issue where running directory outlines (such as `aft_outline` on `pi-rs/engine`) displayed single-line raw JSON string envelopes with escaped `\n` linebreaks in the TUI and LLM context instead of a clean multiline outline tree.

The issue occurred because directory targets triggered `OutlineMode::DirectoryJson`, which serialized the entire response object via `to_string_pretty()`. That escaped all internal linebreaks inside the `"text"` field. 

2 simple changes:
- Update `format_outline` to route directory outlines to `format_outline_text()`, formatting plain text tree outputs with plain-text skipped file footers.
- Add defensive JSON envelope unwrapping in `aft_outline.execute()` so tool result content always receives clean multiline text for Pi's tool execution component and model content stream. This is extra but will ensure it won't break when pi updates.

Ran outline test, 71 passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787485530&installation_model_id=22398&pr_number=169&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F169&signature=d6a65d5c0b416801e07e846a014abd93ee919f05607219981087851453b27b8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes directory outlines rendering as escaped JSON and preserves partial-result warnings. Outputs clean, multiline trees in the TUI and model context.

- **Bug Fixes**
  - Route `OutlineMode::DirectoryJson` to `format_outline_files_text()` so directory outputs render as plain text and keep walk-truncation footers.
  - In `packages/pi-plugin`, safely unwrap JSON envelopes in `reading.ts` by trimming and parsing `response.text`, using `parsed.text` when present.

<sup>Written for commit 6b8f3b77e9f05c9eca538c6880fe202f90b45be0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes directory outline rendering and preserves partial-result notices.
- Routes directory responses through the plain-text outline formatter.
- Unwraps JSON text envelopes in the Pi plugin.
- Adds regression coverage for multiline output and walk-truncation notices.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failures remain within the scope of the previous review thread.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/aft/src/subc_format.rs | Directory outlines now render as plain text while retaining skipped-file and partial-result footers. |
| packages/pi-plugin/src/tools/reading.ts | Outline tool responses defensively unwrap JSON envelopes containing textual output. |
| packages/pi-plugin/src/__tests__/reading.test.ts | Adds coverage for whitespace-padded JSON envelope unwrapping and multiline text preservation. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: trim JSON envelope bounds and add r..."](https://github.com/cortexkit/aft/commit/6b8f3b77e9f05c9eca538c6880fe202f90b45be0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46973832)</sub>

<!-- /greptile_comment -->