### PR TITLE
test: bound fs-lock contender cleanup

### DIFF
--- a/crates/aft/src/fs_lock.rs
+++ b/crates/aft/src/fs_lock.rs
@@ -1060,20 +1060,31 @@ mod tests {
         let (_dir, path) = test_lock_path();
         let guard = acquire_with_config(&path, None, test_config()).expect("acquire lock");
         let contender_path = path.clone();
-        let (tx, rx) = mpsc::sync_channel(1);
+        let (started_tx, started_rx) = mpsc::sync_channel(1);
+        let (result_tx, result_rx) = mpsc::sync_channel(1);
         let contender = std::thread::spawn(move || {
-            tx.send(try_acquire_once(&contender_path))
-                .expect("result receiver should remain open");
+            let _ = started_tx.send(());
+            let _ = result_tx.send(try_acquire_once(&contender_path));
         });
 
-        let result = match rx.recv_timeout(Duration::from_secs(5)) {
+        started_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("contender should start");
+        let result = match result_rx.recv_timeout(Duration::from_secs(2)) {
             Ok(result) => result,
-            Err(error) => {
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                contender.join().expect("contender should not panic");
+                panic!("contender exited without reporting a result");
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
                 drop(guard);
-                contender
-                    .join()
-                    .expect("contender should exit after owner drop");
-                panic!("try-acquire blocked behind the live owner: {error}");
+                match result_rx.recv_timeout(Duration::from_secs(1)) {
+                    Ok(_) | Err(mpsc::RecvTimeoutError::Disconnected) => {
+                        let _ = contender.join();
+                    }
+                    Err(mpsc::RecvTimeoutError::Timeout) => {}
+                }
+                panic!("try-acquire blocked behind the live owner");
             }
         };
 


### PR DESCRIPTION
## Summary

Post-merge follow-up to #235 after independent review found that its timeout branch still performed an unbounded worker `join`.

This tightens the test lifecycle without changing production locking:

- wait for an explicit contender-start handshake before beginning the result watchdog
- distinguish worker disconnection from a real result timeout
- keep the owner live throughout the bounded result window
- after timeout, drop the owner only for cleanup and use a second bounded wait; a persistently stuck worker is detached instead of hanging the test process
- tolerate sender teardown on timeout paths

## Verification

- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 test -p agent-file-tools --lib fs_lock::tests` — 21 passed
- focused test repeated 100 times with a 20-second outer process timeout — 100 passed

The commit is SSH-signed and based on current main at `24744afe`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789561605&installation_model_id=22398&pr_number=236&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F236&signature=12b77f6709d00eb0385cd36d3f5a5e7ad0743b3e7b233be6ead319936ea8d472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds fs-lock test cleanup to avoid unbounded joins when a contender blocks. The old test could hang on timeout; the new test uses handshakes and bounded waits without changing production lock behavior.

- Adds a contender-start handshake (5s) before the watchdog and a bounded result wait (2s); distinguishes disconnection from timeout with clear panics.
- On timeout, keeps the owner live during the wait, then drops it only for cleanup, performs one more bounded wait (1s), and does not join a stuck worker to prevent hanging the test process.

<sup>Written for commit d5afd73c85372f20132ede08aca88863d1dcd6b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR bounds cleanup in the filesystem-lock contention test so a stuck worker cannot hang the test process.
- Adds an explicit handshake before starting the result timeout.
- Distinguishes worker disconnection from timeout.
- Releases the owner only during cleanup and bounds the second wait before detaching a persistently stuck worker.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the changed test cleanup is bounded and does not alter production lock behavior.

The contender-start handshake preserves the intended live-owner test window, disconnection is handled separately, and both timeout waits are bounded so the regression test cannot hang indefinitely during worker cleanup.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/aft/src/fs_lock.rs | Tightens test-only thread synchronization and timeout cleanup without changing production locking behavior; no actionable defect was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test: bound fs-lock contender cleanup"](https://github.com/cortexkit/aft/commit/d5afd73c85372f20132ede08aca88863d1dcd6b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53969826)</sub>

<!-- /greptile_comment -->