### PR TITLE
test: build astro tsdk expectation with component joins (fixes deterministic Windows shard 1/3 failure)

### DIFF
--- a/crates/aft/tests/integration/lsp_manager_test.rs
+++ b/crates/aft/tests/integration/lsp_manager_test.rs
@@ -447,10 +447,14 @@ fn test_custom_server_env_and_initialization_options_reach_spawned_server() {
 fn astro_uses_the_nearest_project_typescript_sdk() {
     let temp_dir = tempdir().unwrap();
     let root = temp_dir.path().join("workspace");
-    let member = root.join("apps/site");
-    let page = member.join("src/page.astro");
-    let root_tsdk = root.join("node_modules/typescript/lib");
-    let member_tsdk = member.join("node_modules/typescript/lib");
+    let member = root.join("apps").join("site");
+    let page = member.join("src").join("page.astro");
+    // Build the expected tsdk exactly as find_project_typescript_sdk does
+    // (component-wise joins). A single join("node_modules/typescript/lib")
+    // keeps its embedded forward slashes on Windows, so the comparison would
+    // hold a mixed-separator path the production walk never produces.
+    let root_tsdk = root.join("node_modules").join("typescript").join("lib");
+    let member_tsdk = member.join("node_modules").join("typescript").join("lib");
     fs::create_dir_all(page.parent().unwrap()).unwrap();
     fs::create_dir_all(&root_tsdk).unwrap();
     fs::create_dir_all(&member_tsdk).unwrap();


### PR DESCRIPTION
`Unit / Cargo integration shard 1/3 (Windows)` has been red on `main` for a while. I called it a rotating flake on #246 — **that was wrong**, and the log on my rebased run shows why.

## It's deterministic, not timing

```
thread 'lsp_manager_test::astro_uses_the_nearest_project_typescript_sdk' panicked at
crates\aft\tests\integration\lsp_manager_test.rs:471:5:
assertion `left == right` failed
  left: String("C:\\...\\workspace\\apps/site\\node_modules\\typescript\\lib")
 right:        "C:\\...\\workspace\\apps/site\\node_modules/typescript/lib"
```

`node_modules\typescript\lib` vs `node_modules/typescript/lib`. Not a timeout, not ordering — a path-separator mismatch that fails the same way every run.

Production walks component-wise (`lsp/manager.rs:2636-2639`):

```rust
let lib = directory.join("node_modules").join("typescript").join("lib");
```

The test built its expectation in one hop (`lsp_manager_test.rs:453`):

```rust
let member_tsdk = member.join("node_modules/typescript/lib");
```

`Path::join` doesn't normalize embedded separators — it appends the string as given. On Windows that leaves the expectation holding a mixed-separator path that the production walk cannot produce. On unix both spellings coincide, so it passes everywhere except the platform it breaks on.

This PR builds the expectation the way production builds the value. Same for the `apps/site` and `src/page.astro` joins in that test, so the whole test uses native separators consistently.

## Why it looked like a flake

Two different failures live in that job and `fail-fast` surfaces whichever trips first:

```
main @ 1d2da675   lsp_manager_test::astro_uses_the_nearest_project_typescript_sdk   ← this bug
PR #246 @ bfaa0d93 configure_test::configure_does_not_warn_for_file_discovered_...   ← "timed out after 10s waiting for aft process exit"
PR #246 @ 967bedfa lsp_manager_test::astro_uses_the_nearest_project_typescript_sdk   ← this bug again
```

Rotating test names read as flake; the cancel point moving (317/493 vs 123/493) is timing, but one of the two underlying failures isn't. The process-exit timeout is still open and unrelated to this.

## Verification

Linux, on this branch: 5 passed, 0 failed (`astro_uses_the_nearest_project_typescript_sdk`, `astro_user_initialization_options_override_the_computed_tsdk`, `astro_without_project_typescript_is_unavailable_without_spawning`). `cargo fmt --check` clean.

**The red control is the CI log above, not a synthetic one** — I have no Windows host, so I can't run the before/after locally. The failure reproduces on two different shas, and the fix makes both sides of the comparison use the same construction, so they're identical by construction on every platform. Your Windows runner is the actual green control.

## Scope note

The same pattern — `join("a/b/c")` with embedded separators — appears **425 times across 49 files** in `crates/aft/tests/integration/`. The vast majority are harmless: paths used for `create_dir_all` or `fs::write`, where Windows accepts forward slashes fine. Only ones whose value is compared against a production-built path can break, and `fail-fast` means any others are hidden behind the first failure.

I've deliberately fixed only the one that's demonstrably red rather than sweeping 425 call sites blind. Flagging the class in case you want a broader pass — a lint or a test helper that builds paths component-wise would prevent the next one.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789763666&installation_model_id=22398&pr_number=248&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F248&signature=9255d9f0d5433233294ca490a6bed8d10a5dc727b96040dba2516503c4384333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a deterministic Windows failure in `astro_uses_the_nearest_project_typescript_sdk` by building the expected TypeScript SDK path with component-wise joins. The test previously used a single join with embedded slashes, producing mixed separators on Windows and a guaranteed mismatch with production.

- Builds expected paths with `join("node_modules").join("typescript").join("lib")` to match production `find_project_typescript_sdk`; also updates `apps/site` and `src/page.astro` joins for consistency.
- Test-only change; no runtime behavior change. Should stabilize `Unit / Cargo integration shard 1/3 (Windows)`. The separate process-exit timeout remains unrelated.

<sup>Written for commit f6e2afcec82ff489efd8ea9bc8a3308e30492cf8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a deterministic Windows-only failure in the Astro TypeScript SDK integration test.
- Builds fixture and expected paths with component-wise joins so they use platform-native separators.
- Aligns the expected SDK path construction with the production lookup implementation.
- Leaves production behavior unchanged.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable issues identified.

The changed test constructs and serializes paths consistently with the production SDK lookup, fixing the Windows separator mismatch without changing fixture semantics on other platforms.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/aft/tests/integration/lsp_manager_test.rs | Replaces embedded slash-separated test paths with component-wise joins, correctly matching production path construction across platforms. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test: build astro tsdk expectation with ..."](https://github.com/cortexkit/aft/commit/f6e2afcec82ff489efd8ea9bc8a3308e30492cf8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54920969)</sub>

<!-- /greptile_comment -->