### PR TITLE
perf(callgraph): match the cold-build path's write mechanics on incremental refresh

### DIFF
--- a/crates/aft/src/callgraph_store/mod.rs
+++ b/crates/aft/src/callgraph_store/mod.rs
@@ -2997,9 +2997,8 @@ impl CallGraphStore {
         let mut profile = RefreshFilesProfile::default();
         self.verify_writer_lease()?;
         let mut conn = self.conn.lock().expect("callgraph store mutex poisoned");
+        ensure_database_ready(&conn)?;
         let total_changes_before = conn.total_changes();
-        let tx = conn.transaction()?;
-        ensure_database_ready(&tx)?;
         let mut changed = Vec::new();
         let mut surface_changed = BTreeSet::new();
         let mut deleted = BTreeSet::new();
@@ -3009,28 +3008,25 @@ impl CallGraphStore {
         let mut selected_ref_ids = BTreeSet::new();
         let mut selected_refs_by_caller = BTreeMap::new();
         let mut changed_extracts: HashMap<String, FileExtract> = HashMap::new();
+        let mut fresh_metadata = BTreeMap::new();
 
         for input in changed_files {
             let abs_path = normalize_file_path(&self.project_root, input)?;
             let rel_path = relative_path(&self.project_root, &abs_path);
             changed.push(rel_path.clone());
-            let old_row = load_file_row(&tx, &rel_path)?;
+            let old_row = load_file_row(&conn, &rel_path)?;
             if !abs_path.exists() {
-                if old_row.is_some() {
+                if old_row.is_some() && deleted.insert(rel_path.clone()) {
                     surface_changed.insert(rel_path.clone());
-                    deleted.insert(rel_path.clone());
                     let started = Instant::now();
-                    let dependent_refs = ref_ids_depending_on(&tx, &self.project_root, &rel_path)?;
+                    let dependent_refs =
+                        ref_ids_depending_on(&conn, &self.project_root, &rel_path)?;
                     profile.dependency_selection += started.elapsed();
                     record_dependent_refs(
                         &mut selected_ref_ids,
                         &mut selected_refs_by_caller,
                         dependent_refs,
                     );
-                    let started = Instant::now();
-                    delete_file_rows(&tx, &rel_path)?;
-                    clear_backend_state_for_file(&tx, &self.project_root, &rel_path)?;
-                    profile.row_deletes += started.elapsed();
                 }
                 continue;
             }
@@ -3042,32 +3038,29 @@ impl CallGraphStore {
                         new_mtime,
                         new_size,
                     } => {
-                        update_file_fresh_metadata(
-                            &tx,
-                            &self.project_root,
-                            &rel_path,
-                            &row.freshness.content_hash,
-                            new_mtime,
-                            new_size,
-                        )?;
+                        fresh_metadata.insert(
+                            rel_path.clone(),
+                            FileFreshness {
+                                content_hash: row.freshness.content_hash,
+                                mtime: new_mtime,
+                                size: new_size,
+                            },
+                        );
                         continue;
                     }
                     FreshnessVerdict::Deleted => {
-                        surface_changed.insert(rel_path.clone());
-                        deleted.insert(rel_path.clone());
-                        let started = Instant::now();
-                        let dependent_refs =
-                            ref_ids_depending_on(&tx, &self.project_root, &rel_path)?;
-                        profile.dependency_selection += started.elapsed();
-                        record_dependent_refs(
-                            &mut selected_ref_ids,
-                            &mut selected_refs_by_caller,
-                            dependent_refs,
-                        );
-                        let started = Instant::now();
-                        delete_file_rows(&tx, &rel_path)?;
-                        clear_backend_state_for_file(&tx, &self.project_root, &rel_path)?;
-                        profile.row_deletes += started.elapsed();
+                        if deleted.insert(rel_path.clone()) {
+                            surface_changed.insert(rel_path.clone());
+                            let started = Instant::now();
+                            let dependent_refs =
+                                ref_ids_depending_on(&conn, &self.project_root, &rel_path)?;
+                            profile.dependency_selection += started.elapsed();
+                            record_dependent_refs(
+                                &mut selected_ref_ids,
+                                &mut selected_refs_by_caller,
+                                dependent_refs,
+                            );
+                        }
                         continue;
                     }
                     FreshnessVerdict::Stale => {}
@@ -3084,7 +3077,7 @@ impl CallGraphStore {
             if surface_is_changed {
                 surface_changed.insert(rel_path.clone());
                 let started = Instant::now();
-                let dependent_refs = ref_ids_depending_on(&tx, &self.project_root, &rel_path)?;
+                let dependent_refs = ref_ids_depending_on(&conn, &self.project_root, &rel_path)?;
                 profile.dependency_selection += started.elapsed();
                 record_dependent_refs(
                     &mut selected_ref_ids,
@@ -3119,6 +3112,24 @@ impl CallGraphStore {
             }
         }
 
+        let tx = conn.transaction()?;
+        for (rel_path, freshness) in fresh_metadata {
+            update_file_fresh_metadata(
+                &tx,
+                &self.project_root,
+                &rel_path,
+                &freshness.content_hash,
+                freshness.mtime,
+                freshness.size,
+            )?;
+        }
+        for rel_path in &deleted {
+            let started = Instant::now();
+            delete_file_rows(&tx, rel_path)?;
+            clear_backend_state_for_file(&tx, &self.project_root, rel_path)?;
+            profile.row_deletes += started.elapsed();
+        }
+
         let started = Instant::now();
         let index = ProjectIndex::from_db_and_callers(
             &tx,
@@ -3128,87 +3139,93 @@ impl CallGraphStore {
         )?;
         profile.index_load += started.elapsed();
 
-        for rel_path in &candidate_own_refresh {
-            let Some(extract) = changed_extracts.get(rel_path) else {
-                continue;
-            };
-            if !write_amplification_baseline_enabled()
-                && stored_extract_matches(&tx, rel_path, extract, &index)?
-            {
-                unchanged_extracts += 1;
-                update_file_fresh_metadata(
-                    &tx,
-                    &self.project_root,
-                    rel_path,
-                    &extract.freshness.content_hash,
-                    extract.freshness.mtime,
-                    extract.freshness.size,
-                )?;
-                continue;
-            }
-
-            own_refresh.insert(rel_path.clone());
-            let started = Instant::now();
-            delete_file_rows(&tx, rel_path)?;
-            profile.row_deletes += started.elapsed();
-            let started = Instant::now();
-            insert_file_extract(&tx, &self.project_root, extract)?;
-            profile.row_inserts += started.elapsed();
-        }
-
-        let dependency_callers = touched_callers
-            .iter()
-            .filter(|rel_path| {
-                !deleted.contains(*rel_path) && !candidate_own_refresh.contains(*rel_path)
-            })
-            .cloned()
-            .collect::<Vec<_>>();
-        for rel_path in dependency_callers {
-            let Some(extract) = caller_extracts.get(&rel_path) else {
-                continue;
-            };
-            if stored_node_ids_match_extract(&tx, &rel_path, extract)? {
-                continue;
-            }
-
-            own_refresh.insert(rel_path.clone());
-            let started = Instant::now();
-            delete_file_rows(&tx, &rel_path)?;
-            profile.row_deletes += started.elapsed();
-            let started = Instant::now();
-            insert_file_extract(&tx, &self.project_root, extract)?;
-            profile.row_inserts += started.elapsed();
-        }
-        let started = Instant::now();
-        for rel_path in &touched_callers {
-            if deleted.contains(rel_path) {
-                continue;
-            }
-            let Some(extract) = caller_extracts.get(rel_path) else {
-                continue;
-            };
-            if own_refresh.contains(rel_path) {
-                delete_refs_for_caller(&tx, rel_path)?;
-                for raw_ref in &extract.raw_refs {
-                    let resolved = resolve_ref(raw_ref.clone(), &index)?;
-                    insert_resolved_ref(&tx, &resolved)?;
+        let workspace_root = self.project_root.display().to_string();
+        {
+            let mut inserts = ColdBuildInsertStatements::new(&tx)?;
+            for rel_path in &candidate_own_refresh {
+                let Some(extract) = changed_extracts.get(rel_path) else {
+                    continue;
+                };
+                if !write_amplification_baseline_enabled()
+                    && stored_extract_matches(&tx, rel_path, extract, &index)?
+                {
+                    unchanged_extracts += 1;
+                    update_file_fresh_metadata(
+                        &tx,
+                        &self.project_root,
+                        rel_path,
+                        &extract.freshness.content_hash,
+                        extract.freshness.mtime,
+                        extract.freshness.size,
+                    )?;
+                    continue;
                 }
-                continue;
+
+                own_refresh.insert(rel_path.clone());
+                let started = Instant::now();
+                delete_file_rows(&tx, rel_path)?;
+                clear_backend_state_for_file(&tx, &self.project_root, rel_path)?;
+                profile.row_deletes += started.elapsed();
+                let started = Instant::now();
+                insert_file_extract_prepared(&mut inserts, &workspace_root, extract)?;
+                profile.row_inserts += started.elapsed();
             }
 
-            let selected_for_caller = selected_refs_by_caller
-                .get(rel_path)
+            let dependency_callers = touched_callers
+                .iter()
+                .filter(|rel_path| {
+                    !deleted.contains(*rel_path) && !candidate_own_refresh.contains(*rel_path)
+                })
                 .cloned()
-                .unwrap_or_default();
-            delete_ref_ids(&tx, &selected_for_caller)?;
-            for raw_ref in &extract.raw_refs {
-                if selected_for_caller.contains(&raw_ref.ref_id) {
-                    let resolved = resolve_ref(raw_ref.clone(), &index)?;
-                    insert_resolved_ref(&tx, &resolved)?;
+                .collect::<Vec<_>>();
+            for rel_path in dependency_callers {
+                let Some(extract) = caller_extracts.get(&rel_path) else {
+                    continue;
+                };
+                if stored_node_ids_match_extract(&tx, &rel_path, extract)? {
+                    continue;
+                }
+
+                own_refresh.insert(rel_path.clone());
+                let started = Instant::now();
+                delete_file_rows(&tx, &rel_path)?;
+                clear_backend_state_for_file(&tx, &self.project_root, &rel_path)?;
+                profile.row_deletes += started.elapsed();
+                let started = Instant::now();
+                insert_file_extract_prepared(&mut inserts, &workspace_root, extract)?;
+                profile.row_inserts += started.elapsed();
+            }
+            let started = Instant::now();
+            for rel_path in &touched_callers {
+                if deleted.contains(rel_path) {
+                    continue;
+                }
+                let Some(extract) = caller_extracts.get(rel_path) else {
+                    continue;
+                };
+                if own_refresh.contains(rel_path) {
+                    delete_refs_for_caller(&tx, rel_path)?;
+                    for raw_ref in &extract.raw_refs {
+                        let resolved = resolve_ref(raw_ref.clone(), &index)?;
+                        insert_resolved_ref_prepared(&mut inserts, &resolved)?;
+                    }
+                    continue;
+                }
+
+                let selected_for_caller = selected_refs_by_caller
+                    .get(rel_path)
+                    .cloned()
+                    .unwrap_or_default();
+                delete_ref_ids(&tx, &selected_for_caller)?;
+                for raw_ref in &extract.raw_refs {
+                    if selected_for_caller.contains(&raw_ref.ref_id) {
+                        let resolved = resolve_ref(raw_ref.clone(), &index)?;
+                        insert_resolved_ref_prepared(&mut inserts, &resolved)?;
+                    }
                 }
             }
+            profile.ref_resolution += started.elapsed();
         }
-        profile.ref_resolution += started.elapsed();
 
         let started = Instant::now();
         delete_method_dispatch_edges_for_callers(&tx, &own_refresh)?;
@@ -6079,6 +6096,7 @@ fn initialize_schema(conn: &Connection) -> Result<()> {
             provenance   TEXT NOT NULL
         );
         CREATE INDEX IF NOT EXISTS idx_dispatch_hints_method ON dispatch_hints(method_name);
+        CREATE INDEX IF NOT EXISTS idx_dispatch_hints_file ON dispatch_hints(file);
 
         CREATE TABLE IF NOT EXISTS type_ref_names (
             name TEXT PRIMARY KEY
@@ -6233,6 +6251,7 @@ fn drop_cold_build_secondary_indexes(tx: &Transaction<'_>) -> Result<()> {
          DROP INDEX IF EXISTS idx_edges_target_file_symbol;
          DROP INDEX IF EXISTS idx_edges_ref_id;
          DROP INDEX IF EXISTS idx_dispatch_hints_method;
+         DROP INDEX IF EXISTS idx_dispatch_hints_file;
          DROP INDEX IF EXISTS idx_backend_file_state_file;",
     )?;
     Ok(())
@@ -6254,6 +6273,7 @@ fn create_cold_build_secondary_indexes(tx: &Transaction<'_>) -> Result<()> {
          CREATE INDEX IF NOT EXISTS idx_edges_target_file_symbol ON edges(target_file, target_symbol, kind);
          CREATE INDEX IF NOT EXISTS idx_edges_ref_id ON edges(ref_id, kind);
          CREATE INDEX IF NOT EXISTS idx_dispatch_hints_method ON dispatch_hints(method_name);
+         CREATE INDEX IF NOT EXISTS idx_dispatch_hints_file ON dispatch_hints(file);
          CREATE INDEX IF NOT EXISTS idx_backend_file_state_file ON backend_file_state(file_path, backend);",
     )?;
     Ok(())
@@ -8896,6 +8916,7 @@ fn insert_resolved_ref_prepared(
     Ok(())
 }
 
+#[cfg(test)]
 fn insert_file_extract(
     tx: &Transaction<'_>,
     project_root: &Path,
@@ -8976,6 +8997,7 @@ fn insert_file_extract(
     Ok(())
 }
 
+#[cfg(test)]
 fn insert_file_dependencies(
     tx: &Transaction<'_>,
     file_path: &str,
@@ -8998,6 +9020,7 @@ fn ref_provenance(raw: &RawRef) -> &'static str {
     }
 }
 
+#[cfg(test)]
 fn insert_resolved_ref(tx: &Transaction<'_>, resolved: &ResolvedRef) -> Result<()> {
     let raw = &resolved.raw;
     debug_assert!(resolved.dependencies.is_superset(&raw.dependencies));
@@ -11065,8 +11088,8 @@ fn clear_backend_state_for_file(
     Ok(())
 }
 
-fn load_file_row(tx: &Transaction<'_>, rel_path: &str) -> Result<Option<FileRow>> {
-    tx.query_row(
+fn load_file_row(conn: &Connection, rel_path: &str) -> Result<Option<FileRow>> {
+    conn.query_row(
         "SELECT surface_fingerprint, content_hash, mtime_ns, size FROM files WHERE path = ?1",
         params![rel_path],
         |row| {
@@ -11415,11 +11438,11 @@ struct DependentRefSelection {
 }
 
 fn ref_ids_depending_on(
-    tx: &Transaction<'_>,
+    conn: &Connection,
     project_root: &Path,
     rel_path: &str,
 ) -> Result<Vec<DependentRefSelection>> {
-    let mut stmt = tx.prepare(
+    let mut stmt = conn.prepare(
         "SELECT DISTINCT r.ref_id, r.kind, r.caller_file, r.module_path, r.target_file
          FROM refs r
          WHERE r.caller_file IN (
@@ -11512,9 +11535,11 @@ fn delete_refs_for_caller(tx: &Transaction<'_>, rel_path: &str) -> Result<()> {
 }
 
 fn delete_ref_ids(tx: &Transaction<'_>, ref_ids: &BTreeSet<String>) -> Result<()> {
+    let mut delete_edges = tx.prepare("DELETE FROM edges WHERE ref_id = ?1")?;
+    let mut delete_refs = tx.prepare("DELETE FROM refs WHERE ref_id = ?1")?;
     for ref_id in ref_ids {
-        tx.execute("DELETE FROM edges WHERE ref_id = ?1", params![ref_id])?;
-        tx.execute("DELETE FROM refs WHERE ref_id = ?1", params![ref_id])?;
+        delete_edges.execute(params![ref_id])?;
+        delete_refs.execute(params![ref_id])?;
     }
     Ok(())
 }


### PR DESCRIPTION
Four of the five findings from #214. One file, no new dependencies.

**Finding 1 from that issue — the full-graph re-read via `ProjectIndex::from_db_and_callers` — is deliberately NOT here.** It's architectural and you may well have a design in mind; mixing it in would make this unmergeable as a unit. This is the mechanical subset only.

## What changed

**Write transaction no longer spans file I/O and parsing.** `build_file_extract` (read + tree-sitter parse) now runs before the transaction opens, collecting into `changed_extracts` / `caller_extracts`; the transaction then does only DB work. Previously the write lock was held across every read and parse in the batch.

**Incremental inserts reuse the cold-build prepared statements.** `ColdBuildInsertStatements` is constructed once per refresh transaction instead of the path issuing per-row `tx.execute`. Statement preparations per refresh drop from `F+N+D+H+B+R+E` to 7.

**`dispatch_hints` gets an index on `file`.** Two queries filter on that column; the only index was on `method_name`. Added at both schema sites — `initialize_schema` (fresh/open-time `CREATE IF NOT EXISTS`) and `create_cold_build_secondary_indexes` (cold-build recreation), plus the matching drop list, so a freshly-created DB and a rebuilt one don't diverge.

```
before:  SCAN dispatch_hints                                        (SELECT and DELETE)
after:   SEARCH dispatch_hints USING INDEX idx_dispatch_hints_file (file=?)
```

**`delete_ref_ids` reuses two prepared statements** instead of re-preparing two per id: 2R → 2 per call.

No public signature changed. `aft_callgraph` impact: `load_file_row` has one refresh caller, `ref_ids_depending_on` three plus a test.

## One behaviour change, corrected from the original description

I originally wrote "no behaviour change." That was wrong, and you caught it on review — thanks.

`clear_backend_state_for_file` is now called on the refresh paths (2 call sites removed from the old inline path, 3 added in the restructured one; net +1). It is **required** by the mechanics switch: the prepared cold-build inserts write `backend_file_state` rows with a plain `INSERT`, so the row must be cleared first. It is also a correctness improvement in its own right — backend rows now refresh with the file instead of going stale.

Everything else is mechanics-only: same rows, same results, same ordering.

## Verification

Rebased onto `10d6d20c` (picks up the `gh_shim` XDG fixture fix).

```
4388 tests run: 4386 passed, 2 failed, 28 skipped
```

Identical failure names to unmodified base in the same checkout (`post_edit_wait_does_not_start_a_server_on_a_cold_root`, `native_sandbox_pty_denies_outside_write_and_renders_screen` — both environmental here). `cargo fmt --check` and `bun run lint` clean.

**Worth flagging for your CI's sake:** this was first gated in a linked worktree, where **19 `callgraph_test::*` tests fail as environment artifacts** — a secondary checkout is a borrow-only artifact root, so the persisted callgraph store is unavailable and those tests fail identically on base. That means the tests covering the code this PR changes do not run in a worktree at all. I re-ran them in the artifact-owner checkout to get a real signal:

```
callgraph tests, owner checkout, with this change:   253 passed, 0 failed
same tests in a linked worktree:                      19 FAIL (borrow-only, base and head alike)
```

If your CI runs the suite in a linked worktree anywhere, this class of change is currently ungated there.

## Performance evidence

Mechanical rather than benchmarked — there's no callgraph refresh benchmark in-tree and building one is a bigger piece of work than the fix:

| | before | after |
|---|---|---|
| insert preparations / refresh txn | `F+N+D+H+B+R+E` | 7 |
| `delete_ref_ids` preparations | 2R | 2 |
| `dispatch_hints` file-filtered queries | full scan | index seek |
| work inside the write txn | read + parse + DB | DB only |

Happy to split this into four commits if you'd rather review them separately, or to drop any individual piece.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR reduces incremental callgraph refresh transaction duration and statement-preparation overhead while adding the missing file index for dispatch hints.
- Parses changed files and dependent callers before opening the write transaction.
- Reuses cold-build prepared statements for incremental inserts.
- Clears and refreshes backend file state on rewritten and deleted files.
- Reuses prepared deletion statements and indexes `dispatch_hints.file`.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/aft/src/callgraph_store/mod.rs | Moves parsing outside the write transaction, reuses prepared statements, refreshes backend state, and adds the dispatch-hint file index without an eligible follow-up defect being established. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  F[Changed files] --> R[Read freshness and dependencies]
  R --> P[Parse changed files and callers]
  P --> T[Open SQLite transaction]
  T --> D[Delete superseded rows and backend state]
  D --> I[Insert extracts through prepared statements]
  I --> E[Resolve references and dispatch edges]
  E --> V[Bump projection revision]
  V --> C[Commit under lifecycle fence]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["perf(callgraph): match the cold-build pa..."](https://github.com/cortexkit/aft/commit/85f6728ade126883850110329cf0d487201678af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54830907)</sub>

**Context used:**

- Knowledge Base — [AFT Rust code intelligence](https://app.greptile.com/cortexkit/-/custom-context/knowledge-base/cortexkit/aft/-/docs/aft-code-intelligence.md)

<!-- /greptile_comment -->