### PR TITLE
fix: recover standalone bridge from closed stdin

### DIFF
--- a/packages/aft-bridge/src/__tests__/bridge-transport.test.ts
+++ b/packages/aft-bridge/src/__tests__/bridge-transport.test.ts
@@ -1,6 +1,7 @@
 /// <reference path="../bun-test.d.ts" />
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { ChildProcess } from "node:child_process";
 import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -135,6 +136,85 @@ process.stdin.on("data", (chunk) => {
     try {
       const response = await bridge.send("version");
       expect(response.version).toBe("1.2.3 🚀");
+    } finally {
+      await bridge.shutdown();
+    }
+  });
+
+  test("respawns when child stdin closes before process exit", async () => {
+    const script = writeExecutable(
+      "closed-stdin.js",
+      `#!/usr/bin/env node
+process.stdin.setEncoding("utf8");
+let buffer = "";
+setInterval(() => {}, 1_000);
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  let newline;
+  while ((newline = buffer.indexOf("\\n")) !== -1) {
+    const line = buffer.slice(0, newline);
+    buffer = buffer.slice(newline + 1);
+    const req = JSON.parse(line);
+    process.stdout.write(JSON.stringify({ id: req.id, success: true, warnings: [], pid: process.pid }) + "\\n");
+  }
+});
+`,
+    );
+    const bridge = new BinaryBridge(script, workDir, { timeoutMs: 5_000, maxRestarts: 0 });
+    const testBridge = bridge as unknown as { process: ChildProcess | null };
+
+    try {
+      const first = await bridge.send("ping");
+      const firstPid = first.pid;
+      const staleChild = testBridge.process;
+      if (!staleChild?.stdin) throw new Error("bridge child stdin is unavailable");
+
+      const closed = new Promise<void>((resolve) => staleChild.stdin?.once("close", resolve));
+      staleChild.stdin.destroy();
+      await closed;
+
+      expect(staleChild.exitCode).toBeNull();
+      const second = await bridge.send("ping");
+      expect(second.pid).not.toBe(firstPid);
+    } finally {
+      await bridge.shutdown();
+    }
+  });
+
+  test("invalidates the child after an asynchronous stdin write failure", async () => {
+    const script = writeExecutable(
+      "write-error.js",
+      `#!/usr/bin/env node
+process.stdin.setEncoding("utf8");
+let buffer = "";
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  let newline;
+  while ((newline = buffer.indexOf("\\n")) !== -1) {
+    const line = buffer.slice(0, newline);
+    buffer = buffer.slice(newline + 1);
+    const req = JSON.parse(line);
+    process.stdout.write(JSON.stringify({ id: req.id, success: true, warnings: [], pid: process.pid }) + "\\n");
+  }
+});
+`,
+    );
+    const bridge = new BinaryBridge(script, workDir, { timeoutMs: 5_000, maxRestarts: 0 });
+    const testBridge = bridge as unknown as { process: ChildProcess | null };
+
+    try {
+      const first = await bridge.send("ping");
+      const staleChild = testBridge.process;
+      if (!staleChild?.stdin) throw new Error("bridge child stdin is unavailable");
+
+      staleChild.stdin.write = ((_chunk: unknown, callback?: (error?: Error | null) => void) => {
+        queueMicrotask(() => callback?.(new Error("simulated EPIPE")));
+        return false;
+      }) as typeof staleChild.stdin.write;
+
+      await expect(bridge.send("mutate")).rejects.toThrow("simulated EPIPE");
+      const second = await bridge.send("ping");
+      expect(second.pid).not.toBe(first.pid);
     } finally {
       await bridge.shutdown();
     }

--- a/packages/aft-bridge/src/bridge.ts
+++ b/packages/aft-bridge/src/bridge.ts
@@ -576,6 +576,21 @@ export class BinaryBridge implements AftProjectTransport {
     return this.process !== null && this.process.exitCode === null && !this.process.killed;
   }
 
+  private invalidateTransportProcess(error: BridgeTransportUnavailableError): void {
+    const proc = this.process;
+    if (!proc) return;
+
+    this.process = null;
+    this.spawnedBinaryFingerprint = null;
+    if (proc.exitCode === null && !proc.killed) {
+      proc.kill("SIGKILL");
+    }
+    this.clearRestartResetTimer();
+    this.configured = false;
+    this.outstandingBackgroundTaskIds.clear();
+    this.rejectAllPending(error);
+  }
+
   hasPendingRequests(): boolean {
     return this.pending.size > 0;
   }
@@ -876,6 +891,7 @@ export class BinaryBridge implements AftProjectTransport {
       const keepBridgeOnTimeout = passive || options?.keepBridgeOnTimeout === true;
       let requestSentAt = Date.now();
 
+      const child = this.process;
       const response = await new Promise<Record<string, unknown>>((resolve, reject) => {
         const timer = setTimeout(() => {
           const entry = this.pending.get(id);
@@ -931,31 +947,31 @@ export class BinaryBridge implements AftProjectTransport {
 
         this.pending.set(id, { resolve, reject, timer, onProgress: options?.onProgress, command });
 
-        if (!this.process?.stdin?.writable) {
+        if (!child?.stdin?.writable) {
           this.pending.delete(id);
           clearTimeout(timer);
-          reject(
-            new BridgeTransportUnavailableError(
-              `${this.errorPrefix} stdin not writable for command "${command}"`,
-            ),
+          const error = new BridgeTransportUnavailableError(
+            `${this.errorPrefix} stdin not writable for command "${command}"`,
           );
+          reject(error);
+          if (this.process === child) this.invalidateTransportProcess(error);
           return;
         }
 
         requestSentAt = Date.now();
-        this.process.stdin.write(line, (err) => {
+        child.stdin.write(line, (err) => {
           if (err) {
+            const error = new BridgeTransportUnavailableError(
+              `${this.errorPrefix} Failed to write to stdin: ${err.message}`,
+              { cause: err },
+            );
             const entry = this.pending.get(id);
             if (entry) {
               this.pending.delete(id);
               clearTimeout(entry.timer);
-              entry.reject(
-                new BridgeTransportUnavailableError(
-                  `${this.errorPrefix} Failed to write to stdin: ${err.message}`,
-                  { cause: err },
-                ),
-              );
+              entry.reject(error);
             }
+            if (this.process === child) this.invalidateTransportProcess(error);
           }
         });
       });
@@ -1178,7 +1194,12 @@ export class BinaryBridge implements AftProjectTransport {
   }
 
   private ensureSpawned(triggeringSessionId?: string): void {
-    if (this.isAlive()) return;
+    if (this.isAlive() && this.process?.stdin?.writable) return;
+    if (this.process !== null) {
+      this.invalidateTransportProcess(
+        new BridgeTransportUnavailableError(`${this.errorPrefix} Child stdin is not writable`),
+      );
+    }
     this.spawnProcess(triggeringSessionId);
   }
 


### PR DESCRIPTION
## Summary

- treat a live child with non-writable stdin as an unusable standalone transport
- retire the stale child before respawn so `BridgePool` cannot keep returning a permanently wedged bridge
- capture the child used for each write and invalidate it only when it is still current, preventing a late callback from killing a replacement

## Outcome semantics

The two failure windows intentionally differ:

1. If stdin is already non-writable when `ensureSpawned()` runs, no write has been attempted. The stale child is invalidated, a replacement is spawned, and that `send()` continues on the replacement.
2. If `stdin.write()` reports an asynchronous error after initiation, the current request rejects with `BridgeTransportUnavailableError` because mutation outcome may be unknown. The child is invalidated so the next request respawns; the current request is never blindly replayed.

This removes the permanent-wedge class while preserving conservative unknown-outcome handling.

## Verification

- regression first reproduced the old permanent `stdin not writable` wedge
- targeted closed-stdin and async-write tests: 2 passed
- complete `bridge-transport.test.ts`: 22 passed
- `@cortexkit/aft-bridge` typecheck: passed
- Biome on changed files: passed
- live driver: one `BinaryBridge` replaced child PID 77753 with PID 77767 and served the next ping successfully

Closes #231

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789554518&installation_model_id=22398&pr_number=233&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F233&signature=f7c101604aaa6cc16aae05326d5983898b93a4c65d73daa0acb0d6e2782b88b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a permanent wedge in `aft-bridge` when a child stays alive but its stdin closes. Previously the bridge stayed stuck; now non-writable stdin is treated as transport failure, the child is invalidated, and a fresh child is spawned. In-flight writes that fail asynchronously reject and are not replayed.

- `BinaryBridge.ensureSpawned` now invalidates a live child with non-writable `stdin` and respawns, so `BridgePool` no longer returns a wedged bridge.
- `send()` captures the child used for the write and only invalidates it if it’s still current, avoiding late-callback races that could kill a replacement.
- On async `stdin.write` errors, the request rejects with `BridgeTransportUnavailableError`; the child is invalidated so the next request respawns.
- Adds tests for closed-stdin-before-exit and async write failure.

<sup>Written for commit 0c4255ca3a28468960e1f92d0b88cbd7a2883590. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR recovers standalone bridges when a live child has unusable stdin and makes asynchronous write-error invalidation child-specific.

- Adds transport invalidation that detaches and kills unusable children, clears process-scoped state, and rejects pending requests.
- Respawns before sending when the current child is alive but stdin is not writable.
- Captures the child used for each write so delayed callbacks cannot invalidate a newer replacement.
- Adds regressions for closed stdin and asynchronous write failures.
</details>

<h3>Confidence Score: 3/5</h3>

The PR should not merge until replacement processes are isolated from the retired child's stream handlers and configuration lifecycle.

Immediate respawn allows delayed stdout closure from the retired child to consume replacement framing, while an in-flight configure continuation can incorrectly transfer configured state to the new process.

**Files Needing Attention:** packages/aft-bridge/src/bridge.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/aft-bridge/src/bridge.ts | Adds closed-stdin recovery and generation-aware write callbacks, but immediate replacement remains exposed to stale stream listeners and configuration continuations. |
| packages/aft-bridge/src/__tests__/bridge-transport.test.ts | Adds useful recovery regressions, but they do not exercise retired-child stream events or configuration completion racing with replacement. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant A as Request A
  participant B as BinaryBridge
  participant Old as Retired child
  participant New as Replacement child
  A->>B: send while configure is active
  Old-->>B: stdin becomes non-writable
  B->>Old: SIGKILL
  B->>New: spawn immediately
  New-->>B: partial stdout response
  Old-->>B: delayed stdout end
  B->>B: flush shared stdout buffer
  Note over B: Replacement frame may be discarded
  B->>B: stale configure continuation marks configured
  Note over B,New: New child may never receive configure
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: recover standalone bridge from clos..."](https://github.com/cortexkit/aft/commit/0c4255ca3a28468960e1f92d0b88cbd7a2883590) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53944602)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [TypeScript AFT bridge: native and daemon-backed transport](https://app.greptile.com/cortexkit/-/custom-context/knowledge-base/cortexkit/aft/-/docs/aft-bridge.md)

<!-- /greptile_comment -->