### PR TITLE
permissions: match absolute rules for paths outside the project root

### DIFF
--- a/packages/opencode-plugin/src/__tests__/permissions-effect.test.ts
+++ b/packages/opencode-plugin/src/__tests__/permissions-effect.test.ts
@@ -21,13 +21,17 @@
  * declares for `ToolContext["ask"]`.
  */
 import { describe, expect, test } from "bun:test";
+import type { BridgePool } from "@cortexkit/aft-bridge";
 import type { ToolContext } from "@opencode-ai/plugin";
 import {
   askEditPermission,
   askGlobPermission,
   askGrepPermission,
+  permissionPath,
   runAsk,
 } from "../tools/permissions.js";
+import { hoistedTools } from "../tools/hoisted.js";
+import type { PluginContext } from "../types.js";
 
 describe("runAsk + Promise", () => {
   test("a resolving Promise body actually runs through runAsk (allow path)", async () => {
@@ -88,6 +92,105 @@ describe("runAsk + Promise", () => {
     });
     await askEditPermission(ctx, ["src/foo.ts"]);
     expect(askWasInvoked).toBe(true);
+  });
+});
+
+describe("hoisted write permission patterns", () => {
+  test("passes an absolute outside-root path to askEditPermission", async () => {
+    let observed: { patterns?: string[] } = {};
+    const bridge = {
+      toolCall: async (
+        _sessionID: string | undefined,
+        _name: string,
+        _args: Record<string, unknown>,
+        options?: { preview?: boolean },
+      ) =>
+        options?.preview === true
+          ? { success: true, preview: true, preview_diff: "" }
+          : { success: true, text: "Created new file." },
+    };
+    const pluginContext = {
+      pool: { getBridge: () => bridge } as unknown as BridgePool,
+      client: {},
+      config: {},
+      storageDir: process.cwd(),
+    } as unknown as PluginContext;
+    const context = {
+      ...makeMockContext(async (input) => {
+        observed = input as typeof observed;
+      }),
+      sessionID: "outside-root-write-permission-test",
+      directory: process.cwd(),
+      worktree: process.cwd(),
+    };
+
+    await hoistedTools(pluginContext).write.execute(
+      { path: "/tmp/x", content: "content\n" },
+      context,
+    );
+
+    expect(observed.patterns).toEqual(["/tmp/x"]);
+  });
+
+  test("uses apply_patch absolute affected paths for outside-root permission asks", async () => {
+    let observed: { patterns?: string[] } = {};
+    const bridge = {
+      toolCall: async (
+        _sessionID: string | undefined,
+        _name: string,
+        _args: Record<string, unknown>,
+        options?: { preview?: boolean },
+      ) =>
+        options?.preview === true
+          ? {
+              success: true,
+              preview: true,
+              preview_diff: "",
+              affected_paths: ["/tmp/report.md"],
+              affected_rel_paths: ["../../../../tmp/report.md"],
+            }
+          : { success: true, text: "Applied patch." },
+    };
+    const pluginContext = {
+      pool: { getBridge: () => bridge } as unknown as BridgePool,
+      client: {},
+      config: {},
+      storageDir: process.cwd(),
+    } as unknown as PluginContext;
+    const context = {
+      ...makeMockContext(async (input) => {
+        observed = input as typeof observed;
+      }),
+      sessionID: "outside-root-apply-patch-permission-test",
+      directory: process.cwd(),
+      worktree: process.cwd(),
+    };
+
+    await hoistedTools(pluginContext).apply_patch.execute(
+      { patchText: "*** Begin Patch\n*** End Patch" },
+      context,
+    );
+
+    expect(observed.patterns).toEqual(["/tmp/report.md"]);
+  });
+});
+
+describe("permissionPath", () => {
+  test("keeps in-project paths relative and root worktrees absolute", () => {
+    const projectContext = {
+      ...makeMockContext(async () => {}),
+      directory: "/workspace/project",
+      worktree: "/workspace/project",
+    };
+    const rootContext = {
+      ...makeMockContext(async () => {}),
+      directory: "/",
+      worktree: "/",
+    };
+
+    expect(permissionPath(projectContext, "src/foo.ts")).toBe("src/foo.ts");
+    expect(permissionPath(projectContext, "/tmp/x")).toBe("/tmp/x");
+    expect(permissionPath(rootContext, "/tmp/x")).toBe("/tmp/x");
   });
 });
 

--- a/packages/opencode-plugin/src/tools/hoisted.ts
+++ b/packages/opencode-plugin/src/tools/hoisted.ts
@@ -29,6 +29,7 @@ import { createBashWriteTool } from "./bash_write.js";
 import {
   askEditPermission,
   assertExternalDirectoryPermission,
+  permissionPath,
   permissionDeniedResponse,
   runAsk,
 } from "./permissions.js";
@@ -472,7 +473,7 @@ function createWriteTool(ctx: PluginContext, editToolName = "edit"): ToolDefinit
       const filePath = resolvePathFromProjectRoot(projectRoot, file);
       persistFilePathAlias(argsRecord, context);
 
-      const relPath = path.relative(projectRoot, filePath);
+      const permissionPattern = permissionPath(context, filePath);
 
       // External-directory check first (mirrors opencode-native write.ts:43).
       {
@@ -487,7 +488,7 @@ function createWriteTool(ctx: PluginContext, editToolName = "edit"): ToolDefinit
         throw toolErrorFromResponse("write", preview);
       }
 
-      const denial = await askEditPermission(context, [relPath], {
+      const denial = await askEditPermission(context, [permissionPattern], {
         filepath: filePath,
         diff: typeof preview.preview_diff === "string" ? preview.preview_diff : "",
       });
@@ -675,7 +676,7 @@ function createEditTool(ctx: PluginContext, writeToolName = "write"): ToolDefini
       const filePath = resolvePathFromProjectRoot(projectRoot, file);
       persistFilePathAlias(argsRecord, context);
 
-      const relPath = path.relative(projectRoot, filePath);
+      const permissionPattern = permissionPath(context, filePath);
 
       // External-directory check first (mirrors opencode-native edit.ts:68).
       {
@@ -693,7 +694,7 @@ function createEditTool(ctx: PluginContext, writeToolName = "write"): ToolDefini
         throw toolErrorFromResponse("edit", preview);
       }
 
-      const denial = await askEditPermission(context, [relPath], {
+      const denial = await askEditPermission(context, [permissionPattern], {
         filepath: filePath,
         diff: typeof preview.preview_diff === "string" ? preview.preview_diff : "",
       });
@@ -852,9 +853,16 @@ function createApplyPatchTool(ctx: PluginContext): ToolDefinition {
       }
 
       const affectedRelPaths = stringArray(preview.affected_rel_paths);
-      const denial = await askEditPermission(context, affectedRelPaths, {
+      const affectedPaths = stringArray(preview.affected_paths);
+      const permissionPatterns = (
+        affectedPaths.length > 0 ? affectedPaths : affectedRelPaths
+      ).map((filePath) => permissionPath(context, filePath));
+      const denial = await askEditPermission(context, permissionPatterns, {
         diff: typeof preview.preview_diff === "string" ? preview.preview_diff : "",
-        filepath: typeof preview.filepath === "string" ? preview.filepath : affectedRelPaths[0],
+        filepath:
+          typeof preview.filepath === "string"
+            ? preview.filepath
+            : affectedPaths[0] ?? affectedRelPaths[0],
       });
       if (denial) return permissionDeniedResponse(denial);
 

--- a/packages/opencode-plugin/src/tools/permissions.ts
+++ b/packages/opencode-plugin/src/tools/permissions.ts
@@ -83,15 +83,33 @@ export function resolveAbsolutePath(context: ToolContext, target: string): strin
   return path.isAbsolute(expanded) ? expanded : path.resolve(projectRootFor(context), expanded);
 }
 
+export function permissionPath(context: ToolContext, target: string): string {
+  const projectRoot = path.resolve(projectRootFor(context));
+  const absolutePath = path.resolve(resolveAbsolutePath(context, target));
+  if (projectRoot === path.parse(projectRoot).root) return absolutePath;
+
+  const relativePath = path.relative(projectRoot, absolutePath);
+  if (
+    relativePath !== "" &&
+    relativePath !== ".." &&
+    !relativePath.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relativePath)
+  ) {
+    return relativePath;
+  }
+
+  return relativePath === "" ? "." : absolutePath;
+}
+
 export function resolveRelativePattern(context: ToolContext, target: string): string {
-  return path.relative(projectRootFor(context), resolveAbsolutePath(context, target)) || ".";
+  return permissionPath(context, target);
 }
 
 export function resolveRelativePatternFromAbsolute(
   context: ToolContext,
   absolutePath: string,
 ): string {
-  return path.relative(projectRootFor(context), absolutePath) || ".";
+  return permissionPath(context, absolutePath);
 }
 
 export function resolveRelativePatterns(context: ToolContext, targets: string[]): string[] {


### PR DESCRIPTION
Permission patterns for edit/write are always relativized against the project root, so any rule written as an absolute path outside that root can never match.

With this config:

```jsonc
"permission": { "edit": { "*": "deny", "/tmp/**": "allow" } }
```

a write to `/tmp/report.md` produces the pattern `../../../../tmp/report.md`. `/tmp/**` doesn't match it, `"*": "deny"` wins, and the write is denied.

It fails in the dangerous direction too. Reverse the rules:

```jsonc
"permission": { "edit": { "*": "allow", "/tmp/**": "deny" } }
```

The deny rule is equally unmatchable, so the write is **allowed**. An absolute deny rule written to protect a path silently protects nothing.

Since AFT hoists `write`/`edit`/`apply_patch`, this is the layer that decides — opencode's own permission handling isn't reached for those tools.

## Change

New `permissionPath` helper in `tools/permissions.ts`:

- target inside the project root → relative path (unchanged)
- target outside → absolute path
- project root is `/` → absolute

`resolveRelativePattern`, `resolveRelativePatternFromAbsolute`, and `resolveRelativePatterns` now delegate to it, so `imports.ts`, `refactoring.ts`, `safety.ts`, and `ast.ts` inherit the fix without changes. The two inline `path.relative` sites in `hoisted.ts` (write, edit) call it directly.

`apply_patch` needed more than the shared helper: its patterns come from the Rust side, where `build_preview_response` emits `affected_rel_paths` alongside `affected_paths`. The TS side was reading the relative array. It now prefers the absolute one and falls back to the relative when it's empty, normalizing both through `permissionPath`.

## Note on the helper names

`resolveRelativePattern` and `resolveRelativePatternFromAbsolute` can now return absolute paths, so the names are stale. Left alone here to keep the diff focused — happy to rename in this PR or a follow-up, whichever you prefer.

## Tests

`permissions-effect.test.ts` drives the real tool path (`hoistedTools(ctx).write.execute(...)`), not the helper in isolation, and covers write and apply_patch separately. Reverting `permissionPath` to the old one-liner fails them with `Expected: "/tmp/x"` / `Received: "../../tmp/x"`.

18 pass in that file; 12 pass across `registration-parity` and `tool-surface-transport-invariant`; `bun run build` clean. Full plugin suite matches baseline (2 pre-existing `format_on_edit` failures, both environmental — formatters installed locally where those tests expect absence).

Preview and execution still receive identical raw args — the pattern only reaches the host permission ask, never the Rust side, so plugin and server can't disagree about the path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788277094&installation_model_id=22398&pr_number=175&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F175&signature=85ee13ca8a41eb3fb8e34614b7a825d5516dd26c4cdaf04ddc991a5a61785c7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix permission pattern handling so absolute rules outside the project root match correctly for `write`, `edit`, and `apply_patch`, preventing unsafe allows and unintended denies.

- **Bug Fixes**
  - Added `permissionPath` to return relative paths for in-project targets and absolute paths for outside-root or `/` worktrees.
  - Updated hoisted `write`, `edit`, and `apply_patch` to use `permissionPath`; `apply_patch` now prefers `affected_paths` and falls back to `affected_rel_paths`, then normalizes.
  - Permission asks now receive the correct pattern (e.g., `/tmp/**` will match `/tmp/x`).
  - Added tests covering hoisted tools and `permissionPath`.

<sup>Written for commit 3d2b5660e7bf9cf28b0917b8cb1b92b5a49ba855. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

