### PR TITLE
A/B probe (do not merge): introspect Windows entry-point membership

### DIFF
--- a/crates/aft/src/callgraph_store/dead_code_projection.rs
+++ b/crates/aft/src/callgraph_store/dead_code_projection.rs
@@ -277,6 +277,16 @@ fn outbound_calls_from_store(
 
 fn entry_points_for_files(project_root: &Path, files: &[PathBuf]) -> BTreeSet<PathBuf> {
     let resolved_entry_points = crate::inspect::resolve_entry_points(project_root);
+    // CI probe instrumentation (probe branch only): name every path spelling
+    // feeding the membership decision so the Windows-only miss is attributable.
+    eprintln!("PROBE projection root = {}", project_root.display());
+    for file in files {
+        eprintln!(
+            "PROBE file = {} | is_entry_point = {}",
+            file.display(),
+            resolved_entry_points.is_entry_point(file)
+        );
+    }
     files
         .iter()
         .filter(|file| resolved_entry_points.is_entry_point(file))

--- a/crates/aft/src/inspect/entry_points.rs
+++ b/crates/aft/src/inspect/entry_points.rs
@@ -784,7 +784,20 @@ fn insert_resolved_entry_point(
 
 fn contains_path(paths: &BTreeSet<PathBuf>, file: &Path) -> bool {
     let snapshot = snapshot_path(file);
-    paths.contains(&snapshot) || paths.contains(&normalize_path(file))
+    let hit = paths.contains(&snapshot) || paths.contains(&normalize_path(file));
+    if !hit {
+        // CI probe instrumentation (probe branch only).
+        eprintln!("PROBE contains_path MISS for {}", file.display());
+        eprintln!("PROBE   snapshot form = {}", snapshot.display());
+        eprintln!(
+            "PROBE   normalize form = {}",
+            normalize_path(file).display()
+        );
+        for p in paths.iter() {
+            eprintln!("PROBE   set entry = {}", p.display());
+        }
+    }
+    hit
 }
 
 fn snapshot_path(path: &Path) -> PathBuf {

--- a/crates/aft/src/inspect/scanners/dead_code.rs
+++ b/crates/aft/src/inspect/scanners/dead_code.rs
@@ -596,10 +596,10 @@ fn materialize_dead_code_contributions(
     for (key, calls) in &outbound_calls_by_caller_file {
         for call in calls.iter().take(4) {
             eprintln!(
-                "PROBE2 outbound key = {} | caller_file = {} | callee = {}",
+                "PROBE2 outbound key = {} | caller_file = {} | target = {}",
                 key.display(),
                 call.caller_file.display(),
-                call.callee_name
+                call.target
             );
         }
     }

--- a/crates/aft/src/inspect/scanners/dead_code.rs
+++ b/crates/aft/src/inspect/scanners/dead_code.rs
@@ -584,6 +584,26 @@ fn materialize_dead_code_contributions(
         group_outbound_calls_by_caller_file(project_root, &snapshot.outbound_calls);
     let oxc_by_file = oxc_verdicts_by_file(project_root, snapshot, &parsed, public_api_files);
 
+    // CI probe instrumentation (probe branch only): dump the verdict inputs
+    // for the Cargo-bin liveness decision.
+    eprintln!("PROBE2 verdict project_root = {}", project_root.display());
+    for f in &liveness_root_files {
+        eprintln!("PROBE2 liveness_root_rel = {f}");
+    }
+    for (f, exports) in &executable_root_exports_by_file {
+        eprintln!("PROBE2 exec_root_rel = {f} exports = {exports:?}");
+    }
+    for (key, calls) in &outbound_calls_by_caller_file {
+        for call in calls.iter().take(4) {
+            eprintln!(
+                "PROBE2 outbound key = {} | caller_file = {} | callee = {}",
+                key.display(),
+                call.caller_file.display(),
+                call.callee_name
+            );
+        }
+    }
+
     parsed
         .into_iter()
         .map(|mut contribution| {


### PR DESCRIPTION
Instrumentation probe on top of main: prints the projection root, every store file path, and on membership miss the full entry-point set with both normalized forms. The Windows job's PROBE lines name the mechanism.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788545884&installation_model_id=22398&pr_number=184&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F184&signature=644cbbf809f8136d8d8c268575c7c7dca73d4a3d3a3d2491b66c79a117451825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI-only probe to log entry-point membership resolution and verdict-side liveness inputs to reproduce a Windows-only miss. Prints the projection root and each store file with its is_entry_point result; on a miss, logs snapshot/normalized paths and the full entry-point set (PROBE), plus liveness roots, executable root exports, and sampled outbound calls used in the dead-code verdict with corrected field names (PROBE2).

<sup>Written for commit b77f7a744e406d26df5dd6ef5c1601f6a1b46970. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

