### PR TITLE
fix(bridge): report a GOODBYE'd call as unknown-outcome, not failed

### DIFF
--- a/packages/aft-bridge/src/__tests__/error-contract.test.ts
+++ b/packages/aft-bridge/src/__tests__/error-contract.test.ts
@@ -1,8 +1,18 @@
 /// <reference path="../bun-test.d.ts" />
 
 import { describe, expect, test } from "bun:test";
+import { SubcError } from "@cortexkit/subc-client";
 import { BridgeTransportTimeoutError, isBridgeTransportTimeout } from "../bridge.js";
-import { adaptToolError, BASH_TRANSPORT_DISPOSITION } from "../error-contract.js";
+import {
+  adaptToolError,
+  BASH_TRANSPORT_DISPOSITION,
+  SUBC_MODULE_RESTART_DISPOSITION,
+} from "../error-contract.js";
+
+/** Shaped exactly as subc-client raises it: bare SubcError, no code. */
+function routeGoodbyeError(): SubcError {
+  return new SubcError("route closed by subc (GOODBYE)");
+}
 
 describe("adaptToolError", () => {
   test("adds bash transport disposition guidance while preserving the error", () => {
@@ -28,5 +38,53 @@ describe("adaptToolError", () => {
     expect(adapted).toBe(original);
     expect(original.message).toBe("read transport timed out");
     expect(original.message).not.toContain(BASH_TRANSPORT_DISPOSITION);
+  });
+
+  test("a route GOODBYE reports an UNKNOWN outcome, never a failure", () => {
+    const original = routeGoodbyeError();
+
+    const adapted = adaptToolError("write", original);
+
+    expect(adapted).toBe(original);
+    expect(original.message).toContain(SUBC_MODULE_RESTART_DISPOSITION);
+    // The wording is the safety property: an operator or agent that reads
+    // "failed" re-runs the call, which double-applies a mutation that may
+    // already have landed before the daemon dropped the reply.
+    expect(original.message).toContain("UNKNOWN");
+    expect(original.message).toContain("never blind-retry a mutation");
+    expect(original.message).not.toContain("Re-run the command.");
+  });
+
+  test("a GOODBYE'd bash call gets the unknown-outcome text, not the re-run text", () => {
+    // BASH_TRANSPORT_DISPOSITION asserts no task was created and says to re-run.
+    // That is true for a not-sent transport failure and FALSE for a GOODBYE,
+    // where the command may already have executed.
+    const original = routeGoodbyeError();
+
+    adaptToolError("bash", original);
+
+    expect(original.message).toContain(SUBC_MODULE_RESTART_DISPOSITION);
+    expect(original.message).not.toContain(BASH_TRANSPORT_DISPOSITION);
+  });
+
+  test("disposition is appended once when the error passes through twice", () => {
+    const original = routeGoodbyeError();
+
+    adaptToolError("read", original);
+    adaptToolError("read", original);
+
+    const occurrences = original.message.split(SUBC_MODULE_RESTART_DISPOSITION).length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  test("a coded SubcError is left alone — only the bare GOODBYE shape matches", () => {
+    // module_reloading is proven-not-forwarded and retryable; it must not be
+    // dressed up as an unknown outcome.
+    const coded = new SubcError("route closed by subc (GOODBYE)", "module_reloading");
+
+    const adapted = adaptToolError("write", coded);
+
+    expect(adapted).toBe(coded);
+    expect(coded.message).not.toContain(SUBC_MODULE_RESTART_DISPOSITION);
   });
 });

--- a/packages/aft-bridge/src/error-contract.ts
+++ b/packages/aft-bridge/src/error-contract.ts
@@ -6,7 +6,11 @@
  * rewrite the contract-owned message while doing so.
  */
 
-import { isConsumerReconnectTransient, StaleRouteHandleError } from "@cortexkit/subc-client";
+import {
+  isConsumerReconnectTransient,
+  StaleRouteHandleError,
+  SubcError,
+} from "@cortexkit/subc-client";
 
 import { isBridgeTransportTimeout } from "./bridge.js";
 import { SubcRootGenerationExpiredError, SubcRootReapedError } from "./subc-transport.js";
@@ -52,6 +56,35 @@ export function toolErrorFromResponse(
 export const BASH_TRANSPORT_DISPOSITION =
   "The transport to the AFT daemon was interrupted; no background task was created for this command and no task ID exists. Re-run the command. Do not poll bash_status for it.";
 
+/**
+ * Agent-facing guidance for a call the daemon GOODBYE'd mid-flight.
+ *
+ * Deliberately does NOT say the call failed. The daemon emits route GOODBYEs
+ * after its drain wait regardless of whether that drain completed, so a call
+ * in flight at GOODBYE was admitted BEFORE the gate closed and may already
+ * have run to completion with only its reply lost. "Failed" reads as an
+ * invitation to re-run, which double-applies a mutation that already landed.
+ */
+export const SUBC_MODULE_RESTART_DISPOSITION =
+  "The AFT daemon module restarted while this call was in flight, so its outcome is UNKNOWN: it may or may not have executed. Verify actual state before re-running, and never blind-retry a mutation.";
+
+/**
+ * A route GOODBYE delivered against an in-flight request.
+ *
+ * COUPLING: subc-client raises this as a bare `SubcError` carrying no code
+ * (client.ts, the `FrameType.Goodbye` branch), so the message literal is the
+ * only discriminator available. Asked upstream for a stable `code` on that
+ * error; until it exists this match is the seam and will fail open (no
+ * disposition appended) rather than misclassify.
+ */
+function isRouteGoodbyeError(error: unknown): boolean {
+  return (
+    error instanceof SubcError &&
+    error.code === undefined &&
+    error.message.includes("route closed by subc")
+  );
+}
+
 function isTransportClassError(error: unknown): boolean {
   return (
     isBridgeTransportTimeout(error) ||
@@ -67,8 +100,20 @@ function isTransportClassError(error: unknown): boolean {
  * object, class, code, or retry behavior. Other commands retain their errors.
  */
 export function adaptToolError(command: string, error: unknown): unknown {
-  if (command !== "bash" || !isTransportClassError(error)) return error;
   if (!(error instanceof Error)) return error;
+
+  // Checked before the bash branch, and applied to every command: a GOODBYE'd
+  // call has an unknown outcome, so BASH_TRANSPORT_DISPOSITION's "no task was
+  // created, re-run the command" would be actively wrong here.
+  if (isRouteGoodbyeError(error)) {
+    if (error.message.includes(SUBC_MODULE_RESTART_DISPOSITION)) return error;
+    error.message = error.message
+      ? `${error.message} ${SUBC_MODULE_RESTART_DISPOSITION}`
+      : SUBC_MODULE_RESTART_DISPOSITION;
+    return error;
+  }
+
+  if (command !== "bash" || !isTransportClassError(error)) return error;
   if (error.message.includes(BASH_TRANSPORT_DISPOSITION)) return error;
   error.message = error.message
     ? `${error.message} ${BASH_TRANSPORT_DISPOSITION}`


### PR DESCRIPTION
A route GOODBYE against an in-flight request currently surfaces as a bare transport error. It reads as "the call failed", which invites a re-run.

It isn't a failure. The daemon emits route GOODBYEs **after** its drain wait, regardless of whether that drain completed (`supervise.rs` — the quiescence result is consumed only by a `warn!`; route release and GOODBYE emission run unconditionally). So a call in flight at GOODBYE was admitted *before* the gate closed and may already have run to completion, with only its reply lost.

We hit this concretely: a `ck module restart aft` issued from an aft-served session lost the reply to its own command, and the already-produced stdout went with it. The command had succeeded.

Re-running such a call double-applies whatever it did. Since harness bash executes through this path, the realistic case is a second `git push`, migration, or `npm publish`.

## Change

Append a disposition saying the outcome is UNKNOWN and that state should be verified before re-running:

```
The AFT daemon module restarted while this call was in flight, so its outcome is
UNKNOWN: it may or may not have executed. Verify actual state before re-running,
and never blind-retry a mutation.
```

Deliberately distinct from `BASH_TRANSPORT_DISPOSITION`, whose "no background task was created … Re-run the command" is correct for a not-sent transport failure and **wrong** here. The GOODBYE branch is checked before the bash branch so a GOODBYE'd bash call cannot pick up the re-run guidance, and a test asserts that specific negative.

**No retry behaviour changes.** `isRouteProvenAbsentError` still gates the single in-place retry on `unknown_channel` / `StaleRouteHandleError` — errors proving the bytes never left. GOODBYE is outcome-unknown by construction and stays out. The existing "outcome-unknown request failures still surface without an in-place retry" test is untouched and still passing.

## The one ugly part, stated plainly

The match is on the message literal `"route closed by subc"`, because subc-client raises the GOODBYE as a bare `SubcError` **with no code** — there is no other discriminator on the wire. It's documented as a seam and fails *open*: if the string changes, callers lose the disposition rather than getting a wrong one. A stable code on that error has been requested upstream in `cortexkit/subconscious`; when it lands this becomes a code check and the string goes away.

Also excluded: a `SubcError` that *does* carry a code (e.g. `module_reloading`, which is proven-not-forwarded and legitimately retryable) is left alone, with a test pinning that.

## Verification

6/6 in `error-contract.test.ts`, each assertion observed failing before being trusted — disabling the predicate reds exactly the three new behavioural tests and leaves the pre-existing two green. Full plugin suites at baseline (bridge 456, aft 198, pi 712, opencode 1289), lint/format clean, v0.49 audit passes, release artifacts untouched.

Wording came out of a review with the subconscious side. The specific ask was to say UNKNOWN rather than "failed" — an operator who reads "failed" re-runs it, which is the same trap in prose that a blanket retry would be in code.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788881411&installation_model_id=22398&pr_number=203&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F203&signature=0ff4f49f1f25a9809a57aeb0cddddfa40f34d2738d4f82412ca3d7872f8b18ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat route GOODBYE on in‑flight calls as UNKNOWN outcome instead of a failure. This prevents unsafe retries that could double-apply mutations.

- **Bug Fixes**
  - Append `SUBC_MODULE_RESTART_DISPOSITION` to bare GOODBYE `SubcError` messages so they state the outcome is UNKNOWN and advise verifying state before any retry.
  - Handle GOODBYE before bash transport logic so `bash` calls don’t get `BASH_TRANSPORT_DISPOSITION` re-run guidance.
  - Retry behavior unchanged; only proven-not-sent errors (e.g., `StaleRouteHandleError`, `unknown_channel`) trigger the single in-place retry.
  - Detect via the literal “route closed by subc” from `@cortexkit/subc-client`; fails open if it changes. Tests cover single append, bash path, and leaving coded errors (e.g., `module_reloading`) untouched.

<sup>Written for commit d3e66a89635f225d5f4bc305e7978cc733d65e4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR distinguishes route GOODBYEs from proven-not-sent transport failures and appends unknown-outcome guidance without changing retry behavior.
- Detects bare route-GOODBYE `SubcError` instances before bash-specific transport handling.
- Warns callers to verify state rather than blindly retrying a potentially completed mutation.
- Adds coverage for bash precedence, idempotent annotation, required wording, and exclusion of coded errors.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

The new branch preserves the original error and existing retry decisions while ensuring matching route GOODBYEs cannot receive the contradictory bash re-run guidance.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/aft-bridge/src/error-contract.ts | Adds narrowly scoped, idempotent GOODBYE classification and unknown-outcome guidance ahead of existing bash transport handling; no actionable defect found. |
| packages/aft-bridge/src/__tests__/error-contract.test.ts | Adds focused tests for disposition wording, branch precedence, duplicate adaptation, and coded-error exclusion. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[adaptToolError receives error] --> B{Bare route GOODBYE SubcError?}
    B -->|Yes| C[Append UNKNOWN-outcome disposition]
    C --> D[Return original error]
    B -->|No| E{Bash transport-class error?}
    E -->|Yes| F[Append safe re-run disposition]
    E -->|No| D
    F --> D
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(bridge): report a GOODBYE&#39;d call as ..."](https://github.com/cortexkit/aft/commit/d3e66a89635f225d5f4bc305e7978cc733d65e4d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51594434)</sub>

<!-- /greptile_comment -->