### PR TITLE
fix: flush pending responses before runtime maintenance

### DIFF
--- a/crates/aft/src/context.rs
+++ b/crates/aft/src/context.rs
@@ -5442,7 +5442,7 @@ impl AppContext {
     pub fn lsp_notify_file_changed(&self, file_path: &Path, content: &str) {
         let config = self.config();
         if let Some(mut lsp) = self.lsp_manager.try_lock() {
-            if let Err(e) = lsp.notify_file_changed(file_path, content, &config) {
+            if let Err(e) = lsp.notify_file_changed_if_running(file_path, content, &config) {
                 crate::slog_warn!("sync error for {}: {}", file_path.display(), e);
             }
         }

--- a/crates/aft/src/lsp/manager.rs
+++ b/crates/aft/src/lsp/manager.rs
@@ -370,6 +370,23 @@ impl LspManager {
             .successful
     }
 
+    fn running_server_keys_for_file(&self, file_path: &Path, config: &Config) -> Vec<ServerKey> {
+        let mut keys = Vec::new();
+        for def in servers_for_file(file_path, config) {
+            let Some(root) = def.workspace_root_for_file(file_path) else {
+                continue;
+            };
+            let key = ServerKey {
+                kind: def.kind.clone(),
+                root,
+            };
+            if self.clients.contains_key(&key) {
+                keys.push(key);
+            }
+        }
+        keys
+    }
+
     /// Detailed version of [`ensure_server_for_file`] that records every
     /// matching server's outcome (`Ok` / `NoRootMarker` / `BinaryNotInstalled`
     /// / `SpawnFailed`).
@@ -628,6 +645,32 @@ impl LspManager {
     ) -> Result<Vec<(ServerKey, i32)>, LspError> {
         let canonical_path = canonicalize_for_lsp(file_path)?;
         let server_keys = self.ensure_server_for_file(&canonical_path, config);
+        self.notify_file_changed_for_server_keys(canonical_path, content, server_keys)
+    }
+
+    /// Notify only LSP servers that are already running for this file.
+    ///
+    /// Post-write notifications are best-effort and must not make a mutation
+    /// wait for cold server startup. Explicit LSP requests use
+    /// [`Self::notify_file_changed_versioned`] and retain lazy startup.
+    pub fn notify_file_changed_if_running(
+        &mut self,
+        file_path: &Path,
+        content: &str,
+        config: &Config,
+    ) -> Result<(), LspError> {
+        let canonical_path = canonicalize_for_lsp(file_path)?;
+        let server_keys = self.running_server_keys_for_file(&canonical_path, config);
+        self.notify_file_changed_for_server_keys(canonical_path, content, server_keys)
+            .map(|_| ())
+    }
+
+    fn notify_file_changed_for_server_keys(
+        &mut self,
+        canonical_path: PathBuf,
+        content: &str,
+        server_keys: Vec<ServerKey>,
+    ) -> Result<Vec<(ServerKey, i32)>, LspError> {
         if server_keys.is_empty() {
             return Ok(Vec::new());
         }
@@ -2153,7 +2196,10 @@ mod failure_hint_tests {
 
 #[cfg(test)]
 mod diagnostic_capacity_tests {
+    use std::fs;
+
     use super::LspManager;
+    use crate::config::Config;
 
     // The lsp.diagnostic_cache_size config knob must actually take effect:
     // set_diagnostic_capacity (called at AppContext construction with the config
@@ -2177,6 +2223,20 @@ mod diagnostic_capacity_tests {
         manager.insert_failed_spawn_for_test();
         assert_eq!(manager.clear_failed_spawns(), 1);
         assert_eq!(manager.clear_failed_spawns(), 0);
+    }
+
+    #[test]
+    fn post_write_notification_does_not_start_a_cold_server() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("main.ts");
+        fs::write(dir.path().join("package.json"), "{}").unwrap();
+        fs::write(&file, "export const value = 1;\n").unwrap();
+
+        let mut manager = LspManager::new();
+        manager
+            .notify_file_changed_if_running(&file, "export const value = 1;\n", &Config::default())
+            .unwrap();
+        assert!(manager.clients.is_empty());
     }
 }
 

--- a/crates/aft/src/main.rs
+++ b/crates/aft/src/main.rs
@@ -367,8 +367,11 @@ fn drain_runtime_events_and_write_pending(
     registry: &RuntimeRegistry,
     pending: &mut PendingResponses,
 ) -> io::Result<usize> {
+    let ctx = registry.current();
+    let mut written = write_ready_pending(ctx, pending)?;
     drain_runtime_events(registry);
-    write_ready_pending(registry.current(), pending)
+    written += write_ready_pending(ctx, pending)?;
+    Ok(written)
 }
 
 fn write_ready_pending(ctx: &AppContext, pending: &mut PendingResponses) -> io::Result<usize> {
@@ -381,8 +384,11 @@ fn drain_runtime_events_and_write_pending_to_writer(
     pending: &mut PendingResponses,
     writer: &mut impl Write,
 ) -> io::Result<usize> {
+    let ctx = registry.current();
+    let mut written = write_ready_pending_to_writer(ctx, pending, writer)?;
     drain_runtime_events(registry);
-    write_ready_pending_to_writer(registry.current(), pending, writer)
+    written += write_ready_pending_to_writer(ctx, pending, writer)?;
+    Ok(written)
 }
 
 #[cfg(test)]
@@ -1278,9 +1284,58 @@ mod pending_response_tests {
             0
         );
         assert_eq!(drain_frames.load(Ordering::SeqCst), 1);
-        assert_eq!(poll_calls.get(), 1);
+        assert_eq!(poll_calls.get(), 2);
         assert!(writer.is_empty());
         assert!(!pending.is_empty());
+    }
+
+    #[test]
+    fn tick_flushes_ready_pending_before_runtime_maintenance() {
+        let root = TempDir::new().unwrap();
+        let registry = make_runtime_registry(root.path());
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let events_for_drain = Arc::clone(&events);
+        registry
+            .current()
+            .set_progress_sender(Some(Arc::new(Box::new(move |_| {
+                events_for_drain.lock().unwrap().push("drain");
+            }))));
+        let generation = registry.current().advance_configure_generation();
+        registry
+            .current()
+            .configure_warnings_sender()
+            .send((
+                generation,
+                ConfigureWarningsFrame {
+                    frame_type: "configure_warnings",
+                    session_id: Some("session-order".to_string()),
+                    project_root: root.path().display().to_string(),
+                    warnings: Vec::new(),
+                },
+            ))
+            .unwrap();
+
+        let events_for_pending = Arc::clone(&events);
+        let mut pending = PendingResponses::default();
+        pending.register(PendingResponse {
+            request_id: "pending-order".to_string(),
+            session_id: "session-order".to_string(),
+            attach_command: "bash".to_string(),
+            poll: Box::new(move |_| {
+                events_for_pending.lock().unwrap().push("pending");
+                Some(Response::success("pending-order", serde_json::json!({})))
+            }),
+        });
+        let mut writer = Vec::new();
+
+        assert_eq!(
+            drain_runtime_events_and_write_pending_to_writer(&registry, &mut pending, &mut writer)
+                .unwrap(),
+            1
+        );
+        assert_eq!(*events.lock().unwrap(), ["pending", "drain"]);
+        assert_eq!(line_values(&writer).len(), 1);
+        assert!(pending.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Flush ready deferred responses before runtime maintenance and again afterward. This prevents a terminal foreground Bash task from waiting behind a synchronous runtime drain before its NDJSON response can be emitted.

The second flush preserves delivery for responses that become ready during maintenance. Runtime maintenance and task execution behavior are otherwise unchanged.

Fixes #172.

## Regression coverage

- Adds a pending-response ordering regression: a ready deferred response must be polled and written before configure-warning maintenance runs.
- Updates the periodic-drain polling expectation for the new before/after flush behavior.

## Validation

- `cargo +nightly-2026-04-29 test -p agent-file-tools pending_response_tests -- --nocapture`
- `cargo +nightly-2026-04-29 test -p agent-file-tools decide_bash_step -- --nocapture`
- `cargo +nightly-2026-04-29 build -p agent-file-tools --release --bin aft`
- Direct `@cortexkit/aft-bridge` smoke against the built binary: configure, Bash launch, terminal status, and output retrieval succeeded.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787849884&installation_model_id=22398&pr_number=173&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F173&signature=d95ad7b37b1847d6a1f2022a9864fefaa59b67357694620e02ad6665af783170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flush ready pending responses before and after runtime maintenance to unblock terminal Bash NDJSON. Post-write LSP file-change notifications now skip cold starts by notifying only running servers.

- **Bug Fixes**
  - Flush pending before `drain_runtime_events`, then flush again after.
  - Removes latency for terminal Bash NDJSON and preserves delivery for responses that become ready during maintenance.
  - LSP: `notify_file_changed_if_running` avoids starting servers on writes; explicit requests retain lazy startup.
  - Tests: add pending/maintenance ordering and twice-per-tick polling; add LSP no-cold-start regression. Fixes #172.

<sup>Written for commit 0904eee860eb7587f73749badf936639d7e31484. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adjusts response-flush ordering and avoids cold LSP startup during post-write notifications.
- Flushes ready deferred responses immediately before runtime maintenance and again afterward.
- Limits post-write file-change notifications to matching LSP servers that are already running.
- Adds regression coverage for pending-response ordering and cold-server behavior.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/aft/src/main.rs | Flushes pending responses on both sides of runtime maintenance and adds ordering regression coverage. |
| crates/aft/src/lsp/manager.rs | Adds a notification path that targets only matching LSP clients already present in the running-client map. |
| crates/aft/src/context.rs | Routes best-effort post-write notifications through the running-server-only LSP path. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(lsp): avoid cold starts after mutati..."](https://github.com/cortexkit/aft/commit/0904eee860eb7587f73749badf936639d7e31484) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48015436)</sub>

<!-- /greptile_comment -->