### PR TITLE
fix: treat current search root as local

### DIFF
--- a/crates/aft/src/readonly_artifacts.rs
+++ b/crates/aft/src/readonly_artifacts.rs
@@ -67,18 +67,21 @@ pub(crate) fn resolve_git_root_from_user_path(
 
     let existing = nearest_existing_parent(&requested)
         .ok_or_else(|| GitRootResolutionError::PathNotFound(requested.clone()))?;
+
+    // `nearest_existing_parent` returns an `fs::canonicalize` result, which on
+    // Windows is a verbatim (`\\?\C:\...`) path. Normalize before comparing the
+    // requested directory with the configured root so aliases such as `.` and
+    // symlinks remain local without requiring the workspace itself to be Git.
+    let existing = crate::inspect::job::canonicalize_normalized(&existing);
+    if existing == crate::inspect::job::canonicalize_normalized(project_root) {
+        return Ok(project_root.to_path_buf());
+    }
+
     let git_base = if existing.is_file() {
         existing.parent().unwrap_or(&existing).to_path_buf()
     } else {
         existing
     };
-    // `nearest_existing_parent` returns an `fs::canonicalize` result, which on
-    // Windows is a verbatim (`\?\C:\...`) path. `git_toplevel` passes it to
-    // `Command::current_dir`, and `CreateProcess` rejects verbatim paths as
-    // `lpCurrentDirectory` (the same Win32 limitation that breaks LSP spawns in
-    // #174). Strip the prefix here so the git probe spawns under a non-verbatim
-    // cwd. On Unix `canonicalize_normalized` is identity-equivalent.
-    let git_base = crate::inspect::job::canonicalize_normalized(&git_base);
     git_toplevel(&git_base).map_err(|error| match error.as_str() {
         "not_a_git_root" => GitRootResolutionError::NotAGitRoot,
         _ => GitRootResolutionError::Other(error),

--- a/crates/aft/tests/integration/aft_search_contract_test.rs
+++ b/crates/aft/tests/integration/aft_search_contract_test.rs
@@ -805,6 +805,113 @@ fn same_root_path_param_is_byte_identical_to_default_search() {
 }
 
 #[test]
+fn non_git_same_root_path_param_is_byte_identical_to_default_search() {
+    let _git_env = crate::test_helpers::hermetic_git_env_guard();
+    let (project, _source_file, _source) = project_with_needle();
+    let ctx = test_context(project.path());
+    *ctx.semantic_index_status()
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = SemanticIndexStatus::Disabled;
+
+    let without_path = response_value(handle_semantic_search(
+        &request_with("needle_symbol", Some("literal")),
+        &ctx,
+    ));
+    let with_path = response_value(handle_semantic_search(
+        &request_with_path("needle_symbol", Some("literal"), project.path()),
+        &ctx,
+    ));
+
+    assert_eq!(
+        serde_json::to_vec(&with_path).expect("serialize with path"),
+        serde_json::to_vec(&without_path).expect("serialize without path"),
+        "non-Git same-root path must preserve the default response byte-for-byte"
+    );
+}
+
+#[test]
+fn non_git_dot_path_param_is_byte_identical_to_default_search() {
+    let _git_env = crate::test_helpers::hermetic_git_env_guard();
+    let (project, _source_file, _source) = project_with_needle();
+    let ctx = test_context(project.path());
+    *ctx.semantic_index_status()
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = SemanticIndexStatus::Disabled;
+
+    let without_path = response_value(handle_semantic_search(
+        &request_with("needle_symbol", Some("literal")),
+        &ctx,
+    ));
+    let with_path = response_value(handle_semantic_search(
+        &request_with_path("needle_symbol", Some("literal"), Path::new(".")),
+        &ctx,
+    ));
+
+    assert_eq!(
+        serde_json::to_vec(&with_path).expect("serialize with path"),
+        serde_json::to_vec(&without_path).expect("serialize without path"),
+        "non-Git dot path must preserve the default response byte-for-byte"
+    );
+}
+
+#[test]
+fn restricted_paths_keep_same_root_local_and_refuse_external_root() {
+    let _git_env = crate::test_helpers::hermetic_git_env_guard();
+    let (session_project, _source_file, _source) = project_with_needle();
+    let (external_project, _source_file, _source) = git_project_with_needle();
+    let ctx = AppContext::new(
+        Box::new(TreeSitterProvider::new()),
+        Config {
+            project_root: Some(session_project.path().to_path_buf()),
+            restrict_to_project_root: true,
+            ..Config::default()
+        },
+    );
+    *ctx.semantic_index_status()
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = SemanticIndexStatus::Disabled;
+
+    let without_path = response_value(handle_semantic_search(
+        &request_with("needle_symbol", Some("literal")),
+        &ctx,
+    ));
+    let same_root = response_value(handle_semantic_search(
+        &request_with_path("needle_symbol", Some("literal"), session_project.path()),
+        &ctx,
+    ));
+
+    assert_eq!(
+        serde_json::to_vec(&same_root).expect("serialize same-root response"),
+        serde_json::to_vec(&without_path).expect("serialize default response"),
+        "path restriction must still allow the configured non-Git root"
+    );
+
+    let external_root = response_value(handle_semantic_search(
+        &request_with_path("needle_symbol", Some("literal"), external_project.path()),
+        &ctx,
+    ));
+
+    assert_eq!(external_root["success"], false);
+    assert_eq!(external_root["code"], "path_outside_root");
+}
+
+#[test]
+fn external_non_git_path_still_returns_not_a_git_root() {
+    let _git_env = crate::test_helpers::hermetic_git_env_guard();
+    let session_project = tempfile::tempdir().expect("session project");
+    let external_project = tempfile::tempdir().expect("external project");
+    let ctx = test_context(session_project.path());
+
+    let response = response_value(handle_semantic_search(
+        &request_with_path("needle_symbol", Some("literal"), external_project.path()),
+        &ctx,
+    ));
+
+    assert_eq!(response["success"], false);
+    assert_eq!(response["code"], "not_a_git_root");
+}
+
+#[test]
 fn external_ignore_rule_mismatch_keeps_drift_in_metadata_only() {
     let _git_env = crate::test_helpers::hermetic_git_env_guard();
     let (owner_project, _owner_source, _source) = git_project_with_needle();


### PR DESCRIPTION
## Summary

- short-circuit canonical current-root aliases before external Git-root probing
- return the configured root's original path form after the normalized comparison
- cover non-Git absolute-root, dot-root, distinct non-Git, and restricted-root behavior

Closes #227

## Verification

- red phase on the parent commit: the restricted same-root case failed with `not_a_git_root`
- focused restriction regression: 1 passed
- full `aft_search_contract_test` module: 42 passed
- `cargo +1.93.0 check -p agent-file-tools --tests`
- `cargo +1.93.0 fmt --all -- --check`
- live NDJSON `tool_call` probe with `restrict_to_project_root: true`: `path: "."` found the non-Git workspace symbol, while a distinct Git root returned `path_outside_root`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789552614&installation_model_id=22398&pr_number=232&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F232&signature=6830eec281f5d3ddb120fcb603f4b3294a46bbc0de394f8f057f93d2b9874d67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats search requests that alias the configured project root (including "." and symlinks) as local, skipping external Git-root probing. Previously these aliases could be treated as external, returning not_a_git_root or path_outside_root in non-Git workspaces or with restrict_to_project_root enabled.

- Normalize the requested path and the configured root once before comparison; when equal, return the configured root’s original path form.
- Normalize upfront so Git probing uses a non-verbatim path on Windows; remove the now-redundant later normalization.
- Tests: non-Git same-root and "." return byte-identical responses to default search; with restrict_to_project_root=true, same-root is allowed and external roots are rejected; external non-Git roots still return not_a_git_root.

<sup>Written for commit 843f79e59b41a5fdfe3e4f9a31494839544ddb77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR treats canonical aliases of the configured search root as local, avoiding unnecessary Git-root probing while preserving the configured root’s original path form.
- Normalizes the requested path before comparing it with the configured project root.
- Returns the configured root directly when both paths identify the same location.
- Adds coverage for non-Git roots, dot aliases, root restrictions, and distinct external paths.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/aft/src/readonly_artifacts.rs | Normalizes the nearest existing requested path and short-circuits when it identifies the configured project root. |
| crates/aft/tests/integration/aft_search_contract_test.rs | Adds regression coverage for same-root aliases in non-Git and root-restricted search configurations. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: treat current search root as local"](https://github.com/cortexkit/aft/commit/843f79e59b41a5fdfe3e4f9a31494839544ddb77) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53937845)</sub>

<!-- /greptile_comment -->