### PR TITLE
Improve Rust callgraph resolution for direct self fields

### DIFF
--- a/crates/aft/src/callgraph_store/mod.rs
+++ b/crates/aft/src/callgraph_store/mod.rs
@@ -8755,7 +8755,7 @@ fn parse_method_dispatch(full_ref: &str) -> Option<(String, String, String, bool
         return None;
     }
     let receiver_expression = full_ref[..delimiter].trim();
-    let receiver = last_name_segment(receiver_expression);
+    let receiver = last_name_segment(receiver_expression).trim();
     let member = &full_ref[member_start..];
     if receiver.is_empty() || member.is_empty() {
         return None;

--- a/crates/aft/src/callgraph_store/mod.rs
+++ b/crates/aft/src/callgraph_store/mod.rs
@@ -9807,6 +9807,8 @@ fn infer_rust_direct_self_field_receiver_type(
 
 fn rust_direct_self_field_name(receiver_expression: &str) -> Option<&str> {
     let (base, field) = receiver_expression.split_once('.')?;
+    let base = base.trim();
+    let field = field.trim();
     (base == "self" && rust_direct_nominal_type_name(field).is_some()).then_some(field)
 }
 
@@ -14100,6 +14102,16 @@ void handle() {
             infer_receiver_type(root, &factory_ref, &mut cache).as_deref(),
             Some("FactoryFoo")
         );
+    }
+
+    #[test]
+    fn rust_direct_self_field_name_trims_separator_whitespace() {
+        for receiver_expression in ["self .engine", "self. engine", "self . engine"] {
+            assert_eq!(
+                rust_direct_self_field_name(receiver_expression),
+                Some("engine")
+            );
+        }
     }
 
     #[test]

--- a/crates/aft/src/callgraph_store/mod.rs
+++ b/crates/aft/src/callgraph_store/mod.rs
@@ -1665,6 +1665,7 @@ struct NameMatchRef {
     caller_file: String,
     caller_symbol: String,
     caller_signature: Option<String>,
+    receiver_expression: String,
     receiver: String,
     method_name: String,
     colon_dispatch: bool,
@@ -1678,6 +1679,8 @@ struct NameMatchCandidate {
     file_path: String,
     scoped_name: String,
     kind: String,
+    // Nodes persist tree-sitter's zero-based rows; dispatch AST helpers use one-based lines.
+    start_line: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -8462,17 +8465,39 @@ fn insert_method_dispatch_edges(
             }
         };
 
-        if let Some(receiver_type) =
-            infer_receiver_type(project_root, &reference, &mut source_cache)
-        {
-            let Some(candidate) =
-                select_type_match_candidate(&reference, candidates.as_slice(), &receiver_type)
-            else {
+        match infer_receiver_type_state(project_root, &reference, &mut source_cache) {
+            ReceiverTypeInference::Known(receiver_type) => {
+                let Some(candidate) =
+                    select_type_match_candidate(&reference, candidates.as_slice(), &receiver_type)
+                else {
+                    continue;
+                };
+                insert_method_dispatch_edge(tx, &reference, &candidate, PROVENANCE_TYPE_MATCH)?;
+                inserted += 1;
                 continue;
-            };
-            insert_method_dispatch_edge(tx, &reference, &candidate, PROVENANCE_TYPE_MATCH)?;
-            inserted += 1;
-            continue;
+            }
+            ReceiverTypeInference::RustDirectSelfField {
+                receiver_type,
+                declaration_file,
+                module_scope,
+            } => {
+                let Some(candidate) = select_rust_direct_self_field_candidate(
+                    project_root,
+                    &reference,
+                    candidates.as_slice(),
+                    &receiver_type,
+                    &declaration_file,
+                    &module_scope,
+                    &mut source_cache,
+                ) else {
+                    continue;
+                };
+                insert_method_dispatch_edge(tx, &reference, &candidate, PROVENANCE_TYPE_MATCH)?;
+                inserted += 1;
+                continue;
+            }
+            ReceiverTypeInference::KnownButUnresolved => continue,
+            ReceiverTypeInference::Unknown => {}
         }
 
         if method_name_match_denylisted(&reference.method_name) {
@@ -8693,7 +8718,7 @@ fn name_match_ref_from_parts(
 ) -> Option<NameMatchRef> {
     let caller_node = caller_node?;
     let full_ref = full_ref?;
-    let (receiver, member, colon_dispatch) = parse_method_dispatch(&full_ref)?;
+    let (receiver_expression, receiver, member, colon_dispatch) = parse_method_dispatch(&full_ref)?;
     let method_name = if member.is_empty() {
         short_name.as_deref()?.to_string()
     } else {
@@ -8705,6 +8730,7 @@ fn name_match_ref_from_parts(
         caller_file,
         caller_symbol,
         caller_signature,
+        receiver_expression,
         receiver,
         method_name,
         colon_dispatch,
@@ -8713,7 +8739,7 @@ fn name_match_ref_from_parts(
     })
 }
 
-fn parse_method_dispatch(full_ref: &str) -> Option<(String, String, bool)> {
+fn parse_method_dispatch(full_ref: &str) -> Option<(String, String, String, bool)> {
     let dot = full_ref.rfind('.').map(|index| (index, 1usize, false));
     let colon = full_ref.rfind("::").map(|index| (index, 2usize, true));
     let arrow = full_ref.rfind("->").map(|index| (index, 2usize, false));
@@ -8728,12 +8754,18 @@ fn parse_method_dispatch(full_ref: &str) -> Option<(String, String, bool)> {
     if member_start >= full_ref.len() {
         return None;
     }
-    let receiver = last_name_segment(&full_ref[..delimiter]);
+    let receiver_expression = full_ref[..delimiter].trim();
+    let receiver = last_name_segment(receiver_expression);
     let member = &full_ref[member_start..];
     if receiver.is_empty() || member.is_empty() {
         return None;
     }
-    Some((receiver.to_string(), member.to_string(), colon_dispatch))
+    Some((
+        receiver_expression.to_string(),
+        receiver.to_string(),
+        member.to_string(),
+        colon_dispatch,
+    ))
 }
 
 fn last_name_segment(value: &str) -> &str {
@@ -8749,7 +8781,7 @@ fn load_name_match_candidates(
     lang: &str,
 ) -> Result<Vec<NameMatchCandidate>> {
     let mut stmt = tx.prepare(
-        "SELECT n.id, n.file_path, n.scoped_name, n.kind
+        "SELECT n.id, n.file_path, n.scoped_name, n.kind, n.start_line
          FROM nodes n JOIN files f ON f.path = n.file_path
          WHERE n.name = ?1
            AND f.lang = ?2
@@ -8762,6 +8794,7 @@ fn load_name_match_candidates(
             file_path: row.get(1)?,
             scoped_name: row.get(2)?,
             kind: row.get(3)?,
+            start_line: (row.get::<_, i64>(4)?.max(0) as u32).saturating_add(1),
         })
     })?;
     rows.collect::<std::result::Result<Vec<_>, _>>()
@@ -8775,21 +8808,53 @@ struct ParsedDispatchSource {
 
 type DispatchSourceCache = HashMap<(String, String), Option<ParsedDispatchSource>>;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ReceiverTypeInference {
+    Unknown,
+    Known(String),
+    RustDirectSelfField {
+        receiver_type: String,
+        declaration_file: String,
+        module_scope: Vec<(usize, usize)>,
+    },
+    KnownButUnresolved,
+}
+
+#[cfg(test)]
 fn infer_receiver_type(
     project_root: &Path,
     reference: &NameMatchRef,
     source_cache: &mut DispatchSourceCache,
 ) -> Option<String> {
+    match infer_receiver_type_state(project_root, reference, source_cache) {
+        ReceiverTypeInference::Known(receiver_type)
+        | ReceiverTypeInference::RustDirectSelfField { receiver_type, .. } => Some(receiver_type),
+        ReceiverTypeInference::Unknown | ReceiverTypeInference::KnownButUnresolved => None,
+    }
+}
+
+fn infer_receiver_type_state(
+    project_root: &Path,
+    reference: &NameMatchRef,
+    source_cache: &mut DispatchSourceCache,
+) -> ReceiverTypeInference {
+    let known = |receiver_type| ReceiverTypeInference::Known(receiver_type);
     match reference.lang.as_str() {
-        "rust" => infer_rust_receiver_type(reference),
+        "rust" => infer_rust_receiver_type(project_root, reference, source_cache),
         "java" => {
             infer_java_like_receiver_type(project_root, reference, LangId::Java, source_cache)
+                .map(known)
+                .unwrap_or(ReceiverTypeInference::Unknown)
         }
         "kotlin" => {
             infer_java_like_receiver_type(project_root, reference, LangId::Kotlin, source_cache)
+                .map(known)
+                .unwrap_or(ReceiverTypeInference::Unknown)
         }
-        "cpp" => infer_cpp_receiver_type(project_root, reference, source_cache),
-        _ => None,
+        "cpp" => infer_cpp_receiver_type(project_root, reference, source_cache)
+            .map(known)
+            .unwrap_or(ReceiverTypeInference::Unknown),
+        _ => ReceiverTypeInference::Unknown,
     }
 }
 
@@ -8812,10 +8877,26 @@ fn parsed_dispatch_source<'a>(
     lang: LangId,
     source_cache: &'a mut DispatchSourceCache,
 ) -> Option<&'a ParsedDispatchSource> {
-    let key = (reference.caller_file.clone(), reference.lang.clone());
+    parsed_dispatch_source_for_file(
+        project_root,
+        &reference.caller_file,
+        &reference.lang,
+        lang,
+        source_cache,
+    )
+}
+
+fn parsed_dispatch_source_for_file<'a>(
+    project_root: &Path,
+    file_path: &str,
+    lang_label: &str,
+    lang: LangId,
+    source_cache: &'a mut DispatchSourceCache,
+) -> Option<&'a ParsedDispatchSource> {
+    let key = (file_path.to_string(), lang_label.to_string());
     source_cache
         .entry(key)
-        .or_insert_with(|| parse_dispatch_source(project_root, &reference.caller_file, lang))
+        .or_insert_with(|| parse_dispatch_source(project_root, file_path, lang))
         .as_ref()
 }
 
@@ -9619,19 +9700,198 @@ fn is_code_ident_char(ch: char) -> bool {
     ch == '_' || ch.is_ascii_alphanumeric()
 }
 
-fn infer_rust_receiver_type(reference: &NameMatchRef) -> Option<String> {
+fn infer_rust_receiver_type(
+    project_root: &Path,
+    reference: &NameMatchRef,
+    source_cache: &mut DispatchSourceCache,
+) -> ReceiverTypeInference {
     if matches!(reference.receiver.as_str(), "self" | "Self") {
-        return enclosing_type_from_scoped_name(&reference.caller_symbol);
+        return enclosing_type_from_scoped_name(&reference.caller_symbol)
+            .map(ReceiverTypeInference::Known)
+            .unwrap_or(ReceiverTypeInference::Unknown);
     }
 
     if reference.colon_dispatch && rust_receiver_looks_type_like(&reference.receiver) {
-        return Some(reference.receiver.clone());
+        return ReceiverTypeInference::Known(reference.receiver.clone());
     }
 
-    reference
+    if let Some(receiver_type) = reference
         .caller_signature
         .as_deref()
         .and_then(|signature| rust_parameter_type(signature, &reference.receiver))
+    {
+        return ReceiverTypeInference::Known(receiver_type);
+    }
+
+    infer_rust_direct_self_field_receiver_type(project_root, reference, source_cache)
+}
+
+fn infer_rust_direct_self_field_receiver_type(
+    project_root: &Path,
+    reference: &NameMatchRef,
+    source_cache: &mut DispatchSourceCache,
+) -> ReceiverTypeInference {
+    if reference.colon_dispatch {
+        return ReceiverTypeInference::Unknown;
+    }
+    let Some(field_name) = rust_direct_self_field_name(&reference.receiver_expression) else {
+        return ReceiverTypeInference::Unknown;
+    };
+    if field_name != reference.receiver {
+        return ReceiverTypeInference::Unknown;
+    }
+
+    let Some(impl_type) = enclosing_type_from_scoped_name(&reference.caller_symbol) else {
+        return ReceiverTypeInference::Unknown;
+    };
+    let Some(struct_name) = rust_direct_nominal_type_name(&impl_type) else {
+        return ReceiverTypeInference::KnownButUnresolved;
+    };
+    let Some(parsed) = parsed_dispatch_source(project_root, reference, LangId::Rust, source_cache)
+    else {
+        return ReceiverTypeInference::Unknown;
+    };
+    let Some(impl_node) =
+        find_enclosing_rust_impl_node(parsed.tree.root_node(), reference.line.max(1))
+    else {
+        return ReceiverTypeInference::Unknown;
+    };
+    if impl_node.child_by_field_name("trait").is_some()
+        || impl_node.child_by_field_name("type_parameters").is_some()
+    {
+        return ReceiverTypeInference::KnownButUnresolved;
+    }
+    let Some(impl_target) = impl_node.child_by_field_name("type") else {
+        return ReceiverTypeInference::KnownButUnresolved;
+    };
+    if impl_target.kind() != "type_identifier"
+        || node_text(impl_target, &parsed.source) != impl_type
+    {
+        return ReceiverTypeInference::KnownButUnresolved;
+    }
+
+    let module_scope = rust_module_scope(impl_node);
+    let Some(struct_node) = find_unique_rust_struct(
+        parsed.tree.root_node(),
+        &parsed.source,
+        struct_name,
+        &module_scope,
+    ) else {
+        return ReceiverTypeInference::KnownButUnresolved;
+    };
+    let Some(field_type) = rust_struct_field_type_node(struct_node, &parsed.source, field_name)
+    else {
+        return ReceiverTypeInference::KnownButUnresolved;
+    };
+    if field_type.kind() != "type_identifier" {
+        return ReceiverTypeInference::KnownButUnresolved;
+    }
+    let field_type_name = node_text(field_type, &parsed.source);
+    if find_unique_rust_struct(
+        parsed.tree.root_node(),
+        &parsed.source,
+        field_type_name,
+        &module_scope,
+    )
+    .is_none()
+    {
+        return ReceiverTypeInference::KnownButUnresolved;
+    }
+
+    ReceiverTypeInference::RustDirectSelfField {
+        receiver_type: field_type_name.to_string(),
+        declaration_file: reference.caller_file.clone(),
+        module_scope,
+    }
+}
+
+fn rust_direct_self_field_name(receiver_expression: &str) -> Option<&str> {
+    let (base, field) = receiver_expression.split_once('.')?;
+    (base == "self" && rust_direct_nominal_type_name(field).is_some()).then_some(field)
+}
+
+fn rust_direct_nominal_type_name(value: &str) -> Option<&str> {
+    let name = value.rsplit("::").next()?.trim();
+    (!name.is_empty()
+        && !name.chars().next().is_some_and(|ch| ch.is_ascii_digit())
+        && name.chars().all(is_rust_ident_char))
+    .then_some(name)
+}
+
+fn find_enclosing_rust_impl_node<'tree>(
+    root: tree_sitter::Node<'tree>,
+    line: u32,
+) -> Option<tree_sitter::Node<'tree>> {
+    let mut best = None;
+    let mut stack = vec![root];
+    while let Some(node) = stack.pop() {
+        if !node_contains_line(node, line) {
+            continue;
+        }
+        if node.kind() == "impl_item" {
+            best = tighter_node(best, node);
+        }
+        push_named_children(node, &mut stack);
+    }
+    best
+}
+
+fn rust_module_scope(node: tree_sitter::Node<'_>) -> Vec<(usize, usize)> {
+    let mut scope = Vec::new();
+    let mut current = node.parent();
+    while let Some(parent) = current {
+        if parent.kind() == "mod_item" {
+            scope.push((parent.start_byte(), parent.end_byte()));
+        }
+        current = parent.parent();
+    }
+    scope.reverse();
+    scope
+}
+
+fn find_unique_rust_struct<'tree>(
+    root: tree_sitter::Node<'tree>,
+    source: &str,
+    expected_name: &str,
+    module_scope: &[(usize, usize)],
+) -> Option<tree_sitter::Node<'tree>> {
+    let mut found = None;
+    let mut stack = vec![root];
+    while let Some(node) = stack.pop() {
+        if node.kind() == "struct_item"
+            && rust_module_scope(node) == module_scope
+            && node.child_by_field_name("type_parameters").is_none()
+            && declaration_name(node, source) == Some(expected_name)
+        {
+            if found.is_some() {
+                return None;
+            }
+            found = Some(node);
+        }
+        push_named_children(node, &mut stack);
+    }
+    found
+}
+
+fn rust_struct_field_type_node<'tree>(
+    struct_node: tree_sitter::Node<'tree>,
+    source: &str,
+    field_name: &str,
+) -> Option<tree_sitter::Node<'tree>> {
+    let fields = struct_node.child_by_field_name("body")?;
+    if fields.kind() != "field_declaration_list" {
+        return None;
+    }
+    for index in 0..fields.named_child_count() {
+        let field = fields.named_child(index as u32)?;
+        if field.kind() != "field_declaration"
+            || declaration_name(field, source) != Some(field_name)
+        {
+            continue;
+        }
+        return field.child_by_field_name("type");
+    }
+    None
 }
 
 fn rust_receiver_looks_type_like(receiver: &str) -> bool {
@@ -9828,6 +10088,76 @@ fn rust_base_type_ident(ty: &str) -> Option<String> {
 
 fn is_rust_ident_char(ch: char) -> bool {
     ch == '_' || ch.is_ascii_alphanumeric()
+}
+
+fn select_rust_direct_self_field_candidate(
+    project_root: &Path,
+    reference: &NameMatchRef,
+    candidates: &[NameMatchCandidate],
+    receiver_type: &str,
+    declaration_file: &str,
+    declaration_scope: &[(usize, usize)],
+    source_cache: &mut DispatchSourceCache,
+) -> Option<NameMatchCandidate> {
+    let eligible = candidates
+        .iter()
+        .filter(|candidate| candidate.node_id != reference.caller_node)
+        .filter(|candidate| {
+            type_candidate_matches(candidate, receiver_type, &reference.method_name)
+        })
+        .filter(|candidate| {
+            rust_direct_self_field_candidate_matches_scope(
+                project_root,
+                candidate,
+                receiver_type,
+                declaration_file,
+                declaration_scope,
+                source_cache,
+            )
+        })
+        .collect::<Vec<_>>();
+    match eligible.as_slice() {
+        [candidate] => Some((**candidate).clone()),
+        _ => None,
+    }
+}
+
+fn rust_direct_self_field_candidate_matches_scope(
+    project_root: &Path,
+    candidate: &NameMatchCandidate,
+    receiver_type: &str,
+    declaration_file: &str,
+    declaration_scope: &[(usize, usize)],
+    source_cache: &mut DispatchSourceCache,
+) -> bool {
+    if candidate.file_path != declaration_file {
+        return false;
+    }
+    let Some(parsed) = parsed_dispatch_source_for_file(
+        project_root,
+        &candidate.file_path,
+        "rust",
+        LangId::Rust,
+        source_cache,
+    ) else {
+        return false;
+    };
+    let Some(impl_node) =
+        find_enclosing_rust_impl_node(parsed.tree.root_node(), candidate.start_line)
+    else {
+        return false;
+    };
+    if impl_node.child_by_field_name("trait").is_some()
+        || impl_node.child_by_field_name("type_parameters").is_some()
+    {
+        return false;
+    }
+    let Some(impl_target) = impl_node.child_by_field_name("type") else {
+        return false;
+    };
+    impl_target.kind() == "type_identifier"
+        && node_text(impl_target, &parsed.source) == receiver_type
+        && rust_module_scope(impl_node) == declaration_scope
 }
 
 fn select_type_match_candidate(
@@ -13773,6 +14103,229 @@ void handle() {
     }
 
     #[test]
+    fn rust_direct_self_field_receiver_type_is_conservative() {
+        let source = r#"struct Engine;
+
+struct Car {
+    engine: Engine,
+}
+
+impl Car {
+    fn run(&self) {
+        self.engine.start();
+    }
+}
+
+struct NestedCar {
+    engine: Engine,
+}
+
+impl NestedCar {
+    fn run(&self) {
+        self.inner.engine.start();
+    }
+}
+
+struct WrappedCar {
+    engine: Option<Engine>,
+}
+
+impl WrappedCar {
+    fn run(&self) {
+        self.engine.start(); // wrapped
+    }
+}
+
+struct GenericCar<T> {
+    engine: T,
+}
+
+impl<T> GenericCar<T> {
+    fn run(&self) {
+        self.engine.start(); // generic
+    }
+}
+
+type EngineAlias = Engine;
+
+struct AliasCar {
+    engine: EngineAlias,
+}
+
+impl AliasCar {
+    fn run(&self) {
+        self.engine.start(); // alias
+    }
+}
+"#;
+        let dir = tempdir().expect("temp dir");
+        let root = dir.path();
+        write_fixture(root, "src/lib.rs", source);
+        let mut cache = DispatchSourceCache::new();
+
+        let mut direct = reference(
+            "rust",
+            "src/lib.rs",
+            "Car::run",
+            "engine",
+            "start",
+            line_of(source, "self.engine.start()"),
+        );
+        direct.receiver_expression = "self.engine".to_string();
+        assert_eq!(
+            infer_receiver_type(root, &direct, &mut cache).as_deref(),
+            Some("Engine")
+        );
+
+        let mut mismatched_impl_target = direct.clone();
+        mismatched_impl_target.caller_symbol = "other::Car::run".to_string();
+        assert!(infer_receiver_type(root, &mismatched_impl_target, &mut cache).is_none());
+
+        let mut nested = reference(
+            "rust",
+            "src/lib.rs",
+            "NestedCar::run",
+            "engine",
+            "start",
+            line_of(source, "self.inner.engine.start()"),
+        );
+        nested.receiver_expression = "self.inner.engine".to_string();
+        assert!(infer_receiver_type(root, &nested, &mut cache).is_none());
+
+        let mut wrapped = reference(
+            "rust",
+            "src/lib.rs",
+            "WrappedCar::run",
+            "engine",
+            "start",
+            line_of(source, "self.engine.start(); // wrapped"),
+        );
+        wrapped.receiver_expression = "self.engine".to_string();
+        assert!(infer_receiver_type(root, &wrapped, &mut cache).is_none());
+
+        let mut generic = reference(
+            "rust",
+            "src/lib.rs",
+            "GenericCar::run",
+            "engine",
+            "start",
+            line_of(source, "self.engine.start(); // generic"),
+        );
+        generic.receiver_expression = "self.engine".to_string();
+        assert!(infer_receiver_type(root, &generic, &mut cache).is_none());
+
+        let mut alias = reference(
+            "rust",
+            "src/lib.rs",
+            "AliasCar::run",
+            "engine",
+            "start",
+            line_of(source, "self.engine.start(); // alias"),
+        );
+        alias.receiver_expression = "self.engine".to_string();
+        assert!(infer_receiver_type(root, &alias, &mut cache).is_none());
+    }
+
+    #[test]
+    fn rust_direct_self_reference_field_receiver_is_not_inferred() {
+        let source = r#"struct Engine;
+
+struct Car {
+    engine: &'static Engine,
+}
+
+impl Car {
+    fn run(&self) {
+        self.engine.start();
+    }
+}
+"#;
+        let dir = tempdir().expect("temp dir");
+        let root = dir.path();
+        write_fixture(root, "src/lib.rs", source);
+        let mut cache = DispatchSourceCache::new();
+        let mut reference = reference(
+            "rust",
+            "src/lib.rs",
+            "Car::run",
+            "engine",
+            "start",
+            line_of(source, "self.engine.start()"),
+        );
+        reference.receiver_expression = "self.engine".to_string();
+
+        assert!(infer_receiver_type(root, &reference, &mut cache).is_none());
+    }
+
+    #[test]
+    fn rust_trait_impl_self_field_receiver_is_not_inferred() {
+        let source = r#"trait Drive {
+    fn run(&self);
+}
+
+struct Engine;
+
+struct Car {
+    engine: Engine,
+}
+
+impl Drive for Car {
+    fn run(&self) {
+        self.engine.start();
+    }
+}
+"#;
+        let dir = tempdir().expect("temp dir");
+        let root = dir.path();
+        write_fixture(root, "src/lib.rs", source);
+        let mut cache = DispatchSourceCache::new();
+        let mut reference = reference(
+            "rust",
+            "src/lib.rs",
+            "Car::run",
+            "engine",
+            "start",
+            line_of(source, "self.engine.start()"),
+        );
+        reference.receiver_expression = "self.engine".to_string();
+
+        assert!(infer_receiver_type(root, &reference, &mut cache).is_none());
+    }
+
+    #[test]
+    fn rust_self_field_does_not_bind_struct_from_another_module() {
+        let source = r#"struct Engine;
+
+mod unrelated {
+    struct Car {
+        engine: Engine,
+    }
+}
+
+impl Car {
+    fn run(&self) {
+        self.engine.start();
+    }
+}
+"#;
+        let dir = tempdir().expect("temp dir");
+        let root = dir.path();
+        write_fixture(root, "src/lib.rs", source);
+        let mut cache = DispatchSourceCache::new();
+        let mut reference = reference(
+            "rust",
+            "src/lib.rs",
+            "Car::run",
+            "engine",
+            "start",
+            line_of(source, "self.engine.start()"),
+        );
+        reference.receiver_expression = "self.engine".to_string();
+
+        assert!(infer_receiver_type(root, &reference, &mut cache).is_none());
+    }
+
+    #[test]
     fn unknown_java_receiver_still_uses_name_match_fallback() {
         let source = r#"class EntryPoint {
     void handle() {
@@ -13817,6 +14370,7 @@ class OnlyService {
             caller_file: caller_file.to_string(),
             caller_symbol: caller_symbol.to_string(),
             caller_signature: None,
+            receiver_expression: receiver.to_string(),
             receiver: receiver.to_string(),
             method_name: method_name.to_string(),
             colon_dispatch: false,
@@ -13831,6 +14385,7 @@ class OnlyService {
             file_path: "src/targets.fixture".to_string(),
             scoped_name: scoped_name.to_string(),
             kind: "method".to_string(),
+            start_line: 1,
         }
     }
 

--- a/crates/aft/tests/integration/callgraph_store_name_match_test.rs
+++ b/crates/aft/tests/integration/callgraph_store_name_match_test.rs
@@ -399,12 +399,12 @@ impl Car {
         true,
     ));
     assert!(
-        tree["children"].as_array().unwrap().iter().all(|child| {
-            child["name"] != "Engine::start"
-                || child["approximate"] != false
-                || child["resolved_by"] != "type_match"
-        }),
-        "unresolved actual::Engine must not precisely match unrelated Engine::start: {tree:#}"
+        tree["children"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|child| child["name"] != "Engine::start"),
+        "unresolved actual::Engine must not match unrelated Engine::start: {tree:#}"
     );
 
     let callers = json(callgraph_store_adapter::callers_result(
@@ -415,12 +415,10 @@ impl Car {
         true,
     ));
     assert!(
-        flattened_callers(&callers).iter().all(|entry| {
-            entry["symbol"] != "Car::run"
-                || entry["approximate"] != false
-                || entry["resolved_by"] != "type_match"
-        }),
-        "unrelated Engine::start must not report Car::run as a precise caller: {callers:#}"
+        flattened_callers(&callers)
+            .iter()
+            .all(|entry| entry["symbol"] != "Car::run"),
+        "unrelated Engine::start must not report Car::run as a caller: {callers:#}"
     );
 }
 
@@ -470,12 +468,12 @@ impl Car {
         true,
     ));
     assert!(
-        tree["children"].as_array().unwrap().iter().all(|child| {
-            child["name"] != "Engine::start"
-                || child["approximate"] != false
-                || child["resolved_by"] != "type_match"
-        }),
-        "imported Engine must not precisely match unrelated Engine::start: {tree:#}"
+        tree["children"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|child| child["name"] != "Engine::start"),
+        "imported Engine must not match unrelated Engine::start: {tree:#}"
     );
 
     let callers = json(callgraph_store_adapter::callers_result(
@@ -486,12 +484,10 @@ impl Car {
         true,
     ));
     assert!(
-        flattened_callers(&callers).iter().all(|entry| {
-            entry["symbol"] != "Car::run"
-                || entry["approximate"] != false
-                || entry["resolved_by"] != "type_match"
-        }),
-        "unrelated Engine::start must not report Car::run as a precise caller: {callers:#}"
+        flattened_callers(&callers)
+            .iter()
+            .all(|entry| entry["symbol"] != "Car::run"),
+        "unrelated Engine::start must not report Car::run as a caller: {callers:#}"
     );
 }
 

--- a/crates/aft/tests/integration/callgraph_store_name_match_test.rs
+++ b/crates/aft/tests/integration/callgraph_store_name_match_test.rs
@@ -239,7 +239,7 @@ struct Holder {
 
 impl Holder {
     fn check(&self) {
-        let _ = self.path.as_path();
+        let _ = self. path.as_path();
     }
 }
 

--- a/crates/aft/tests/integration/callgraph_store_name_match_test.rs
+++ b/crates/aft/tests/integration/callgraph_store_name_match_test.rs
@@ -224,6 +224,278 @@ pub fn noisy_stdlib_calls() {
 }
 
 #[test]
+fn rust_direct_self_field_with_stdlib_type_does_not_name_match_project_method() {
+    let dir = tempdir().unwrap();
+    let root = canonical_root(dir.path());
+    write_file(
+        &root.join("main.rs"),
+        r#"mod other;
+
+use std::path::PathBuf;
+
+struct Holder {
+    path: PathBuf,
+}
+
+impl Holder {
+    fn check(&self) {
+        let _ = self.path.as_path();
+    }
+}
+
+fn main() {
+    let holder = Holder {
+        path: PathBuf::from("."),
+    };
+    holder.check();
+}
+"#,
+    );
+    write_file(
+        &root.join("other.rs"),
+        r#"pub struct PrinterPath;
+
+impl PrinterPath {
+    pub fn as_path(&self) {}
+}
+"#,
+    );
+
+    let store = build_store(&root, "rust-stdlib-field-method", &project_files(&root));
+    let tree = json(callgraph_store_adapter::call_tree_result(
+        &store,
+        &root.join("main.rs"),
+        "Holder::check",
+        1,
+        true,
+    ));
+    assert!(
+        tree["children"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|child| child["name"] != "PrinterPath::as_path"),
+        "PathBuf::as_path must not resolve to the unrelated project method: {tree:#}"
+    );
+
+    let callers = json(callgraph_store_adapter::callers_result(
+        &store,
+        &root.join("other.rs"),
+        "PrinterPath::as_path",
+        1,
+        true,
+    ));
+    assert!(
+        flattened_callers(&callers)
+            .iter()
+            .all(|entry| entry["symbol"] != "Holder::check"),
+        "PrinterPath::as_path must not report Holder::check as a caller: {callers:#}"
+    );
+}
+
+#[test]
+fn rust_direct_self_field_resolves_by_declared_type() {
+    let dir = tempdir().unwrap();
+    let root = canonical_root(dir.path());
+    write_file(
+        &root.join("src/lib.rs"),
+        r#"struct Engine;
+
+impl Engine {
+    fn start(&self) {}
+}
+
+struct Unrelated;
+
+impl Unrelated {
+    fn start(&self) {}
+}
+
+struct Car {
+    engine: Engine,
+}
+
+impl Car {
+    fn run(&self) {
+        self.engine.start();
+    }
+}
+"#,
+    );
+
+    let store = build_store(&root, "rust-direct-self-field", &project_files(&root));
+    let tree = json(callgraph_store_adapter::call_tree_result(
+        &store,
+        &root.join("src/lib.rs"),
+        "Car::run",
+        1,
+        true,
+    ));
+    let children = tree["children"].as_array().unwrap();
+    assert_eq!(children.len(), 1, "call_tree: {tree:#}");
+    let child = &children[0];
+    assert_eq!(child["name"], "Engine::start", "call_tree: {tree:#}");
+    assert_eq!(child["approximate"], false, "call_tree: {tree:#}");
+    assert_eq!(child["resolved_by"], "type_match", "call_tree: {tree:#}");
+
+    let callers = json(callgraph_store_adapter::callers_result(
+        &store,
+        &root.join("src/lib.rs"),
+        "Engine::start",
+        1,
+        true,
+    ));
+    let entries = flattened_callers(&callers);
+    assert_eq!(entries.len(), 1, "callers: {callers:#}");
+    assert_eq!(entries[0]["symbol"], "Car::run");
+    assert_eq!(entries[0]["approximate"], false, "callers: {callers:#}");
+    assert_eq!(
+        entries[0]["resolved_by"], "type_match",
+        "callers: {callers:#}"
+    );
+}
+
+#[test]
+fn rust_scoped_field_type_does_not_precisely_match_unrelated_same_named_method() {
+    let dir = tempdir().unwrap();
+    let root = canonical_root(dir.path());
+    write_file(
+        &root.join("src/actual.rs"),
+        r#"pub struct Engine;
+"#,
+    );
+    write_file(
+        &root.join("src/unrelated.rs"),
+        r#"pub struct Engine;
+
+impl Engine {
+    pub fn start(&self) {}
+}
+"#,
+    );
+    write_file(
+        &root.join("src/lib.rs"),
+        r#"mod actual;
+mod unrelated;
+
+struct Car {
+    engine: actual::Engine,
+}
+
+impl Car {
+    fn run(&self) {
+        self.engine.start();
+    }
+}
+"#,
+    );
+
+    let store = build_store(&root, "rust-scoped-field-type", &project_files(&root));
+    let tree = json(callgraph_store_adapter::call_tree_result(
+        &store,
+        &root.join("src/lib.rs"),
+        "Car::run",
+        1,
+        true,
+    ));
+    assert!(
+        tree["children"].as_array().unwrap().iter().all(|child| {
+            child["name"] != "Engine::start"
+                || child["approximate"] != false
+                || child["resolved_by"] != "type_match"
+        }),
+        "unresolved actual::Engine must not precisely match unrelated Engine::start: {tree:#}"
+    );
+
+    let callers = json(callgraph_store_adapter::callers_result(
+        &store,
+        &root.join("src/unrelated.rs"),
+        "Engine::start",
+        1,
+        true,
+    ));
+    assert!(
+        flattened_callers(&callers).iter().all(|entry| {
+            entry["symbol"] != "Car::run"
+                || entry["approximate"] != false
+                || entry["resolved_by"] != "type_match"
+        }),
+        "unrelated Engine::start must not report Car::run as a precise caller: {callers:#}"
+    );
+}
+
+#[test]
+fn rust_imported_field_type_does_not_precisely_match_unrelated_same_named_method() {
+    let dir = tempdir().unwrap();
+    let root = canonical_root(dir.path());
+    write_file(
+        &root.join("src/actual.rs"),
+        r#"pub struct Engine;
+"#,
+    );
+    write_file(
+        &root.join("src/unrelated.rs"),
+        r#"pub struct Engine;
+
+impl Engine {
+    pub fn start(&self) {}
+}
+"#,
+    );
+    write_file(
+        &root.join("src/lib.rs"),
+        r#"mod actual;
+mod unrelated;
+
+use actual::Engine;
+
+struct Car {
+    engine: Engine,
+}
+
+impl Car {
+    fn run(&self) {
+        self.engine.start();
+    }
+}
+"#,
+    );
+
+    let store = build_store(&root, "rust-imported-field-type", &project_files(&root));
+    let tree = json(callgraph_store_adapter::call_tree_result(
+        &store,
+        &root.join("src/lib.rs"),
+        "Car::run",
+        1,
+        true,
+    ));
+    assert!(
+        tree["children"].as_array().unwrap().iter().all(|child| {
+            child["name"] != "Engine::start"
+                || child["approximate"] != false
+                || child["resolved_by"] != "type_match"
+        }),
+        "imported Engine must not precisely match unrelated Engine::start: {tree:#}"
+    );
+
+    let callers = json(callgraph_store_adapter::callers_result(
+        &store,
+        &root.join("src/unrelated.rs"),
+        "Engine::start",
+        1,
+        true,
+    ));
+    assert!(
+        flattened_callers(&callers).iter().all(|entry| {
+            entry["symbol"] != "Car::run"
+                || entry["approximate"] != false
+                || entry["resolved_by"] != "type_match"
+        }),
+        "unrelated Engine::start must not report Car::run as a precise caller: {callers:#}"
+    );
+}
+
+#[test]
 fn rust_known_self_type_without_method_does_not_fall_back_to_name_match() {
     let dir = tempdir().unwrap();
     let root = canonical_root(dir.path());
@@ -455,6 +727,69 @@ export function entry(permissionRuleEngine: PermissionRuleEngine) {
     assert_eq!(
         billing_edges, 0,
         "receiver scoring should not cross-edge to BillingRuleEngine"
+    );
+}
+
+#[test]
+fn rust_nested_same_named_type_does_not_match_root_field_type() {
+    let dir = tempdir().unwrap();
+    let root = canonical_root(dir.path());
+    write_file(
+        &root.join("src/lib.rs"),
+        r#"struct Engine;
+
+struct Car {
+    engine: Engine,
+}
+
+impl Car {
+    fn run(&self) {
+        self.engine.start();
+    }
+}
+
+mod nested {
+    pub struct Engine;
+
+    impl Engine {
+        pub fn start(&self) {}
+    }
+}
+"#,
+    );
+
+    let store = build_store(
+        &root,
+        "rust-nested-same-named-field-type",
+        &project_files(&root),
+    );
+    let tree = json(callgraph_store_adapter::call_tree_result(
+        &store,
+        &root.join("src/lib.rs"),
+        "Car::run",
+        1,
+        true,
+    ));
+    let precise_tree_edge = tree["children"].as_array().unwrap().iter().any(|child| {
+        child["name"] == "Engine::start"
+            && child["resolved_by"] == "type_match"
+            && child["approximate"] == false
+    });
+    let callers = json(callgraph_store_adapter::callers_result(
+        &store,
+        &root.join("src/lib.rs"),
+        "Engine::start",
+        1,
+        true,
+    ));
+    let precise_reverse_edge = flattened_callers(&callers).iter().any(|entry| {
+        entry["symbol"] == "Car::run"
+            && entry["resolved_by"] == "type_match"
+            && entry["approximate"] == false
+    });
+    assert!(
+        !precise_tree_edge && !precise_reverse_edge,
+        "root Engine field must not precisely match nested Engine::start; call_tree: {tree:#}; callers: {callers:#}"
     );
 }
 

--- a/crates/aft/tests/integration/callgraph_store_name_match_test.rs
+++ b/crates/aft/tests/integration/callgraph_store_name_match_test.rs
@@ -356,7 +356,7 @@ impl Car {
 }
 
 #[test]
-fn rust_scoped_field_type_does_not_precisely_match_unrelated_same_named_method() {
+fn rust_scoped_field_type_does_not_match_unrelated_same_named_method() {
     let dir = tempdir().unwrap();
     let root = canonical_root(dir.path());
     write_file(
@@ -423,7 +423,7 @@ impl Car {
 }
 
 #[test]
-fn rust_imported_field_type_does_not_precisely_match_unrelated_same_named_method() {
+fn rust_imported_field_type_does_not_match_unrelated_same_named_method() {
     let dir = tempdir().unwrap();
     let root = canonical_root(dir.path());
     write_file(


### PR DESCRIPTION
## Summary

While testing Rust callgraph output, I ran into a case where `Holder::check` calls `PathBuf::as_path`, but AFT could still produce an approximate edge to an unrelated `PrinterPath::as_path` elsewhere in the project. So i create this pr and explain what I do.

The existing `name_match` fallback is useful when the receiver type is genuinely unknown, so I didn't want to remove or weaken that behavior. The issue here is that for a simple field receiver like `self.path`, we can sometimes recover enough local type information to make a better decision — and when we can't, guessing by method name can be misleading.

## What changed

This adds a conservative path for direct `self.field.method()` calls.

When the field can be tied to a concrete local type in the same lexical scope, AFT uses the existing precise `type_match` path. For example, if `self.engine` is known to be an `Engine`, `Car::run -> Engine::start` is resolved precisely.

If the field is clearly present but its type can't be resolved safely, the call is left unresolved instead of being connected to an unrelated same-named method. Precise candidates are also checked against the field type's lexical module scope, so a same-named type inside a nested module can't accidentally become the target.

I intentionally kept this narrow. This isn't meant to add general Rust type or module resolution. Imported or scoped types, nested fields, generics, trait impls, references, aliases, wrappers, deref/coercion, and cross-file type identities stay conservative unless AFT already knows how to resolve them.

## Tests

The tests cover the original `PathBuf` / `PrinterPath` case, precise resolution for a local field type, preservation of the existing `name_match` fallback for genuinely unknown receivers, and the scoped/imported/nested-module cases that could otherwise create false precise edges.

The relevant unit and integration tests pass, along with:

    cargo check -p agent-file-tools
    cargo fmt --check
    git diff --check

The full crate suite still has four failures in this local environment. I reproduced all four against a clean worktree at the same HEAD with the same failure signatures, so they appear to be baseline/environment-related rather than introduced by this change.(I guess it's because of my base environment.)

Thanks for your project. It helps a lot in my coding time.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788784024&installation_model_id=22398&pr_number=196&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F196&signature=39970ae772d981f6f9f4fb7ab813d893523029f0f522699d8774ceb7fbaae033"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Rust callgraph accuracy for direct `self.field.method()` calls, including spaced forms like `self .engine.start()`. Resolves only when the field’s type is a proven local concrete struct in the same file and module, and suppresses name-only matches when the field is known but unsafe to resolve.

- **Bug Fixes**
  - Add conservative Rust self-field inference that uses `type_match` only when the field’s type is a concrete, local, non-generic struct in the same file and lexical module; validates inherent `impl` by checking the candidate’s `start_line`, file, and module scope; rejects trait and generic impls.
  - Normalize whitespace by storing a trimmed `receiver_expression`, so forms like `self .engine` and `self. engine` are detected.
  - When a self field exists but its type can’t be safely proven (nested fields, wrappers, references, aliases, generics, trait impls, imports, cross-file types, or nested same-named types), leave the call unresolved and skip `name_match`; genuinely unknown receivers keep the fallback.

<sup>Written for commit 952522a19e17a222db8f88de0a9844266e52b563. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR improves Rust callgraph resolution for direct `self.field.method()` calls while preserving conservative behavior when the field type cannot be proven.
- Retains the full receiver expression and normalizes whitespace around direct field access.
- Resolves locally declared concrete field types through scoped inherent implementations.
- Suppresses misleading name-only fallback when a direct self field is recognized but unresolved.
- Adds unit and integration coverage for precise, unresolved, scoped, and whitespace-separated cases.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/aft/src/callgraph_store/mod.rs | Adds conservative Rust direct-self-field inference, lexical-scope validation, and whitespace normalization; the previously reported whitespace bypasses are resolved. |
| crates/aft/tests/integration/callgraph_store_name_match_test.rs | Adds end-to-end coverage for precise field-type resolution and suppression of unrelated method-name matches, including whitespace after the field-access dot. |

</details>

<sub>Reviews (5): Last reviewed commit: ["Clarify unresolved Rust field test names"](https://github.com/cortexkit/aft/commit/952522a19e17a222db8f88de0a9844266e52b563) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51431537)</sub>

<!-- /greptile_comment -->