### PR TITLE
docs: clarify aft_search path scope

### DIFF
--- a/crates/aft/src/subc_tool_schemas.json
+++ b/crates/aft/src/subc_tool_schemas.json
@@ -269,7 +269,7 @@
         "type": "boolean"
       },
       "path": {
-        "description": "Search a different project root (absolute or ~ path). Requires that project to have been indexed by AFT.",
+        "description": "Only set this to search a different Git project (absolute or ~ path). Omit it for the current configured workspace, including non-Git workspace roots; this is not a subdirectory filter. Unindexed external projects use a bounded lexical fallback.",
         "type": "string"
       }
     },

--- a/packages/opencode-plugin/src/tools/semantic.ts
+++ b/packages/opencode-plugin/src/tools/semantic.ts
@@ -48,7 +48,7 @@ export function semanticTools(ctx: PluginContext): Record<string, ToolDefinition
           .string()
           .optional()
           .describe(
-            "Search a different project root (absolute or ~ path). Requires that project to have been indexed by AFT.",
+            "Only set this to search a different Git project (absolute or ~ path). Omit it for the current configured workspace, including non-Git workspace roots; this is not a subdirectory filter. Unindexed external projects use a bounded lexical fallback.",
           ),
       ),
     },

--- a/packages/pi-plugin/src/tools/semantic.ts
+++ b/packages/pi-plugin/src/tools/semantic.ts
@@ -61,7 +61,7 @@ const SearchParams = Type.Object(
     path: Type.Optional(
       Type.String({
         description:
-          "Search a different project root (absolute or ~ path). Requires that project to have been indexed by AFT.",
+          "Only set this to search a different Git project (absolute or ~ path). Omit it for the current configured workspace, including non-Git workspace roots; this is not a subdirectory filter. Unindexed external projects use a bounded lexical fallback.",
       }),
     ),
   },


### PR DESCRIPTION
## Summary

- tell agents to omit `path` for the configured workspace, including non-Git aggregate workspaces
- clarify that `path` selects a different Git project rather than filtering a subtree
- document the existing bounded lexical fallback for unindexed external projects
- keep OpenCode, Pi, and the embedded subc schema aligned

## Why

Agents commonly pass a known project directory explicitly because `path` usually means search scope. For a non-Git configured workspace, that redundant argument currently reaches Git-root resolution and fails with `not_a_git_root`.

This is stage 1 of the remediation tracked in #227. The runtime hardening is intentionally split into a second PR.

## Validation

- `bun run --filter @cortexkit/aft-opencode typecheck`
- `bun run --filter @cortexkit/aft-pi typecheck`
- `CI=true bun test packages/opencode-plugin/src/__tests__/subc-tool-schemas-fresh.test.ts packages/opencode-plugin/src/__tests__/registration-parity.test.ts` (15 passed)
- `bunx biome check` on both tool definitions and the generated schema

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789550339&installation_model_id=22398&pr_number=228&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F228&signature=9cc415fceb1744c0e537de6e30c0ccef2763d8c6c5f12652cfc88e4623b90ba2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies `aft_search` path scope and aligns wording across the core schema and plugins to prevent agents from passing workspace paths that trigger not_a_git_root errors. Old docs suggested using `path` to set search scope and required an indexed project; new docs limit `path` to switching to a different Git project, state it is not a subdirectory filter, and document a bounded lexical fallback for unindexed projects.

- Callers: omit `path` for the configured workspace (including non-Git roots). No runtime or schema-shape changes.
- Review: string-only updates in `crates/aft/src/subc_tool_schemas.json`, `packages/opencode-plugin/src/tools/semantic.ts`, and `packages/pi-plugin/src/tools/semantic.ts`.

<sup>Written for commit 4bf712179b5a88109ff6d6f85d93d36e17e470e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This documentation-only PR aligns the OpenCode, Pi, and generated SubC schemas around the existing `aft_search.path` behavior.

- Clarifies that `path` selects a different Git project rather than filtering a workspace subtree.
- Instructs agents to omit `path` for the configured workspace, including non-Git roots.
- Documents the bounded lexical fallback for unindexed external projects.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it only clarifies agent-facing descriptions and those descriptions match the existing search behavior.

The three changed descriptions remain aligned and accurately distinguish configured-workspace search, external Git-project selection, and bounded lexical fallback without altering runtime behavior.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/aft/src/subc_tool_schemas.json | Updates the generated SubC search schema description consistently with the host tool definitions. |
| packages/opencode-plugin/src/tools/semantic.ts | Clarifies the OpenCode-facing optional search path semantics without changing executable behavior. |
| packages/pi-plugin/src/tools/semantic.ts | Applies the same clarified search path description to Pi, preserving cross-host schema parity. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(pi): clarify aft\_search path scope"](https://github.com/cortexkit/aft/commit/4bf712179b5a88109ff6d6f85d93d36e17e470e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53929386)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [AFT SubC tool-surface bridge](https://app.greptile.com/cortexkit/-/custom-context/knowledge-base/cortexkit/aft/-/docs/aft-subc-bridge.md)
- Knowledge Base — [OpenCode unified AFT tool surface](https://app.greptile.com/cortexkit/-/custom-context/knowledge-base/cortexkit/aft/-/docs/opencode-tool-surface.md)
- Knowledge Base — [Pi plugin: AFT host integration and tool surface](https://app.greptile.com/cortexkit/-/custom-context/knowledge-base/cortexkit/aft/-/docs/pi-plugin.md)
</details>

<!-- /greptile_comment -->