### PR TITLE
logging: label the perf tick rolling window and emit the interval count

### DIFF
--- a/crates/aft/src/logging.rs
+++ b/crates/aft/src/logging.rs
@@ -568,7 +568,7 @@ struct ToolCallPerfSample {
 
 #[derive(Clone, Copy, Default)]
 struct ToolCallPerfSummary {
-    count: usize,
+    window: usize,
     p50_total_ms: u64,
     max_total_ms: u64,
     p50_queue_ms: u64,
@@ -831,7 +831,7 @@ pub fn perf_tick(executor: Option<&Executor>) {
     };
     let sample = sample.unwrap_or_default();
     crate::slog_info!(
-        "perf tick: watcher={{ingested:{},paths:{},dropped:{}}} drains={} tier2=[{}] semantic={{collects:{},files:{},chunks:{},ms:{}}} callgraph_invalidations={} executor_completed={{interactive:{},maintenance:{}}} oldest_queued_ms={{interactive:{},maintenance:{}}} toolcall={{count:{},p50_total_ms:{},max_total_ms:{},p50_queue_ms:{},max_queue_ms:{}}} file_log_dropped={}",
+        "perf tick: watcher={{ingested:{},paths:{},dropped:{}}} drains={} tier2=[{}] semantic={{collects:{},files:{},chunks:{},ms:{}}} callgraph_invalidations={} executor_completed={{interactive:{},maintenance:{}}} oldest_queued_ms={{interactive:{},maintenance:{}}} {} file_log_dropped={}",
         watcher_ingested,
         watcher_paths,
         watcher_dropped,
@@ -846,11 +846,7 @@ pub fn perf_tick(executor: Option<&Executor>) {
         completed_maintenance,
         format_optional_ms(sample.interactive_oldest_ms),
         format_optional_ms(sample.maintenance_oldest_ms),
-        tool_calls.count,
-        tool_calls.p50_total_ms,
-        tool_calls.max_total_ms,
-        tool_calls.p50_queue_ms,
-        tool_calls.max_queue_ms,
+        format_tool_call_summary(new_tool_calls, tool_calls),
         file_lines_dropped,
     );
 }
@@ -879,12 +875,23 @@ fn summarize_tool_calls(samples: &VecDeque<ToolCallPerfSample>) -> ToolCallPerfS
     queues.sort_unstable();
     let median_index = (samples.len() - 1) / 2;
     ToolCallPerfSummary {
-        count: samples.len(),
+        window: samples.len(),
         p50_total_ms: totals[median_index],
         max_total_ms: totals[totals.len() - 1],
         p50_queue_ms: queues[median_index],
         max_queue_ms: queues[queues.len() - 1],
     }
+}
+
+fn format_tool_call_summary(new_tool_calls: u64, summary: ToolCallPerfSummary) -> String {
+    format!(
+        "toolcall={{new:{new_tool_calls},window:{},p50_total_ms:{},max_total_ms:{},p50_queue_ms:{},max_queue_ms:{}}}",
+        summary.window,
+        summary.p50_total_ms,
+        summary.max_total_ms,
+        summary.p50_queue_ms,
+        summary.max_queue_ms,
+    )
 }
 
 fn format_optional_ms(value: Option<u64>) -> String {
@@ -1056,10 +1063,28 @@ mod tests {
 
         let summary = summarize_tool_calls(&samples);
 
-        assert_eq!(summary.count, 4);
+        assert_eq!(summary.window, 4);
         assert_eq!(summary.p50_total_ms, 5);
         assert_eq!(summary.max_total_ms, 9);
         assert_eq!(summary.p50_queue_ms, 2);
         assert_eq!(summary.max_queue_ms, 5);
+    }
+
+    #[test]
+    fn tool_call_tick_labels_interval_count_and_rolling_window() {
+        let samples = VecDeque::from([ToolCallPerfSample {
+            total_ms: 3_000,
+            queue_ms: 2_900,
+        }]);
+        let summary = summarize_tool_calls(&samples);
+
+        assert_eq!(
+            format_tool_call_summary(1, summary),
+            "toolcall={new:1,window:1,p50_total_ms:3000,max_total_ms:3000,p50_queue_ms:2900,max_queue_ms:2900}"
+        );
+        assert_eq!(
+            format_tool_call_summary(0, summary),
+            "toolcall={new:0,window:1,p50_total_ms:3000,max_total_ms:3000,p50_queue_ms:2900,max_queue_ms:2900}"
+        );
     }
 }


### PR DESCRIPTION
Closes #206. Built to the shape you specced:

```
toolcall={new:3,window:256,p50_total_ms:…,max_total_ms:…,p50_queue_ms:…,max_queue_ms:…}
```

- `new:` first in the group, carrying the already-computed `new_tool_calls` — it stays the emit gate, it's just no longer discarded after gating
- `count` → `window` on both the field and `ToolCallPerfSummary`
- ring undrained, percentiles unchanged

The group's formatting moved into a small private `format_tool_call_summary(new_tool_calls, summary) -> String`, called from the emit site. That's what makes the test possible without log capture or waiting for `perf_tick_interval()` to elapse — `perf_tick` early-returns on the interval check and mutates process-global `PERF`, so asserting on it directly would have been either timing-dependent or global-state-dependent. Everything else on the tick line is untouched.

The test is the case you asked for — the one that proves the two fields mean different things:

```rust
assert_eq!(format_tool_call_summary(1, summary), "toolcall={new:1,window:1,…max_total_ms:3000…");
assert_eq!(format_tool_call_summary(0, summary), "toolcall={new:0,window:1,…max_total_ms:3000…");
```

Same 3.0s sample, same window; `new:` drops to 0 while `max_total_ms` still reports it. That's the misdiagnosis shape, pinned.

**Field rename flagged as you asked:** `count` → `window` inside the `toolcall={}` group. Line-prefix consumers are unaffected; anything parsing that group's field names by name will need the rename.

Verification: `--lib` 2283 passed / 6 skipped · release build clean · `cargo fmt --check` clean · `aft_inspect` 0/0/0/0. Red control run independently of the implementer's — swapping `new:` back to `count:` in the format string gives `left: "toolcall={count:1,window:1,…"` against the expected `new:1`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788954156&installation_model_id=22398&pr_number=208&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F208&signature=c9a4b502dbb2f3c3c7fd859ddb26baa452962865d0d7d97113060cc5ee35d802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies perf tick logging by emitting the per-interval `new` tool-call count and labeling the rolling window size as `window`. This removes ambiguity between interval activity and the rolling sample window and closes #206.

- New Features
  - Add `new:` to `toolcall={}` using `new_tool_calls` (still the emit gate).
  - Rename `count` to `window` in `toolcall={}` and `ToolCallPerfSummary`.
  - Keep the rolling ring undrained; percentiles unchanged.
  - Extract `format_tool_call_summary()` and add a unit test to distinguish `new` vs `window`.

- Migration
  - Update any log parsers from `toolcall.count` to `toolcall.window`.

<sup>Written for commit 3f7f84e108dab7ced1d490f755dfdc295341845e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR clarifies tool-call performance logging by emitting the interval call count separately from the rolling sample-window size.
- Adds `new` as the first field in the `toolcall={}` group.
- Renames the rolling summary field from `count` to `window`.
- Extracts tool-call summary formatting into a private helper and tests that interval and rolling-window values can differ.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the intentional logging-field contract change clearly documented and tested.

The interval counter is derived from the existing cumulative tool-call counter at emitted-tick boundaries, while the renamed window field continues to describe the retained rolling sample buffer; no changed-code-triggered failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/aft/src/logging.rs | Cleanly separates the existing interval counter from the undrained rolling-window size while preserving percentile calculations and emission behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["logging: label the perf tick rolling win..."](https://github.com/cortexkit/aft/commit/3f7f84e108dab7ced1d490f755dfdc295341845e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51786701)</sub>

<!-- /greptile_comment -->