### PR TITLE
A/B probe (do not merge): lsp cold-start only

### DIFF
--- a/crates/aft/src/context.rs
+++ b/crates/aft/src/context.rs
@@ -5442,7 +5442,7 @@ impl AppContext {
     pub fn lsp_notify_file_changed(&self, file_path: &Path, content: &str) {
         let config = self.config();
         if let Some(mut lsp) = self.lsp_manager.try_lock() {
-            if let Err(e) = lsp.notify_file_changed(file_path, content, &config) {
+            if let Err(e) = lsp.notify_file_changed_if_running(file_path, content, &config) {
                 crate::slog_warn!("sync error for {}: {}", file_path.display(), e);
             }
         }

--- a/crates/aft/src/lsp/manager.rs
+++ b/crates/aft/src/lsp/manager.rs
@@ -370,6 +370,23 @@ impl LspManager {
             .successful
     }
 
+    fn running_server_keys_for_file(&self, file_path: &Path, config: &Config) -> Vec<ServerKey> {
+        let mut keys = Vec::new();
+        for def in servers_for_file(file_path, config) {
+            let Some(root) = def.workspace_root_for_file(file_path) else {
+                continue;
+            };
+            let key = ServerKey {
+                kind: def.kind.clone(),
+                root,
+            };
+            if self.clients.contains_key(&key) {
+                keys.push(key);
+            }
+        }
+        keys
+    }
+
     /// Detailed version of [`ensure_server_for_file`] that records every
     /// matching server's outcome (`Ok` / `NoRootMarker` / `BinaryNotInstalled`
     /// / `SpawnFailed`).
@@ -628,6 +645,32 @@ impl LspManager {
     ) -> Result<Vec<(ServerKey, i32)>, LspError> {
         let canonical_path = canonicalize_for_lsp(file_path)?;
         let server_keys = self.ensure_server_for_file(&canonical_path, config);
+        self.notify_file_changed_for_server_keys(canonical_path, content, server_keys)
+    }
+
+    /// Notify only LSP servers that are already running for this file.
+    ///
+    /// Post-write notifications are best-effort and must not make a mutation
+    /// wait for cold server startup. Explicit LSP requests use
+    /// [`Self::notify_file_changed_versioned`] and retain lazy startup.
+    pub fn notify_file_changed_if_running(
+        &mut self,
+        file_path: &Path,
+        content: &str,
+        config: &Config,
+    ) -> Result<(), LspError> {
+        let canonical_path = canonicalize_for_lsp(file_path)?;
+        let server_keys = self.running_server_keys_for_file(&canonical_path, config);
+        self.notify_file_changed_for_server_keys(canonical_path, content, server_keys)
+            .map(|_| ())
+    }
+
+    fn notify_file_changed_for_server_keys(
+        &mut self,
+        canonical_path: PathBuf,
+        content: &str,
+        server_keys: Vec<ServerKey>,
+    ) -> Result<Vec<(ServerKey, i32)>, LspError> {
         if server_keys.is_empty() {
             return Ok(Vec::new());
         }
@@ -2153,7 +2196,10 @@ mod failure_hint_tests {
 
 #[cfg(test)]
 mod diagnostic_capacity_tests {
+    use std::fs;
+
     use super::LspManager;
+    use crate::config::Config;
 
     // The lsp.diagnostic_cache_size config knob must actually take effect:
     // set_diagnostic_capacity (called at AppContext construction with the config
@@ -2177,6 +2223,20 @@ mod diagnostic_capacity_tests {
         manager.insert_failed_spawn_for_test();
         assert_eq!(manager.clear_failed_spawns(), 1);
         assert_eq!(manager.clear_failed_spawns(), 0);
+    }
+
+    #[test]
+    fn post_write_notification_does_not_start_a_cold_server() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("main.ts");
+        fs::write(dir.path().join("package.json"), "{}").unwrap();
+        fs::write(&file, "export const value = 1;\n").unwrap();
+
+        let mut manager = LspManager::new();
+        manager
+            .notify_file_changed_if_running(&file, "export const value = 1;\n", &Config::default())
+            .unwrap();
+        assert!(manager.clients.is_empty());
     }
 }
 


### PR DESCRIPTION
Single-commit probe off green base 566bcde2: 0904eee8 (notify_file_changed_if_running). Windows dead-code manifest test verdict wanted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788543110&installation_model_id=22398&pr_number=182&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F182&signature=058480026fa7f2a8f76e76df802928b6516b90f7ab7cce65cfdb0f0c28b217e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoid cold-starting LSP servers after file writes. Post-write notifications now only target servers that are already running; interactive requests still start servers when needed.

- **Bug Fixes**
  - Added `LspManager::notify_file_changed_if_running` to send updates only to running servers.
  - Switched `AppContext::lsp_notify_file_changed` to the new method to prevent cold starts after mutations.
  - Added helpers to target running servers and a test that confirms no client is started on post-write notifications.

<sup>Written for commit d7bf9a5395f20d93df275aaf2c614090bc440f6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

