### PR TITLE
A/B probe (do not merge): introspect at the green base

### DIFF
--- a/crates/aft/src/callgraph_store/dead_code_projection.rs
+++ b/crates/aft/src/callgraph_store/dead_code_projection.rs
@@ -277,6 +277,16 @@ fn outbound_calls_from_store(
 
 fn entry_points_for_files(project_root: &Path, files: &[PathBuf]) -> BTreeSet<PathBuf> {
     let resolved_entry_points = crate::inspect::resolve_entry_points(project_root);
+    // CI probe instrumentation (probe branch only): name every path spelling
+    // feeding the membership decision so the Windows-only miss is attributable.
+    eprintln!("PROBE projection root = {}", project_root.display());
+    for file in files {
+        eprintln!(
+            "PROBE file = {} | is_entry_point = {}",
+            file.display(),
+            resolved_entry_points.is_entry_point(file)
+        );
+    }
     files
         .iter()
         .filter(|file| resolved_entry_points.is_entry_point(file))

--- a/crates/aft/src/inspect/entry_points.rs
+++ b/crates/aft/src/inspect/entry_points.rs
@@ -784,7 +784,20 @@ fn insert_resolved_entry_point(
 
 fn contains_path(paths: &BTreeSet<PathBuf>, file: &Path) -> bool {
     let snapshot = snapshot_path(file);
-    paths.contains(&snapshot) || paths.contains(&normalize_path(file))
+    let hit = paths.contains(&snapshot) || paths.contains(&normalize_path(file));
+    if !hit {
+        // CI probe instrumentation (probe branch only).
+        eprintln!("PROBE contains_path MISS for {}", file.display());
+        eprintln!("PROBE   snapshot form = {}", snapshot.display());
+        eprintln!(
+            "PROBE   normalize form = {}",
+            normalize_path(file).display()
+        );
+        for p in paths.iter() {
+            eprintln!("PROBE   set entry = {}", p.display());
+        }
+    }
+    hit
 }
 
 fn snapshot_path(path: &Path) -> PathBuf {

--- a/crates/aft/src/inspect/scanners/dead_code.rs
+++ b/crates/aft/src/inspect/scanners/dead_code.rs
@@ -596,10 +596,10 @@ fn materialize_dead_code_contributions(
     for (key, calls) in &outbound_calls_by_caller_file {
         for call in calls.iter().take(4) {
             eprintln!(
-                "PROBE2 outbound key = {} | caller_file = {} | callee = {}",
+                "PROBE2 outbound key = {} | caller_file = {} | target = {}",
                 key.display(),
                 call.caller_file.display(),
-                call.callee_name
+                call.target
             );
         }
     }

--- a/crates/aft/src/inspect/scanners/dead_code.rs
+++ b/crates/aft/src/inspect/scanners/dead_code.rs
@@ -584,6 +584,26 @@ fn materialize_dead_code_contributions(
         group_outbound_calls_by_caller_file(project_root, &snapshot.outbound_calls);
     let oxc_by_file = oxc_verdicts_by_file(project_root, snapshot, &parsed, public_api_files);
 
+    // CI probe instrumentation (probe branch only): dump the verdict inputs
+    // for the Cargo-bin liveness decision.
+    eprintln!("PROBE2 verdict project_root = {}", project_root.display());
+    for f in &liveness_root_files {
+        eprintln!("PROBE2 liveness_root_rel = {f}");
+    }
+    for (f, exports) in &executable_root_exports_by_file {
+        eprintln!("PROBE2 exec_root_rel = {f} exports = {exports:?}");
+    }
+    for (key, calls) in &outbound_calls_by_caller_file {
+        for call in calls.iter().take(4) {
+            eprintln!(
+                "PROBE2 outbound key = {} | caller_file = {} | callee = {}",
+                key.display(),
+                call.caller_file.display(),
+                call.callee_name
+            );
+        }
+    }
+
     parsed
         .into_iter()
         .map(|mut contribution| {


### PR DESCRIPTION
Same instrumentation as #184, applied to the previously-green base 566bcde2. The Windows PROBE/PROBE2 lines here answer why the base fails under today's runner image when the same-day green run passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788548808&installation_model_id=22398&pr_number=190&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F190&signature=b0b8403445dff0efaa819190cb38d87dce20c70123e493a7fb3f60d7ffbd7e8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add temporary CI probe logging to diagnose Windows-only failures on the current runner image by introspecting entry-point checks and liveness inputs. Logs are marked PROBE/PROBE2 for easy filtering.

- **New Features**
  - Log entry-point membership decisions with all path spellings.
  - Dump contains_path misses with snapshot/normalized forms and set entries.
  - Emit liveness verdict inputs: liveness roots, executable root exports, and grouped outbound calls.

<sup>Written for commit 7296eb0d00d112ce095d16da17fabbcae0359f91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

