### PR TITLE
A/B probe (do not merge): flush reorder only

### DIFF
--- a/crates/aft/src/main.rs
+++ b/crates/aft/src/main.rs
@@ -367,8 +367,11 @@ fn drain_runtime_events_and_write_pending(
     registry: &RuntimeRegistry,
     pending: &mut PendingResponses,
 ) -> io::Result<usize> {
+    let ctx = registry.current();
+    let mut written = write_ready_pending(ctx, pending)?;
     drain_runtime_events(registry);
-    write_ready_pending(registry.current(), pending)
+    written += write_ready_pending(ctx, pending)?;
+    Ok(written)
 }
 
 fn write_ready_pending(ctx: &AppContext, pending: &mut PendingResponses) -> io::Result<usize> {
@@ -381,8 +384,11 @@ fn drain_runtime_events_and_write_pending_to_writer(
     pending: &mut PendingResponses,
     writer: &mut impl Write,
 ) -> io::Result<usize> {
+    let ctx = registry.current();
+    let mut written = write_ready_pending_to_writer(ctx, pending, writer)?;
     drain_runtime_events(registry);
-    write_ready_pending_to_writer(registry.current(), pending, writer)
+    written += write_ready_pending_to_writer(ctx, pending, writer)?;
+    Ok(written)
 }
 
 #[cfg(test)]
@@ -1278,9 +1284,58 @@ mod pending_response_tests {
             0
         );
         assert_eq!(drain_frames.load(Ordering::SeqCst), 1);
-        assert_eq!(poll_calls.get(), 1);
+        assert_eq!(poll_calls.get(), 2);
         assert!(writer.is_empty());
         assert!(!pending.is_empty());
+    }
+
+    #[test]
+    fn tick_flushes_ready_pending_before_runtime_maintenance() {
+        let root = TempDir::new().unwrap();
+        let registry = make_runtime_registry(root.path());
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let events_for_drain = Arc::clone(&events);
+        registry
+            .current()
+            .set_progress_sender(Some(Arc::new(Box::new(move |_| {
+                events_for_drain.lock().unwrap().push("drain");
+            }))));
+        let generation = registry.current().advance_configure_generation();
+        registry
+            .current()
+            .configure_warnings_sender()
+            .send((
+                generation,
+                ConfigureWarningsFrame {
+                    frame_type: "configure_warnings",
+                    session_id: Some("session-order".to_string()),
+                    project_root: root.path().display().to_string(),
+                    warnings: Vec::new(),
+                },
+            ))
+            .unwrap();
+
+        let events_for_pending = Arc::clone(&events);
+        let mut pending = PendingResponses::default();
+        pending.register(PendingResponse {
+            request_id: "pending-order".to_string(),
+            session_id: "session-order".to_string(),
+            attach_command: "bash".to_string(),
+            poll: Box::new(move |_| {
+                events_for_pending.lock().unwrap().push("pending");
+                Some(Response::success("pending-order", serde_json::json!({})))
+            }),
+        });
+        let mut writer = Vec::new();
+
+        assert_eq!(
+            drain_runtime_events_and_write_pending_to_writer(&registry, &mut pending, &mut writer)
+                .unwrap(),
+            1
+        );
+        assert_eq!(*events.lock().unwrap(), ["pending", "drain"]);
+        assert_eq!(line_values(&writer).len(), 1);
+        assert!(pending.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Single-commit probe off green base 566bcde2: f957d38d (flush pending before runtime maintenance). Windows dead-code manifest test verdict wanted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788543108&installation_model_id=22398&pr_number=181&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F181&signature=37a3cf8f55d5ca6c52c3f948edbb13d1ed8937e18fbd421d437e3e75a03413b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered the tick to flush ready pending responses before runtime maintenance, then flush again after using the same context. This ensures pending responses are written deterministically and fixes ordering issues seen on Windows.

- **Bug Fixes**
  - Call `write_ready_pending`/`write_ready_pending_to_writer` before `drain_runtime_events`, then again after; accumulate writes.
  - Capture `ctx` once to avoid context changes mid-tick.
  - Added `tick_flushes_ready_pending_before_runtime_maintenance` test and updated poll count expectations.

<sup>Written for commit 23f28131383ea8342109bcad4f390f04c68c867c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

