### PR TITLE
fix: isolate standalone bridge process generations

### DIFF
--- a/packages/aft-bridge/src/__tests__/bridge-transport.test.ts
+++ b/packages/aft-bridge/src/__tests__/bridge-transport.test.ts
@@ -220,6 +220,155 @@ process.stdin.on("data", (chunk) => {
     }
   });
 
+  test("ignores stale child stdout end after replacement owns the buffer", async () => {
+    const script = writeExecutable(
+      "stale-stdout.js",
+      `#!/usr/bin/env node
+process.stdin.setEncoding("utf8");
+let buffer = "";
+setInterval(() => {}, 1_000);
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  let newline;
+  while ((newline = buffer.indexOf("\\n")) !== -1) {
+    const line = buffer.slice(0, newline);
+    buffer = buffer.slice(newline + 1);
+    const req = JSON.parse(line);
+    process.stdout.write(JSON.stringify({ id: req.id, success: true, warnings: [], pid: process.pid }) + "\\n");
+  }
+});
+`,
+    );
+    const bridge = new BinaryBridge(script, workDir, { timeoutMs: 5_000, maxRestarts: 0 });
+    const testBridge = bridge as unknown as {
+      process: ChildProcess | null;
+      stdoutBuffer: string;
+    };
+
+    try {
+      await bridge.send("ping");
+      const staleChild = testBridge.process;
+      if (!staleChild?.stdin) throw new Error("bridge child stdin is unavailable");
+
+      const closed = new Promise<void>((resolve) => staleChild.stdin?.once("close", resolve));
+      staleChild.stdin.destroy();
+      await closed;
+      await bridge.send("ping");
+
+      testBridge.stdoutBuffer = '{"id":"replacement"';
+      staleChild.stdout?.emit("end");
+      expect(testBridge.stdoutBuffer).toBe('{"id":"replacement"');
+    } finally {
+      await bridge.shutdown();
+    }
+  });
+
+  test("does not carry configure completion across child generations", async () => {
+    const script = writeExecutable(
+      "configure-generation.js",
+      `#!/usr/bin/env node
+process.stdin.setEncoding("utf8");
+let buffer = "";
+let configured = false;
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  let newline;
+  while ((newline = buffer.indexOf("\\n")) !== -1) {
+    const line = buffer.slice(0, newline);
+    buffer = buffer.slice(newline + 1);
+    const req = JSON.parse(line);
+    if (req.command === "configure") configured = true;
+    process.stdout.write(JSON.stringify({
+      id: req.id,
+      success: true,
+      warnings: [],
+      configured,
+      pid: process.pid,
+    }) + "\\n");
+  }
+});
+`,
+    );
+    const bridge = new BinaryBridge(script, workDir, { timeoutMs: 5_000, maxRestarts: 0 });
+    const testBridge = bridge as unknown as {
+      process: ChildProcess | null;
+      deliverConfigureWarnings: () => Promise<void>;
+    };
+    let releaseWarnings: (() => void) | undefined;
+    let warningsEntered: (() => void) | undefined;
+    const warningGate = new Promise<void>((resolve) => {
+      releaseWarnings = resolve;
+    });
+    const entered = new Promise<void>((resolve) => {
+      warningsEntered = resolve;
+    });
+    testBridge.deliverConfigureWarnings = async () => {
+      warningsEntered?.();
+      await warningGate;
+    };
+
+    try {
+      const first = bridge.send("ping");
+      await entered;
+      const staleChild = testBridge.process;
+      if (!staleChild?.stdin) throw new Error("bridge child stdin is unavailable");
+
+      const closed = new Promise<void>((resolve) => staleChild.stdin?.once("close", resolve));
+      staleChild.stdin.destroy();
+      await closed;
+      const second = bridge.send("ping");
+      releaseWarnings?.();
+      await Promise.allSettled([first, second]);
+
+      const third = await bridge.send("ping");
+      expect(third.configured).toBe(true);
+    } finally {
+      releaseWarnings?.();
+      await bridge.shutdown();
+    }
+  });
+
+  test("invalidates the child when stdin write throws synchronously", async () => {
+    const script = writeExecutable(
+      "sync-write-error.js",
+      `#!/usr/bin/env node
+process.stdin.setEncoding("utf8");
+let buffer = "";
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  let newline;
+  while ((newline = buffer.indexOf("\\n")) !== -1) {
+    const line = buffer.slice(0, newline);
+    buffer = buffer.slice(newline + 1);
+    const req = JSON.parse(line);
+    process.stdout.write(JSON.stringify({ id: req.id, success: true, warnings: [], pid: process.pid }) + "\\n");
+  }
+});
+`,
+    );
+    const bridge = new BinaryBridge(script, workDir, { timeoutMs: 5_000, maxRestarts: 0 });
+    const testBridge = bridge as unknown as {
+      process: ChildProcess | null;
+      pending: Map<string, unknown>;
+    };
+
+    try {
+      const first = await bridge.send("ping");
+      const staleChild = testBridge.process;
+      if (!staleChild?.stdin) throw new Error("bridge child stdin is unavailable");
+      staleChild.stdin.write = (() => {
+        throw new Error("synchronous write failure");
+      }) as typeof staleChild.stdin.write;
+
+      await expect(bridge.send("mutate")).rejects.toThrow("synchronous write failure");
+      expect(testBridge.pending.size).toBe(0);
+      const second = await bridge.send("ping");
+      expect(second.pid).not.toBe(first.pid);
+    } finally {
+      await bridge.shutdown();
+    }
+  });
+
   test("single timeout with child stdout activity keeps bridge warm and sibling alive", async () => {
     const script = writeExecutable(
       "alive-starvation.js",

--- a/packages/aft-bridge/src/__tests__/error-contract.test.ts
+++ b/packages/aft-bridge/src/__tests__/error-contract.test.ts
@@ -10,12 +10,14 @@ import {
 import {
   BridgeTransportTimeoutError,
   BridgeTransportUnavailableError,
+  BridgeTransportUnknownOutcomeError,
   isBridgeTransportTimeout,
 } from "../bridge.js";
 import {
   AftToolError,
   adaptToolError,
   BASH_TRANSPORT_DISPOSITION,
+  BRIDGE_TRANSPORT_UNKNOWN_OUTCOME_DISPOSITION,
   isBashTransportDeadError,
   SUBC_MODULE_RESTART_DISPOSITION,
 } from "../error-contract.js";
@@ -111,6 +113,10 @@ describe("isBashTransportDeadError", () => {
       }),
     ],
     ["route GOODBYE with unknown outcome", routeGoodbyeError()],
+    [
+      "standalone write with unknown outcome",
+      new BridgeTransportUnknownOutcomeError("write failed"),
+    ],
     ["live bridge request timeout", new BridgeTransportTimeoutError("bash", 100, "bridge busy")],
     ["ordinary tool failure", new Error("command failed")],
   ];
@@ -172,6 +178,17 @@ describe("adaptToolError", () => {
     adaptToolError("bash", original);
 
     expect(original.message).toContain(SUBC_MODULE_RESTART_DISPOSITION);
+    expect(original.message).not.toContain(BASH_TRANSPORT_DISPOSITION);
+  });
+
+  test("an outcome-unknown standalone write never gets bash re-run guidance", () => {
+    const original = new BridgeTransportUnknownOutcomeError("stdin write failed");
+
+    adaptToolError("bash", original);
+
+    expect(original.message).toContain(BRIDGE_TRANSPORT_UNKNOWN_OUTCOME_DISPOSITION);
+    expect(original.message).toContain("UNKNOWN");
+    expect(original.message).toContain("never blind-retry a mutation");
     expect(original.message).not.toContain(BASH_TRANSPORT_DISPOSITION);
   });
 

--- a/packages/aft-bridge/src/bridge.ts
+++ b/packages/aft-bridge/src/bridge.ts
@@ -248,6 +248,14 @@ export class BridgeTransportUnavailableError extends Error {
   }
 }
 
+/** The transport failed after a request may have been written to the child. */
+export class BridgeTransportUnknownOutcomeError extends BridgeTransportUnavailableError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "BridgeTransportUnknownOutcomeError";
+  }
+}
+
 /** Type guard for a transport-timeout rejection (bridge busy, retryable). */
 export function isBridgeTransportTimeout(err: unknown): err is BridgeTransportTimeoutError {
   return err instanceof Error && (err as { code?: unknown }).code === "transport_timeout";
@@ -588,7 +596,11 @@ export class BinaryBridge implements AftProjectTransport {
     this.clearRestartResetTimer();
     this.configured = false;
     this.outstandingBackgroundTaskIds.clear();
-    this.rejectAllPending(error);
+    this.rejectAllPending(
+      error instanceof BridgeTransportUnknownOutcomeError
+        ? error
+        : new BridgeTransportUnknownOutcomeError(error.message, { cause: error }),
+    );
   }
 
   hasPendingRequests(): boolean {
@@ -808,6 +820,14 @@ export class BinaryBridge implements AftProjectTransport {
       if (!this.configured) {
         if (command !== "configure" && command !== "version") {
           if (!this._configurePromise) {
+            const configuringChild = this.process;
+            const requireConfiguringChild = (): void => {
+              if (this.process !== configuringChild) {
+                throw new BridgeTransportUnavailableError(
+                  `${this.errorPrefix} Bridge process changed during configure; retry on replacement`,
+                );
+              }
+            };
             // First caller — create the configure promise.
             // All parallel callers await this same promise.
             //
@@ -829,6 +849,7 @@ export class BinaryBridge implements AftProjectTransport {
                   },
                   implicitTransportOptions,
                 );
+                requireConfiguringChild();
                 if (configResult.success === false) {
                   throw new Error(
                     `${this.errorPrefix} Configure failed: ${configResult.message ?? "unknown error"}`,
@@ -838,7 +859,9 @@ export class BinaryBridge implements AftProjectTransport {
                 // and relayed through stderr → plugin log. No need to re-log here
                 // (doing so would just duplicate the same line in aft-plugin.log).
                 await this.deliverConfigureWarnings(configResult, params, options);
+                requireConfiguringChild();
                 await this.checkVersion(implicitTransportOptions);
+                requireConfiguringChild();
                 // Re-check liveness after version check — checkVersion() swallows
                 // errors as best-effort, so the bridge may have died without throwing.
                 if (!this.isAlive()) {
@@ -959,21 +982,27 @@ export class BinaryBridge implements AftProjectTransport {
         }
 
         requestSentAt = Date.now();
-        child.stdin.write(line, (err) => {
-          if (err) {
-            const error = new BridgeTransportUnavailableError(
-              `${this.errorPrefix} Failed to write to stdin: ${err.message}`,
-              { cause: err },
-            );
-            const entry = this.pending.get(id);
-            if (entry) {
-              this.pending.delete(id);
-              clearTimeout(entry.timer);
-              entry.reject(error);
-            }
-            if (this.process === child) this.invalidateTransportProcess(error);
+        const handleWriteFailure = (cause: unknown): void => {
+          const writeError = cause instanceof Error ? cause : new Error(String(cause));
+          const error = new BridgeTransportUnknownOutcomeError(
+            `${this.errorPrefix} Failed to write to stdin: ${writeError.message}`,
+            { cause: writeError },
+          );
+          const entry = this.pending.get(id);
+          if (entry) {
+            this.pending.delete(id);
+            clearTimeout(entry.timer);
+            entry.reject(error);
           }
-        });
+          if (this.process === child) this.invalidateTransportProcess(error);
+        };
+        try {
+          child.stdin.write(line, (err) => {
+            if (err) handleWriteFailure(err);
+          });
+        } catch (err) {
+          handleWriteFailure(err);
+        }
       });
 
       if (
@@ -1305,9 +1334,11 @@ export class BinaryBridge implements AftProjectTransport {
 
     const stdoutDecoder = new StringDecoder("utf8");
     child.stdout?.on("data", (chunk: Buffer) => {
+      if (this.process !== currentChild) return;
       this.onStdoutData(stdoutDecoder.write(chunk));
     });
     child.stdout?.on("end", () => {
+      if (this.process !== currentChild) return;
       const remaining = stdoutDecoder.end();
       if (remaining) this.onStdoutData(remaining);
       this.flushStdoutBuffer();
@@ -1315,9 +1346,11 @@ export class BinaryBridge implements AftProjectTransport {
 
     const stderrDecoder = new StringDecoder("utf8");
     child.stderr?.on("data", (chunk: Buffer) => {
+      if (this.process !== currentChild) return;
       this.onStderrData(stderrDecoder.write(chunk));
     });
     child.stderr?.on("end", () => {
+      if (this.process !== currentChild) return;
       const remaining = stderrDecoder.end();
       if (remaining) this.onStderrData(remaining);
       this.flushStderrBuffer();
@@ -1351,7 +1384,7 @@ export class BinaryBridge implements AftProjectTransport {
         this.configured = false;
         this.clearRestartResetTimer();
         this.rejectAllPending(
-          new BridgeTransportUnavailableError(`${this.errorPrefix} Binary killed by ${signal}`),
+          new BridgeTransportUnknownOutcomeError(`${this.errorPrefix} Binary killed by ${signal}`),
         );
         return;
       }
@@ -1622,7 +1655,7 @@ export class BinaryBridge implements AftProjectTransport {
     }
 
     this.rejectAllPending(
-      new BridgeTransportUnavailableError(
+      new BridgeTransportUnknownOutcomeError(
         `${this.errorPrefix} Binary crashed (restarts: ${this._restartCount})${cause ? `: ${cause.message}` : ""} (see ${this.getLogFilePathVia()})`,
         { cause },
       ),

--- a/packages/aft-bridge/src/error-contract.ts
+++ b/packages/aft-bridge/src/error-contract.ts
@@ -12,7 +12,11 @@ import {
   SubcError,
 } from "@cortexkit/subc-client";
 
-import { BridgeTransportUnavailableError, isBridgeTransportTimeout } from "./bridge.js";
+import {
+  BridgeTransportUnavailableError,
+  BridgeTransportUnknownOutcomeError,
+  isBridgeTransportTimeout,
+} from "./bridge.js";
 import {
   SubcRootGenerationExpiredError,
   SubcRootReapedError,
@@ -72,6 +76,10 @@ export const BASH_TRANSPORT_DISPOSITION =
 export const SUBC_MODULE_RESTART_DISPOSITION =
   "The AFT daemon module restarted while this call was in flight, so its outcome is UNKNOWN: it may or may not have executed. Verify actual state before re-running, and never blind-retry a mutation.";
 
+/** Agent-facing guidance for a standalone request whose write outcome is unknown. */
+export const BRIDGE_TRANSPORT_UNKNOWN_OUTCOME_DISPOSITION =
+  "The standalone AFT transport failed after this call may have been sent, so its outcome is UNKNOWN: it may or may not have executed. Verify actual state before re-running, and never blind-retry a mutation.";
+
 /**
  * A route GOODBYE delivered against an in-flight request.
  *
@@ -115,6 +123,7 @@ export function isBashTransportDeadError(error: unknown): error is Error {
   if (!(error instanceof Error) || hasEngineResponse(error) || isRouteGoodbyeError(error)) {
     return false;
   }
+  if (error instanceof BridgeTransportUnknownOutcomeError) return false;
 
   return (
     error instanceof BridgeTransportUnavailableError ||
@@ -132,13 +141,20 @@ function isTransportClassError(error: unknown): boolean {
 
 /**
  * Append agent-facing recovery guidance without changing the original error
- * object, class, code, or retry behavior. Two dispositions exist: a route
- * GOODBYE appends the unknown-outcome guidance on EVERY command (checked
- * first), and bash transport failures append the re-run guidance. Commands
- * matching neither retain their errors untouched.
+ * object, class, code, or retry behavior. Unknown-outcome errors append safety
+ * guidance on every command; proven bash transport failures append re-run
+ * guidance. Commands matching neither retain their errors untouched.
  */
 export function adaptToolError(command: string, error: unknown): unknown {
   if (!(error instanceof Error)) return error;
+
+  if (error instanceof BridgeTransportUnknownOutcomeError) {
+    if (error.message.includes(BRIDGE_TRANSPORT_UNKNOWN_OUTCOME_DISPOSITION)) return error;
+    error.message = error.message
+      ? `${error.message} ${BRIDGE_TRANSPORT_UNKNOWN_OUTCOME_DISPOSITION}`
+      : BRIDGE_TRANSPORT_UNKNOWN_OUTCOME_DISPOSITION;
+    return error;
+  }
 
   // Checked before the bash branch, and applied to every command: a GOODBYE'd
   // call has an unknown outcome, so BASH_TRANSPORT_DISPOSITION's "no task was

--- a/packages/aft-bridge/src/index.ts
+++ b/packages/aft-bridge/src/index.ts
@@ -47,6 +47,7 @@ export {
   BinaryBridge,
   BridgeTransportTimeoutError,
   BridgeTransportUnavailableError,
+  BridgeTransportUnknownOutcomeError,
   compareSemver,
   isBridgeTransportTimeout,
   tagStderrLine,
@@ -103,6 +104,7 @@ export {
   type AftToolErrorCause,
   adaptToolError,
   BASH_TRANSPORT_DISPOSITION,
+  BRIDGE_TRANSPORT_UNKNOWN_OUTCOME_DISPOSITION,
   isBashTransportDeadError,
   toolErrorFromResponse,
 } from "./error-contract.js";


### PR DESCRIPTION
## Summary

Follow-up to #233 and the two post-review P1 findings:

- ignore stdout/stderr callbacks from retired child generations so a stale `end` cannot flush replacement output
- fence configure completion to the child that received configure, preventing an old continuation from marking a replacement configured
- retire the child and clear pending state for both synchronous and asynchronous stdin write failures
- classify in-flight standalone failures as outcome-unknown so bash host fallback cannot blind-replay a possible mutation

## Request outcome contract

- a child already known to be unwritable before a request is queued can still be replaced before dispatch
- after write initiation or an in-flight child teardown, the outcome is `UNKNOWN`; callers receive verification guidance and host fallback is ineligible
- no request is replayed across process generations

## Review findings addressed

- https://github.com/cortexkit/aft/pull/233#discussion_r3037020509
- https://github.com/cortexkit/aft/pull/233#discussion_r3037020510

## Verification

- `bun test packages/aft-bridge/src/__tests__` — 488 passed, 14 skipped
- `bun run --filter @cortexkit/aft-bridge typecheck`
- Biome check on all five changed files
- public barrel driver: unknown-outcome error exported, fallback ineligible, UNKNOWN/no-blind-retry guidance present

All commits are SSH-signed and based on merge commit `7ea58ee2`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789560423&installation_model_id=22398&pr_number=234&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F234&signature=d7c65dba5f6c5d31159e9c42b39daa1cc698ad2b86117a9883967c9c20320aa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates bridge process generations to prevent stale-child output, cross-generation configure completion, and blind replay after stdin write failures. Previously, retired children could flush replacement stdout, configure completion could carry over, and in‑flight standalone failures were treated as retryable; now we fence I/O and configure to the owning child, retire on write errors, and surface an unknown‑outcome error that blocks bash fallback.

- Introduces `BridgeTransportUnknownOutcomeError` and `BRIDGE_TRANSPORT_UNKNOWN_OUTCOME_DISPOSITION`; exported from `aft-bridge`.
- Treats stdin write failures (sync and async), crashes, and signals as unknown outcome: clears pending, rejects with unknown‑outcome error, and invalidates the current child; no request is replayed across generations.
- Ignores stdout/stderr `data`/`end` from retired children; only the current child can mutate buffers.
- Fences configure: ties warnings, version check, and completion to the child that started configure; if the child changes, throws `BridgeTransportUnavailableError` instructing a retry on the replacement.
- Updates error adaptation to append unknown‑outcome guidance and to exclude unknown‑outcome errors from `isBashTransportDeadError`, making bash host fallback ineligible.

**Migration**
- If you special‑case transport failures, handle `BridgeTransportUnknownOutcomeError` explicitly: verify actual state before retrying and never blind‑retry mutations; do not route these errors to bash fallback. No other changes required.

<sup>Written for commit c3b5854f0dcd3856be2002eb2744b1eac8646e2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR isolates standalone bridge process generations and introduces an explicit unknown-outcome error contract to prevent unsafe mutation replay.

- Fences configure completion and stream callbacks to their originating child.
- Retires children after synchronous or asynchronous stdin write failures.
- Prevents bash host fallback for standalone requests that may already have executed.
- Exports and tests the new unknown-outcome error contract.
</details>

<h3>Confidence Score: 4/5</h3>

The timeout-escalation gap should be fixed before merging because an in-flight mutation can be rejected without the required outcome-unknown guidance.

Generation fencing and write/crash handling are improved, but handleTimeout still emits an untyped sibling-abort error after requests may have reached the child, bypassing the new no-blind-retry contract.

**Files Needing Attention:** packages/aft-bridge/src/bridge.ts, packages/aft-bridge/src/error-contract.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/aft-bridge/src/bridge.ts | Adds process-generation guards and unknown-outcome handling, but timeout escalation still rejects in-flight siblings with a plain Error. |
| packages/aft-bridge/src/error-contract.ts | Adds unknown-outcome guidance and disables bash fallback for the new error type, but cannot recognize the plain sibling-timeout rejection. |
| packages/aft-bridge/src/index.ts | Correctly exports the new error class and disposition constant. |
| packages/aft-bridge/src/__tests__/bridge-transport.test.ts | Adds focused generation and write-failure regressions but does not assert unknown-outcome classification for timeout-aborted siblings. |
| packages/aft-bridge/src/__tests__/error-contract.test.ts | Verifies fallback ineligibility and safety guidance for explicitly typed unknown-outcome errors. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Standalone request written] --> B{Response received?}
  B -->|Yes| C[Resolve request]
  B -->|Write or child failure| D[Retire child generation]
  D --> E[Reject pending as outcome UNKNOWN]
  E --> F[Verify state; never blind-retry]
  B -->|Sibling timeout escalates| G[Reject siblings with plain Error]
  G --> H[SIGKILL child]
  H --> I[Unknown-outcome guidance is omitted]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: block fallback for unknown bridge o..."](https://github.com/cortexkit/aft/commit/c3b5854f0dcd3856be2002eb2744b1eac8646e2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53965463)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [TypeScript AFT bridge: native and daemon-backed transport](https://app.greptile.com/cortexkit/-/custom-context/knowledge-base/cortexkit/aft/-/docs/aft-bridge.md)

<!-- /greptile_comment -->