### PR TITLE
fix: classify timeout-aborted siblings as unknown

### DIFF
--- a/packages/aft-bridge/src/__tests__/bridge-transport.test.ts
+++ b/packages/aft-bridge/src/__tests__/bridge-transport.test.ts
@@ -6,7 +6,11 @@ import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { setActiveLogger } from "../active-logger.js";
-import { BinaryBridge, isBridgeTransportTimeout } from "../bridge.js";
+import {
+  BinaryBridge,
+  BridgeTransportUnknownOutcomeError,
+  isBridgeTransportTimeout,
+} from "../bridge.js";
 import type { Logger, LogMeta } from "../logger.js";
 import { BridgePool } from "../pool.js";
 
@@ -508,20 +512,20 @@ process.stdin.on("data", (chunk) => {
         () => "resolved",
         (err) => String(err instanceof Error ? err.message : err),
       );
-      const siblingResult = bridge.send("sibling", {}, { timeoutMs: 1_000 }).then(
+      const siblingResult = bridge.send("sibling", {}, { timeoutMs: 1_000 }).then<unknown>(
         () => "resolved",
-        (err) => String(err instanceof Error ? err.message : err),
+        (err) => err,
       );
 
       const [second, sibling] = (await Promise.race([
         Promise.all([secondResult, siblingResult]),
-        new Promise<[string, string]>((resolve) =>
+        new Promise<[string, unknown]>((resolve) =>
           setTimeout(() => resolve(["pending", "pending"]), 200),
         ),
-      ])) as [string, string];
+      ])) as [string, unknown];
 
       expect(second).toMatch(/timed out|aborted/);
-      expect(sibling).toContain("sibling timeout");
+      expect(sibling).toBeInstanceOf(BridgeTransportUnknownOutcomeError);
       expect(bridge.isAlive()).toBe(false);
       expect(testBridge.configured).toBe(false);
     } finally {

--- a/packages/aft-bridge/src/bridge.ts
+++ b/packages/aft-bridge/src/bridge.ts
@@ -1590,7 +1590,9 @@ export class BinaryBridge implements AftProjectTransport {
     // sibling in-flight requests now instead of leaving them parked until their
     // own independent timers fire.
     this.rejectAllPending(
-      new Error(`${this.errorPrefix} bridge killed during sibling timeout — request aborted`),
+      new BridgeTransportUnknownOutcomeError(
+        `${this.errorPrefix} bridge killed during sibling timeout — request aborted`,
+      ),
     );
     // Forget outstanding background task ids: their removal hooks died with
     // the child (foreground polls were just rejected and won't resume, and a


### PR DESCRIPTION
## Summary

Post-merge follow-up to #234 for its remaining P1 review finding:

- timeout escalation now rejects sibling in-flight requests with `BridgeTransportUnknownOutcomeError` instead of a plain `Error`
- the existing repeated-timeout regression now asserts the exact error class rather than matching message text

This lets the merged #234 error contract append UNKNOWN/no-blind-retry guidance and keeps bash host fallback ineligible when a sibling mutation may already have executed.

Review finding: https://github.com/cortexkit/aft/pull/234#discussion_r3796200244

## Verification

- `bun test packages/aft-bridge/src/__tests__` — 488 passed, 14 skipped
- `bun run --filter @cortexkit/aft-bridge typecheck`
- Biome check on both changed files

The commit is SSH-signed and based on the #234 merge commit `24744afe`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789561605&installation_model_id=22398&pr_number=237&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F237&signature=73937b4b234bb87157e9f9afcfd12a926af7202100906b21c5486b1ebabe28e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies timeout-aborted sibling requests as unknown outcome. Previously these rejections used a generic Error; now they use BridgeTransportUnknownOutcomeError to prevent blind retries and keep bash host fallback ineligible when a sibling mutation may have executed.

- BinaryBridge now rejects all pending requests with BridgeTransportUnknownOutcomeError when a sibling-timeout escalation kills the bridge.
- Tests assert the error class instead of matching message text, preserving the repeated-timeout regression.
- Migration: update any consumer logic that parsed error messages to handle BridgeTransportUnknownOutcomeError; do not retry or trigger host fallback on this error.

<sup>Written for commit bb86c8a790a69f4ca39fceb36b21f753b280d3b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR refines timeout-escalation handling so sibling in-flight requests are explicitly classified as having an unknown outcome.

- Replaces the generic sibling-abort error with `BridgeTransportUnknownOutcomeError`.
- Strengthens the repeated-timeout regression test to assert the exact error class.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The production change narrows the sibling-abort error classification without changing timeout reachability or cleanup behavior, and the updated regression directly verifies the intended contract.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/aft-bridge/src/bridge.ts | Correctly classifies requests interrupted by timeout-driven process termination as unknown outcomes, preserving no-blind-retry behavior. |
| packages/aft-bridge/src/__tests__/bridge-transport.test.ts | Updates the timeout-escalation regression to verify the sibling rejection’s structured error class rather than message text. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: classify timeout-aborted siblings a..."](https://github.com/cortexkit/aft/commit/bb86c8a790a69f4ca39fceb36b21f753b280d3b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53969829)</sub>

**Context used:**

- Knowledge Base — [TypeScript AFT bridge: native and daemon-backed transport](https://app.greptile.com/cortexkit/-/custom-context/knowledge-base/cortexkit/aft/-/docs/aft-bridge.md)

<!-- /greptile_comment -->