### PR TITLE
bash_rewrite: stop the grep footer firing on single-file, external, and fresh targets

### DIFF
--- a/crates/aft/src/bash_rewrite/rules.rs
+++ b/crates/aft/src/bash_rewrite/rules.rs
@@ -1,6 +1,9 @@
 use serde_json::{json, Value};
+use std::path::Path;
+use std::time::{Duration, SystemTime};
 
 const REGEX_SIZE_LIMIT: usize = 10 * 1024 * 1024;
+const GREP_FOOTER_FRESHNESS_WINDOW: Duration = Duration::from_secs(60);
 
 use crate::bash_rewrite::footer::{add_footer, add_grep_footer};
 use crate::bash_rewrite::parser::parse;
@@ -32,9 +35,14 @@ impl RewriteRule for GrepRule {
         ctx: &AppContext,
     ) -> Result<Response, String> {
         let params = grep_request(command, "grep").ok_or("not a grep rewrite")?;
+        let path = params
+            .get("path")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
         try_call_and_grep_footer(
             crate::commands::grep::handle_grep(&request("grep", params, session_id), ctx),
             ctx,
+            path.as_deref(),
         )
     }
 }
@@ -55,9 +63,14 @@ impl RewriteRule for RgRule {
         ctx: &AppContext,
     ) -> Result<Response, String> {
         let params = grep_request(command, "rg").ok_or("not an rg rewrite")?;
+        let path = params
+            .get("path")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
         try_call_and_grep_footer(
             crate::commands::grep::handle_grep(&request("grep", params, session_id), ctx),
             ctx,
+            path.as_deref(),
         )
     }
 }
@@ -204,13 +217,60 @@ fn try_call_and_footer(response: Response, replacement_tool: &str) -> Result<Res
 
 /// Grep/rg variant: same decline handling, but the footer is the enforced
 /// code-search redirect, steering to `aft_search` when it's registered.
-fn try_call_and_grep_footer(response: Response, ctx: &AppContext) -> Result<Response, String> {
+fn try_call_and_grep_footer(
+    response: Response,
+    ctx: &AppContext,
+    path: Option<&str>,
+) -> Result<Response, String> {
     if let Some(err) = declined_error(&response, "grep") {
         return Err(err);
     }
     let output = response_output(&response.data);
-    let footered = add_grep_footer(&output, ctx.config().aft_search_registered);
+    let footered = if should_suppress_grep_footer(path, &grep_project_root(ctx)) {
+        output
+    } else {
+        add_grep_footer(&output, ctx.config().aft_search_registered)
+    };
     Ok(apply_footer(response, footered))
+}
+
+fn grep_project_root(ctx: &AppContext) -> std::path::PathBuf {
+    let configured = ctx
+        .config()
+        .project_root
+        .clone()
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
+    std::fs::canonicalize(&configured).unwrap_or(configured)
+}
+
+fn should_suppress_grep_footer(path: Option<&str>, project_root: &Path) -> bool {
+    let Some(path) = path else {
+        return false;
+    };
+    let target = Path::new(path);
+    let target = if target.is_absolute() {
+        target.to_path_buf()
+    } else {
+        project_root.join(target)
+    };
+    let Ok(target) = std::fs::canonicalize(target) else {
+        return false;
+    };
+    if !target.starts_with(project_root) {
+        return true;
+    }
+    let Ok(metadata) = std::fs::metadata(&target) else {
+        return false;
+    };
+    if metadata.is_file() {
+        return true;
+    }
+    let Ok(modified) = metadata.modified() else {
+        return false;
+    };
+    SystemTime::now()
+        .duration_since(modified)
+        .is_ok_and(|age| age < GREP_FOOTER_FRESHNESS_WINDOW)
 }
 
 fn declined_error(response: &Response, replacement_tool: &str) -> Option<String> {
@@ -502,9 +562,84 @@ fn ls_request(command: &str) -> Option<Value> {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+    use std::time::{Duration, SystemTime};
+
     use serde_json::json;
 
-    use super::find_request;
+    use super::{find_request, should_suppress_grep_footer};
+
+    fn fixture() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir(dir.path().join("src")).unwrap();
+        fs::write(dir.path().join("src/app.ts"), "foo\n").unwrap();
+        dir
+    }
+
+    #[test]
+    fn single_named_file_suppresses_grep_footer() {
+        let dir = fixture();
+        assert!(should_suppress_grep_footer(Some("src/app.ts"), dir.path()));
+    }
+
+    #[test]
+    fn directory_path_keeps_grep_footer() {
+        let dir = fixture();
+        filetime::set_file_mtime(
+            dir.path().join("src"),
+            filetime::FileTime::from_system_time(SystemTime::now() - Duration::from_secs(61)),
+        )
+        .unwrap();
+        assert!(!should_suppress_grep_footer(Some("src"), dir.path()));
+    }
+
+    #[test]
+    fn no_path_keeps_grep_footer() {
+        let dir = fixture();
+        assert!(!should_suppress_grep_footer(None, dir.path()));
+    }
+
+    #[test]
+    fn external_file_suppresses_grep_footer() {
+        let dir = fixture();
+        let external = tempfile::NamedTempFile::new().unwrap();
+        assert!(should_suppress_grep_footer(
+            external.path().to_str(),
+            dir.path()
+        ));
+    }
+
+    #[test]
+    fn freshly_modified_file_suppresses_grep_footer() {
+        let dir = fixture();
+        let file = dir.path().join("src/app.ts");
+        fs::write(&file, "foo\nbar\n").unwrap();
+        assert!(should_suppress_grep_footer(file.to_str(), dir.path()));
+    }
+
+    #[test]
+    fn old_directory_inside_project_root_keeps_grep_footer() {
+        let dir = fixture();
+        let directory = dir.path().join("src");
+        filetime::set_file_mtime(
+            &directory,
+            filetime::FileTime::from_system_time(SystemTime::now() - Duration::from_secs(61)),
+        )
+        .unwrap();
+        assert!(!should_suppress_grep_footer(Some("src"), dir.path()));
+    }
+
+    #[test]
+    fn old_file_inside_project_root_suppresses_grep_footer() {
+        let dir = fixture();
+        let file = dir.path().join("src/app.ts");
+        filetime::set_file_mtime(
+            &file,
+            filetime::FileTime::from_system_time(SystemTime::now() - Duration::from_secs(61)),
+        )
+        .unwrap();
+        assert!(should_suppress_grep_footer(Some("src/app.ts"), dir.path()));
+    }
 
     #[test]
     fn find_absolute_path_uses_glob_path_arg() {

--- a/crates/aft/tests/integration/bash_rewrite_test.rs
+++ b/crates/aft/tests/integration/bash_rewrite_test.rs
@@ -11,6 +11,7 @@
 #![cfg(unix)]
 
 use std::fs;
+use std::time::{Duration, SystemTime};
 
 use aft::bash_rewrite::{parser, try_rewrite};
 use aft::commands::edit_match::handle_edit_match;
@@ -104,6 +105,11 @@ fn rewrites_grep_and_rejects_pipes() {
     let dir = tempfile::tempdir().unwrap();
     fs::create_dir_all(dir.path().join("src")).unwrap();
     fs::write(dir.path().join("src/lib.rs"), "fn Needle() {}\n").unwrap();
+    filetime::set_file_mtime(
+        dir.path().join("src"),
+        filetime::FileTime::from_system_time(SystemTime::now() - Duration::from_secs(61)),
+    )
+    .unwrap();
     let ctx = context(dir.path(), true);
 
     let data = rewrite(
@@ -127,6 +133,16 @@ fn grep_footer_steers_to_aft_search_when_registered() {
     let dir = tempfile::tempdir().unwrap();
     fs::create_dir_all(dir.path().join("src")).unwrap();
     fs::write(dir.path().join("src/lib.rs"), "fn needle() {}\n").unwrap();
+    filetime::set_file_mtime(
+        dir.path(),
+        filetime::FileTime::from_system_time(SystemTime::now() - Duration::from_secs(61)),
+    )
+    .unwrap();
+    filetime::set_file_mtime(
+        dir.path().join("src"),
+        filetime::FileTime::from_system_time(SystemTime::now() - Duration::from_secs(61)),
+    )
+    .unwrap();
     let target = format!("grep -ni needle {}", dir.path().join("src").display());
 
     // Registered → footer names `aft_search`, not the grep tool.
@@ -158,6 +174,11 @@ fn grep_rewrite_rejects_oversized_regex_programs() {
 fn rewrites_rg_and_rejects_chains() {
     let dir = tempfile::tempdir().unwrap();
     fs::write(dir.path().join("notes.txt"), "alpha beta\n").unwrap();
+    filetime::set_file_mtime(
+        dir.path(),
+        filetime::FileTime::from_system_time(SystemTime::now() - Duration::from_secs(61)),
+    )
+    .unwrap();
     let ctx = context(dir.path(), true);
 
     let data =

--- a/packages/aft-bridge/src/__tests__/bash-hints.test.ts
+++ b/packages/aft-bridge/src/__tests__/bash-hints.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import {
   commandInvokesCodeSearch,
   maybeAppendConflictsHint,
@@ -231,6 +234,78 @@ describe("maybeAppendGrepSearchHint", () => {
     expect(maybeAppendGrepSearchHint(output, "grep x src/file.ts", true, "   ")).toBe(
       `${output}\n\n${AFT_SEARCH_HINT}`,
     );
+  });
+
+  test("suppresses a piped grep targeting an in-project file", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "aft-bash-hints-"));
+    try {
+      fs.mkdirSync(path.join(root, "src"));
+      const file = path.join(root, "src/app.ts");
+      fs.writeFileSync(file, "foo\n");
+      const old = new Date(Date.now() - 61_000);
+      fs.utimesSync(file, old, old);
+      expect(maybeAppendGrepSearchHint("hit", "grep -n foo src/app.ts | head -5", true, root)).toBe(
+        "hit",
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("keeps the lecture for a piped old in-project directory search", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "aft-bash-hints-"));
+    try {
+      const src = path.join(root, "src");
+      fs.mkdirSync(src);
+      fs.writeFileSync(path.join(src, "app.ts"), "foo\n");
+      const old = new Date(Date.now() - 61_000);
+      fs.utimesSync(src, old, old);
+      expect(maybeAppendGrepSearchHint("hit", "grep -n foo src | head -5", true, root)).toContain(
+        AFT_SEARCH_HINT,
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("suppresses a piped grep targeting a fresh in-project file", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "aft-bash-hints-"));
+    try {
+      fs.mkdirSync(path.join(root, "src"));
+      fs.writeFileSync(path.join(root, "src/app.ts"), "foo\n");
+      expect(maybeAppendGrepSearchHint("hit", "grep -n foo src/app.ts | head -5", true, root)).toBe(
+        "hit",
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("keeps the lecture for a piped grep targeting a nonexistent path", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "aft-bash-hints-"));
+    try {
+      expect(
+        maybeAppendGrepSearchHint("hit", "grep -n foo src/missing.ts | head -5", true, root),
+      ).toContain(AFT_SEARCH_HINT);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("suppresses a multi-operand grep when any operand is an existing file", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "aft-bash-hints-"));
+    try {
+      const src = path.join(root, "src");
+      fs.mkdirSync(src);
+      fs.writeFileSync(path.join(src, "app.ts"), "foo\n");
+      const old = new Date(Date.now() - 61_000);
+      fs.utimesSync(src, old, old);
+      expect(
+        maybeAppendGrepSearchHint("hit", "grep -n foo src/app.ts src/ | head -5", true, root),
+      ).toBe("hit");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/aft-bridge/src/bash-hints.ts
+++ b/packages/aft-bridge/src/bash-hints.ts
@@ -1,7 +1,8 @@
+import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
-// Pure helpers for the bash-output hint nudges appended to bash tool results.
+// Helpers for the bash-output hint nudges appended to bash tool results.
 //
 // Shared across harnesses (OpenCode applies it in `tool.execute.after`; Pi
 // applies it inside its hoisted bash tool). Returns the new output string (or
@@ -18,6 +19,7 @@ const GREP_SEARCH_GREP_HINT =
   "DO NOT search code by running grep/rg in bash — it is unindexed, unranked, and serial. Use the `grep` tool instead (indexed and ranked).";
 
 const GREP_SEARCH_HINT_PREFIX = "DO NOT search code by running grep/rg in bash —";
+const GREP_SEARCH_FRESHNESS_WINDOW_MS = 60_000;
 
 type Quote = "none" | "single" | "double";
 
@@ -133,11 +135,16 @@ function shouldSuppressGrepSearchHint(command: string, projectRoot: string | und
     const operands = collectPathOperands(firstStage, firstToken.end);
     // No path operands → grep reads stdin or searches the (in-project) cwd.
     if (operands.length === 0) return false;
+    let sawInProjectOperand = false;
     for (const operand of operands) {
       if (isDynamicPathOperand(operand)) continue;
-      if (isPathInsideProject(resolvedRoot, effectiveCwd, operand)) return false;
+      const resolvedOperand = resolvePathOperand(effectiveCwd, operand);
+      if (!isPathInsideProject(resolvedRoot, effectiveCwd, operand)) continue;
+      sawInProjectOperand = true;
+      if (shouldSuppressResolvedPath(resolvedOperand)) return true;
     }
     // All operands resolve outside the project → this grep is external.
+    if (sawInProjectOperand) return false;
   }
 
   return sawCodeSearchStatement;
@@ -253,6 +260,17 @@ function isPathInsideProject(resolvedRoot: string, baseCwd: string, operand: str
   const resolved = resolvePathOperand(baseCwd, operand);
   const rel = path.relative(resolvedRoot, resolved);
   return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+}
+
+function shouldSuppressResolvedPath(resolved: string): boolean {
+  try {
+    const stats = fs.statSync(resolved);
+    if (stats.isFile()) return true;
+    const ageMs = Date.now() - stats.mtimeMs;
+    return ageMs >= 0 && ageMs < GREP_SEARCH_FRESHNESS_WINDOW_MS;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/packages/opencode-plugin/src/__tests__/e2e/bash.test.ts
+++ b/packages/opencode-plugin/src/__tests__/e2e/bash.test.ts
@@ -1,7 +1,7 @@
 /// <reference path="../../bun-test.d.ts" />
 
 import { afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, utimes, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { type BinaryBridge, BridgePool } from "@cortexkit/aft-bridge";
 import type { ToolContext } from "@opencode-ai/plugin";
@@ -344,6 +344,8 @@ maybeDescribe("e2e bash command (OpenCode adapter + bridge + Rust)", () => {
     const h = await harness({ experimental_bash_rewrite: true });
     await mkdir(h.path("src"));
     await writeFile(h.path("src", "lib.ts"), "needle\nhaystack\n", "utf8");
+    const old = new Date(Date.now() - 61_000);
+    await utimes(h.path("src"), old, old);
 
     const response = await h.bridge.send("bash", {
       command: `grep -r needle ${h.path("src")}`,

--- a/packages/pi-plugin/src/__tests__/e2e/bash.test.ts
+++ b/packages/pi-plugin/src/__tests__/e2e/bash.test.ts
@@ -9,7 +9,7 @@
 /// <reference path="../../bun-test.d.ts" />
 
 import { afterEach, beforeAll, describe, expect, test } from "bun:test";
-import { mkdir, realpath, writeFile } from "node:fs/promises";
+import { mkdir, realpath, utimes, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { type BinaryBridge, BridgePool } from "@cortexkit/aft-bridge";
 import { withEnv } from "../../../../aft-bridge/src/__tests__/test-utils/env-guard.js";
@@ -306,6 +306,8 @@ maybeDescribe("e2e bash command (Pi adapter + bridge + Rust)", () => {
     const h = await harness({ rewrite: true });
     await mkdir(h.path("src"));
     await writeFile(h.path("src", "lib.ts"), "needle\nhaystack\n", "utf8");
+    const old = new Date(Date.now() - 61_000);
+    await utimes(h.path("src"), old, old);
 
     const response = await h.bridge.send("bash", {
       command: `grep -r needle ${h.path("src")}`,


### PR DESCRIPTION
The "DO NOT search code by running grep/rg in bash" footer is unconditional, so it also fires on greps where the indexed tool has nothing to add:

- a single named file — `grep -n foo src/app.ts` isn't a tree search
- a path outside the indexed project root, like a scratch file in `/tmp`
- a file written seconds ago, before the index has caught up

On a busy day that's most of the times it appears, which trains agents to hesitate on searches that were fine. The footer is also appended to output that already went through the indexed grep tool — the rewrite happened, then the result gets told not to do what it just did.

## Change

Suppress the footer when the target is an existing file, resolves outside the project root, or has an mtime inside a 60s window. Tree searches over indexed project paths keep it, which is the case the footer exists for. Errors and missing paths keep it too.

Nothing about the rewrite changes — same routing, same results, only the appended hint.

The mtime condition does real work on directories: a directory whose mtime moved recently had files added or removed, so the index may lag and a tree search there is reasonable.

## Two implementations, both needed

`add_grep_footer` in `bash_rewrite` covers commands the Rust rewrite handles. `maybeAppendGrepSearchHint` in `aft-bridge/src/bash-hints.ts` covers the ones it rejects — including anything piped, since the rewrite bails on pipes.

Fixing only the Rust side leaves this split:

```
grep -n foo src/app.ts            → silent
grep -n foo src/app.ts | head -5  → still lectured
```

So both paths got the same conditions. The TS side already handled the outside-root case, including `cd` tracking across statements; only the file and freshness conditions were added there.

Two things worth flagging:

- The 60s window is now a constant in each language and they can drift apart. Sharing it across the FFI boundary looked worse than the duplication, but say the word if you'd rather have it derived.
- `bash-hints.ts` was pure and now calls `fs.statSync` — one guarded stat per in-project operand, and any throw keeps the footer.

For multi-operand greps like `grep foo src/app.ts src/`, an explicit file suppresses. Naming a file is the signal that this isn't a tree search.

## Tests

Six unit tests in `rules.rs` and five in `bash-hints.test.ts`, covering each condition and its negative.

Two existing e2e fixtures needed their target directory backdated. They build a `tempdir` milliseconds before asserting, so the directory is newborn and now suppresses under the freshness rule — an artifact of the fixture, not of the behavior being tested. Backdating restores what they were written to check.

`cargo test bash_rewrite` 12 unit + 20 integration; `cargo test --lib` 2142; aft-bridge 415; plugin suites at baseline.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788277115&installation_model_id=22398&pr_number=176&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F176&signature=d7fe0b57a93deb460dbe3896156e638fac280a1a7b13908db963d10cedb7ac67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop showing the grep/rg warning footer on single-file, external, or freshly modified targets. The hint still appears for tree searches in the indexed project where it's useful.

- **Bug Fixes**
  - Suppress footer when: the target is an existing file, resolves outside the project root, or was modified within 60s (directories included).
  - Apply the same logic in Rust (`bash_rewrite` footer) and in TS (`@cortexkit/aft-bridge` piped/rejected greps).
  - Tree searches under the project keep the footer; missing paths and errors keep it.
  - Multi-operand greps suppress if any operand is an existing file.
  - No change to rewrite routing or results; only the appended hint behavior.

- **Tests**
  - Added unit tests in Rust and TS for all conditions.
  - Updated e2e fixtures to backdate directories to avoid accidental freshness suppression.

<sup>Written for commit b9d7ef850b9eac1d0e547ca18c33abbf2c2d1c72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

