### PR TITLE
fix old description

### DIFF
--- a/packages/pi-plugin/README.md
+++ b/packages/pi-plugin/README.md
@@ -59,8 +59,8 @@ All four keep the same agent-facing parameters as Pi's built-ins, so your prompt
 
 AFT reads config from two levels, project overrides user:
 
-- **User:** `~/.pi/agent/aft.jsonc` (or `.json`)
-- **Project:** `<project>/.pi/aft.jsonc` (or `.json`)
+- **User:** `~/.config/cortexkit/aft.jsonc` (or `.json`)
+- **Project:** `<project>/.cortexkit/aft.jsonc` (or `.json`)
 
 All keys are optional. Example:
 

--- a/packages/pi-plugin/README.md
+++ b/packages/pi-plugin/README.md
@@ -59,8 +59,8 @@ All four keep the same agent-facing parameters as Pi's built-ins, so your prompt
 
 AFT reads config from two levels, project overrides user:
 
-- **User:** `~/.config/cortexkit/aft.jsonc` (or `.json`)
-- **Project:** `<project>/.cortexkit/aft.jsonc` (or `.json`)
+- **User:** `~/.config/cortexkit/aft.jsonc`
+- **Project:** `<project>/.cortexkit/aft.jsonc`
 
 All keys are optional. Example:
 


### PR DESCRIPTION
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787573262&installation_model_id=22398&pr_number=170&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F170&signature=b8a0e627d0e227dd4c4f1e448ddbb65674b48b30dec8703b80b9cec22804730f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the `pi-plugin` README to point AFT config to the new CortexKit locations and remove unsupported `.json` variants. Docs now reference `~/.config/cortexkit/aft.jsonc` and `<project>/.cortexkit/aft.jsonc`, replacing `~/.pi/agent` and `.pi`.

<sup>Written for commit a160ba9bfe5c360d851aa8633e6b22aef61ef79e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates the Pi plugin documentation to list only the supported user and project `aft.jsonc` configuration paths.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/pi-plugin/README.md | Removes the unsupported `.json` alternatives and replaces the obsolete Pi-specific locations with the current CortexKit `aft.jsonc` paths. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Update README.md"](https://github.com/cortexkit/aft/commit/a160ba9bfe5c360d851aa8633e6b22aef61ef79e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47225606)</sub>

<!-- /greptile_comment -->