### PR TITLE
test: pin route-GOODBYE reconnect classification before the SDK flip

### DIFF
--- a/packages/aft-bridge/src/__tests__/subc-transport.test.ts
+++ b/packages/aft-bridge/src/__tests__/subc-transport.test.ts
@@ -497,6 +497,56 @@ describe("SubcTransport Rd reconnect", () => {
     expect(client.routeOpens.length).toBe(2); // route re-opened
     expect(calls).toBe(2); // exactly two underlying requests — no auto-retry
   });
+
+  test("a route GOODBYE carrying kind=outcome_unknown KEEPS the client until the classifier reads it", async () => {
+    // A module restart sends GOODBYE to every route on the connection, so a
+    // mid-request call rejects with a SubcError (the raw request() path never
+    // produces a managed SubcCallError). isConsumerReconnectTransient reaches
+    // `err instanceof SubcCallError` first, so today that error is
+    // non-transient: route dropped, client KEPT, next call re-opens on the
+    // same connection.
+    //
+    // The fixture carries `kind` even though today's SubcError has only
+    // `code`. That is the point, and it is what makes this more than a
+    // restatement of the timeout test above: cortexkit/subconscious#6 proposes
+    // moving `kind` onto SubcError, and a route GOODBYE is outcome-unknown by
+    // construction (the daemon sends it after the drain wait regardless of
+    // execution status — see the disposition in error-contract.ts). So this is
+    // the error shape the SDK will hand us post-#6. The behaviour flip does not
+    // come from the error changing; it comes from the classifier starting to
+    // READ this field. Modelling the field now is what lets that flip land as a
+    // red test instead of as a live reconnect-policy change on an SDK bump.
+    //
+    // Characterization, not endorsement — the flip is probably correct. When it
+    // lands, flip the assertions and keep the test.
+    let calls = 0;
+    let madeClients = 0;
+    const goodbye = Object.assign(new SubcError("route closed by subc (GOODBYE)"), {
+      kind: "outcome_unknown",
+    });
+    const client = new FakeClient(async () => {
+      calls += 1;
+      if (calls === 1) throw goodbye;
+      return envelope({ id: "r", success: true, text: "after-restart" });
+    });
+    const pool = new SubcTransportPool({
+      connectionFile: "/tmp/fake",
+      harness: "opencode",
+      connect: async () => {
+        madeClients += 1;
+        return client;
+      },
+    });
+    const t = pool.getBridge(TEST_PROJECT_ROOT);
+
+    await expect(t.toolCall("s", "edit", {})).rejects.toBeInstanceOf(SubcError);
+    expect(client.closed).toBe(0); // client kept — reading `kind` would make this 1
+    const result = await t.toolCall("s", "edit", {});
+    expect(result.text).toBe("after-restart");
+    expect(madeClients).toBe(1); // never reconnected — reading `kind` would make this 2
+    expect(client.routeOpens.length).toBe(2); // route re-opened on the same client
+    expect(calls).toBe(2); // no in-place retry: a GOODBYE mid-call is outcome-unknown
+  });
 });
 
 describe("SubcTransport reply envelope (B-#7)", () => {


### PR DESCRIPTION
One test. It pins behaviour that is currently correct, unpinned, and about to change through a dependency rather than through this repo.

## What's unpinned

A module restart sends GOODBYE to every route on the connection, so a mid-request call rejects with a **bare `SubcError`** — the raw `request()` path never produces a managed `SubcCallError`.

`isConsumerReconnectTransient` reaches its `err instanceof SubcCallError` branch first, so a bare `SubcError` falls through to non-transient. Today that means: route dropped, **client kept**, next call re-opens on the same connection. That's the behaviour every seat here relies on across `ck module restart aft`.

Nothing asserts it. The nearest test — `a plain timeout (non-transient SubcError) KEEPS the client` — covers the same *class*, but a timeout and a GOODBYE can be classified differently, so it would stay green through the change below.

## Why now

[cortexkit/subconscious#6](https://github.com/cortexkit/subconscious/issues/6) proposes putting `kind` on `SubcError` itself. If the classifier then reads it, GOODBYE flips false→true and the `dropClient` decisions consuming this classifier change behaviour — on an SDK bump alone, with no diff in this repo.

I think that flip is **probably correct**: a route GOODBYE genuinely is the transient class. This isn't an argument against it. It's that a reconnect-policy change arriving through a dependency should land as a red test you adopt deliberately, not as a reconnect storm someone diagnoses later. The comment says so, and says to flip the assertions rather than delete the test when it happens.

## Verification

Red control, since a characterization test that can't fail is worse than none:

```
green                                       55 pass / 0 fail
mutate SubcError → SocketClosedError        (verified applied via cmp, not assumed)
  ↳ simulates exactly the flip: GOODBYE becomes transient
red                                         54 pass / 1 fail — only the new test
restore                                     (verified via cmp)
green                                       55 pass / 0 fail
```

Full `packages/aft-bridge` suite: 474 pass / 0 fail. Lint and format clean.

The mutation targets the classification, not the assertion, so it fails for the reason the test exists — `expect(client.closed).toBe(0)` and `expect(madeClients).toBe(1)` are what break.

Test-only; no production code touched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789417410&installation_model_id=22398&pr_number=223&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F223&signature=9ee86c348c1b7bb68e31fe173530d48847d24212cb1cedd0a4b2af9416570299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the current reconnect classification for route GOODBYE to prevent an SDK-only change from silently changing reconnect policy. Today a mid-request GOODBYE yields a bare `SubcError` that `isConsumerReconnectTransient` treats as non-transient: the route drops, the client is kept, the next call reopens on the same connection, and there is no in-place retry.

- Adds a characterization test in `packages/aft-bridge/src/__tests__/subc-transport.test.ts` asserting: first call rejects with `SubcError` (not `SubcCallError`), client stays open, second call succeeds on the same client, and there is no auto-retry.
- The fixture carries `kind: "outcome_unknown"` even though today’s `SubcError` has only `code`, so the test will turn red when the classifier starts reading `kind`.
- Test-only; no production code.

**When the SDK flips**
- When `cortexkit/subconscious#6` adds `kind` to `SubcError` and the classifier consumes it, GOODBYE will classify transient and this test should fail.
- Action: flip the assertions to expect client drop and reconnect; do not delete the test.

<sup>Written for commit 410f55fce9103ad2e6cdfe7c5c7a34b4cd5fd16b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This test-only PR pins the current reconnect policy for route GOODBYE failures before a planned SDK classifier change.
- Models a route GOODBYE as a bare `SubcError` carrying `kind: "outcome_unknown"`.
- Verifies the client remains open, the route reopens on the same connection, and the failed call is not retried in place.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/aft-bridge/src/__tests__/subc-transport.test.ts | Adds a focused reconnect-policy characterization test and now explicitly models the structured GOODBYE discriminator requested in the previous review. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test: pin route-GOODBYE reconnect classi..."](https://github.com/cortexkit/aft/commit/410f55fce9103ad2e6cdfe7c5c7a34b4cd5fd16b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53660144)</sub>

**Context used:**

- Knowledge Base — [AFT SubC tool-surface bridge](https://app.greptile.com/cortexkit/-/custom-context/knowledge-base/cortexkit/aft/-/docs/aft-subc-bridge.md)
- Knowledge Base — [TypeScript AFT bridge: native and daemon-backed transport](https://app.greptile.com/cortexkit/-/custom-context/knowledge-base/cortexkit/aft/-/docs/aft-bridge.md)

<!-- /greptile_comment -->