### PR TITLE
fix: resolve Python LSPs from nested virtualenvs

### DIFF
--- a/.github/workflows/_unit-suite.yml
+++ b/.github/workflows/_unit-suite.yml
@@ -245,6 +245,13 @@ jobs:
 
       - uses: taiki-e/install-action@nextest
 
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+
+      - name: Install Pyright integration dependency
+        run: npm install --global pyright@1.1.411
+
       - uses: actions/download-artifact@v4
         with:
           name: linux-nextest-archive

--- a/assets/aft.schema.json
+++ b/assets/aft.schema.json
@@ -364,7 +364,7 @@
         "lsp_ty": {
           "type": "boolean",
           "default": false,
-          "description": "Use experimental Python `ty` type checker. Falls back to pyright if unavailable."
+          "description": "Run the experimental Python `ty` type checker alongside Pyright. Use lsp.python = 'ty' to select ty exclusively."
         }
       },
       "additionalProperties": false,

--- a/assets/aft.schema.json
+++ b/assets/aft.schema.json
@@ -446,8 +446,8 @@
             "ty",
             "auto"
           ],
-          "default": "pyright",
-          "description": "Which Python LSP to use. 'ty' is experimental and falls back to pyright if unavailable."
+          "default": "auto",
+          "description": "Which Python LSP to use. 'auto' stays on Pyright while ty is experimental; select 'ty' explicitly to opt in without fallback."
         },
         "diagnostics_on_edit": {
           "type": "boolean",

--- a/crates/aft/src/commands/configure.rs
+++ b/crates/aft/src/commands/configure.rs
@@ -22,7 +22,9 @@ use crate::context::{
 };
 use crate::harness::Harness;
 use crate::log_ctx;
-use crate::lsp::registry::{resolve_lsp_binary, servers_for_file, ServerKind};
+use crate::lsp::registry::{
+    resolve_lsp_binary, resolve_server_binary, servers_for_file, ServerKind,
+};
 use crate::parser::{detect_language, LangId, SharedSymbolCache};
 use crate::protocol::{RawRequest, Response};
 use crate::search_index::{
@@ -948,6 +950,33 @@ fn is_custom_server(kind: &ServerKind) -> bool {
     matches!(kind, ServerKind::Custom(_))
 }
 
+fn configured_lsp_binary_resolves(
+    configured: &crate::config::UserServerDef,
+    files: &[PathBuf],
+    config: &crate::config::Config,
+) -> bool {
+    let project_root = config.project_root.as_deref();
+    for file in files {
+        if let Some(server) = servers_for_file(file, config).into_iter().find(|server| {
+            server.kind.id_str() == configured.id && server.binary == configured.binary
+        }) {
+            let workspace_root = if matches!(server.kind, ServerKind::Python | ServerKind::Ty) {
+                server.workspace_root_for_file_with_project_root(file, project_root)
+            } else {
+                project_root.map(Path::to_path_buf)
+            };
+            return resolve_server_binary(&server, workspace_root.as_deref(), config).is_some();
+        }
+    }
+
+    resolve_lsp_binary(
+        &configured.binary,
+        project_root,
+        &config.lsp_paths_extra,
+    )
+    .is_some()
+}
+
 fn lsp_missing_hint(binary: &str) -> String {
     crate::format::install_hint(binary)
 }
@@ -1321,20 +1350,31 @@ fn detect_missing_tools_for_languages(
 
 fn detect_missing_lsp_binaries(files: &[PathBuf], config: &crate::config::Config) -> Vec<Value> {
     let mut warnings = Vec::new();
-    let mut seen = HashSet::new();
-    let mut resolved_binaries = HashSet::new();
-    let mut missing_binaries = HashSet::new();
+    let mut seen_resolutions = HashSet::new();
+    let mut file_driven_servers = HashSet::new();
+    let mut seen_explicit_servers = HashSet::new();
+    let mut warned_binaries = HashSet::new();
 
     let project_root = config.project_root.as_deref();
-    let extra_paths = &config.lsp_paths_extra;
 
     for file in files {
         for server in servers_for_file(&file, config) {
+            let workspace_root = if matches!(server.kind, ServerKind::Python | ServerKind::Ty) {
+                server.workspace_root_for_file_with_project_root(file, project_root)
+            } else {
+                project_root.map(Path::to_path_buf)
+            };
+            let identity = (server.kind.id_str().to_string(), server.binary.clone());
             if is_custom_server(&server.kind)
-                || !seen.insert((server.kind.id_str().to_string(), server.binary.clone()))
+                || !seen_resolutions.insert((
+                    server.kind.id_str().to_string(),
+                    server.binary.clone(),
+                    workspace_root.clone(),
+                ))
             {
                 continue;
             }
+            file_driven_servers.insert(identity);
 
             if !config.lsp_auto_install_binaries.contains(&server.binary) {
                 continue;
@@ -1344,15 +1384,9 @@ fn detect_missing_lsp_binaries(files: &[PathBuf], config: &crate::config::Config
                 continue;
             }
 
-            if !resolved_binaries.contains(&server.binary) {
-                if resolve_lsp_binary(&server.binary, project_root, extra_paths).is_some() {
-                    resolved_binaries.insert(server.binary.clone());
-                } else {
-                    missing_binaries.insert(server.binary.clone());
-                }
-            }
-
-            if missing_binaries.contains(&server.binary) {
+            if resolve_server_binary(&server, workspace_root.as_deref(), config).is_none()
+                && warned_binaries.insert(server.binary.clone())
+            {
                 warnings.push(json!({
                     "kind": "lsp_binary_missing",
                     "server": server.binary,
@@ -1372,7 +1406,11 @@ fn detect_missing_lsp_binaries(files: &[PathBuf], config: &crate::config::Config
             continue;
         }
 
-        if server.disabled || !seen.insert((server.id.clone(), server.binary.clone())) {
+        let identity = (server.id.clone(), server.binary.clone());
+        if server.disabled
+            || file_driven_servers.contains(&identity)
+            || !seen_explicit_servers.insert(identity)
+        {
             continue;
         }
 
@@ -1380,15 +1418,9 @@ fn detect_missing_lsp_binaries(files: &[PathBuf], config: &crate::config::Config
             continue;
         }
 
-        if !resolved_binaries.contains(&server.binary) {
-            if resolve_lsp_binary(&server.binary, project_root, extra_paths).is_some() {
-                resolved_binaries.insert(server.binary.clone());
-            } else {
-                missing_binaries.insert(server.binary.clone());
-            }
-        }
-
-        if missing_binaries.contains(&server.binary) {
+        if !configured_lsp_binary_resolves(server, files, config)
+            && warned_binaries.insert(server.binary.clone())
+        {
             warnings.push(json!({
                 "kind": "lsp_binary_missing",
                 "server": server.id,

--- a/crates/aft/src/commands/configure.rs
+++ b/crates/aft/src/commands/configure.rs
@@ -969,12 +969,7 @@ fn configured_lsp_binary_resolves(
         }
     }
 
-    resolve_lsp_binary(
-        &configured.binary,
-        project_root,
-        &config.lsp_paths_extra,
-    )
-    .is_some()
+    resolve_lsp_binary(&configured.binary, project_root, &config.lsp_paths_extra).is_some()
 }
 
 fn lsp_missing_hint(binary: &str) -> String {

--- a/crates/aft/src/commands/lsp_inspect.rs
+++ b/crates/aft/src/commands/lsp_inspect.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 use crate::context::AppContext;
 use crate::lsp::diagnostics::StoredDiagnostic;
 use crate::lsp::manager::{PullFileOutcome, ServerAttempt, ServerAttemptResult};
-use crate::lsp::registry::{resolve_server_binary, servers_for_file, ServerDef, ServerKind};
+use crate::lsp::registry::{resolve_server_binary, servers_for_file, ServerDef};
 use crate::protocol::{RawRequest, Response};
 
 #[derive(Debug, Deserialize)]
@@ -45,6 +45,17 @@ pub fn handle_lsp_inspect(req: &RawRequest, ctx: &AppContext) -> Response {
     };
 
     let mut pull_results_json = Vec::new();
+    let mut diagnostics_gaps = outcomes
+        .attempts
+        .iter()
+        .filter_map(|attempt| match &attempt.result {
+            ServerAttemptResult::Ok { .. } => None,
+            result => Some(serde_json::json!({
+                "server_id": attempt.server_id,
+                "reason": spawn_status(result),
+            })),
+        })
+        .collect::<Vec<_>>();
     if !outcomes.successful.is_empty() {
         let pull_results = {
             let mut lsp = ctx.lsp();
@@ -59,6 +70,15 @@ pub fn handle_lsp_inspect(req: &RawRequest, ctx: &AppContext) -> Response {
         pull_results_json = pull_results
             .iter()
             .map(|result| {
+                if !matches!(
+                    &result.outcome,
+                    PullFileOutcome::Full { .. } | PullFileOutcome::Unchanged
+                ) {
+                    diagnostics_gaps.push(serde_json::json!({
+                        "server_id": result.server_key.kind.id_str(),
+                        "reason": pull_status(&result.outcome),
+                    }));
+                }
                 serde_json::json!({
                     "server_id": result.server_key.kind.id_str(),
                     "workspace_root": result.server_key.root.display().to_string(),
@@ -99,6 +119,8 @@ pub fn handle_lsp_inspect(req: &RawRequest, ctx: &AppContext) -> Response {
                 .collect::<Vec<_>>(),
             "matching_servers": matching_servers,
             "pull_results": pull_results_json,
+            "diagnostics_complete": diagnostics_gaps.is_empty(),
+            "diagnostics_gaps": diagnostics_gaps,
             "diagnostics_count": diagnostics.len(),
             "diagnostics": diagnostics_to_json(&diagnostics),
         }),
@@ -118,13 +140,12 @@ fn inspect_server(
         }
     };
     let binary_path = resolve_server_binary(def, workspace_root.as_deref(), config);
-    let resolution_root = if matches!(def.kind, ServerKind::Python | ServerKind::Ty) {
-        workspace_root.as_deref()
-    } else {
-        config.project_root.as_deref()
-    };
-    let binary_source =
-        classify_binary_source(&binary_path, resolution_root, &config.lsp_paths_extra);
+    let binary_source = classify_binary_source(
+        &binary_path,
+        workspace_root.as_deref(),
+        config.project_root.as_deref(),
+        &config.lsp_paths_extra,
+    );
     let spawn_status = attempt
         .map(|attempt| spawn_status(&attempt.result))
         .unwrap_or_else(|| "not_attempted".to_string());
@@ -146,6 +167,7 @@ fn inspect_server(
 
 fn classify_binary_source(
     binary_path: &Option<PathBuf>,
+    workspace_root: Option<&Path>,
     project_root: Option<&Path>,
     extra_paths: &[PathBuf],
 ) -> &'static str {
@@ -153,10 +175,12 @@ fn classify_binary_source(
         return "not_found";
     };
 
-    if let Some(root) = project_root {
+    if let Some(root) = workspace_root {
         if path.starts_with(root.join(".venv")) || path.starts_with(root.join("venv")) {
             return "project_virtualenv";
         }
+    }
+    if let Some(root) = project_root {
         if path.starts_with(root.join("node_modules").join(".bin")) {
             return "project_node_modules";
         }

--- a/crates/aft/src/commands/lsp_inspect.rs
+++ b/crates/aft/src/commands/lsp_inspect.rs
@@ -111,20 +111,22 @@ fn inspect_server(
     canonical: &Path,
     config: &crate::config::Config,
 ) -> serde_json::Value {
+    let workspace_root = match attempt.map(|attempt| &attempt.result) {
+        Some(ServerAttemptResult::Ok { server_key }) => Some(server_key.root.clone()),
+        _ => {
+            def.workspace_root_for_file_with_project_root(canonical, config.project_root.as_deref())
+        }
+    };
     let binary_path = resolve_lsp_binary(
         &def.binary,
-        config.project_root.as_deref(),
+        workspace_root.as_deref(),
         &config.lsp_paths_extra,
     );
     let binary_source = classify_binary_source(
         &binary_path,
-        config.project_root.as_deref(),
+        workspace_root.as_deref(),
         &config.lsp_paths_extra,
     );
-    let workspace_root = match attempt.map(|attempt| &attempt.result) {
-        Some(ServerAttemptResult::Ok { server_key }) => Some(server_key.root.clone()),
-        _ => def.workspace_root_for_file(canonical),
-    };
     let spawn_status = attempt
         .map(|attempt| spawn_status(&attempt.result))
         .unwrap_or_else(|| "not_attempted".to_string());
@@ -154,6 +156,9 @@ fn classify_binary_source(
     };
 
     if let Some(root) = project_root {
+        if path.starts_with(root.join(".venv")) || path.starts_with(root.join("venv")) {
+            return "project_virtualenv";
+        }
         if path.starts_with(root.join("node_modules").join(".bin")) {
             return "project_node_modules";
         }

--- a/crates/aft/src/commands/lsp_inspect.rs
+++ b/crates/aft/src/commands/lsp_inspect.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 use crate::context::AppContext;
 use crate::lsp::diagnostics::StoredDiagnostic;
 use crate::lsp::manager::{PullFileOutcome, ServerAttempt, ServerAttemptResult};
-use crate::lsp::registry::{resolve_lsp_binary, servers_for_file, ServerDef};
+use crate::lsp::registry::{resolve_server_binary, servers_for_file, ServerDef, ServerKind};
 use crate::protocol::{RawRequest, Response};
 
 #[derive(Debug, Deserialize)]
@@ -117,16 +117,14 @@ fn inspect_server(
             def.workspace_root_for_file_with_project_root(canonical, config.project_root.as_deref())
         }
     };
-    let binary_path = resolve_lsp_binary(
-        &def.binary,
-        workspace_root.as_deref(),
-        &config.lsp_paths_extra,
-    );
-    let binary_source = classify_binary_source(
-        &binary_path,
-        workspace_root.as_deref(),
-        &config.lsp_paths_extra,
-    );
+    let binary_path = resolve_server_binary(def, workspace_root.as_deref(), config);
+    let resolution_root = if matches!(def.kind, ServerKind::Python | ServerKind::Ty) {
+        workspace_root.as_deref()
+    } else {
+        config.project_root.as_deref()
+    };
+    let binary_source =
+        classify_binary_source(&binary_path, resolution_root, &config.lsp_paths_extra);
     let spawn_status = attempt
         .map(|attempt| spawn_status(&attempt.result))
         .unwrap_or_else(|| "not_attempted".to_string());

--- a/crates/aft/src/commands/lsp_inspect.rs
+++ b/crates/aft/src/commands/lsp_inspect.rs
@@ -185,6 +185,9 @@ fn classify_binary_source(
         if path.starts_with(root.join(".venv")) || path.starts_with(root.join("venv")) {
             return "project_virtualenv";
         }
+        if path.starts_with(root.join("node_modules").join(".bin")) {
+            return "project_node_modules";
+        }
     }
     if let Some(root) = project_root {
         if path.starts_with(root.join("node_modules").join(".bin")) {

--- a/crates/aft/src/commands/lsp_inspect.rs
+++ b/crates/aft/src/commands/lsp_inspect.rs
@@ -63,6 +63,12 @@ pub fn handle_lsp_inspect(req: &RawRequest, ctx: &AppContext) -> Response {
                 Ok(results) => results,
                 Err(err) => {
                     crate::slog_warn!("[lsp_inspect] pull_file_diagnostics failed: {err}");
+                    let server_ids = outcomes
+                        .successful
+                        .iter()
+                        .map(|server_key| server_key.kind.id_str().to_string())
+                        .collect::<Vec<_>>();
+                    diagnostics_gaps.extend(pull_failure_gaps(&server_ids, &err.to_string()));
                     Vec::new()
                 }
             }
@@ -212,6 +218,18 @@ fn pull_status(outcome: &PullFileOutcome) -> String {
     }
 }
 
+fn pull_failure_gaps(server_ids: &[String], reason: &str) -> Vec<serde_json::Value> {
+    server_ids
+        .iter()
+        .map(|server_id| {
+            serde_json::json!({
+                "server_id": server_id,
+                "reason": format!("pull_failed: {reason}"),
+            })
+        })
+        .collect()
+}
+
 fn collect_file_diagnostics(ctx: &AppContext, canonical: &Path) -> Vec<StoredDiagnostic> {
     let lsp = ctx.lsp();
     lsp.get_diagnostics_for_file(canonical)
@@ -258,4 +276,16 @@ fn sorted_disabled_lsp(disabled: &std::collections::HashSet<String>) -> Vec<Stri
 
 fn normalize_query_path(path: &Path) -> PathBuf {
     std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn top_level_pull_failure_produces_incomplete_gaps() {
+        let gaps = super::pull_failure_gaps(&["python".to_string()], "didOpen failed");
+
+        assert_eq!(gaps.len(), 1);
+        assert_eq!(gaps[0]["server_id"], "python");
+        assert_eq!(gaps[0]["reason"], "pull_failed: didOpen failed");
+    }
 }

--- a/crates/aft/src/config.rs
+++ b/crates/aft/src/config.rs
@@ -297,8 +297,8 @@ pub struct Config {
     /// The plugin populates these from its own auto-install cache (e.g.
     /// `~/.cache/aft/lsp-packages/<pkg>/node_modules/.bin/`) so a binary AFT
     /// installed itself is discoverable without needing it on PATH.
-    /// Resolution order: `<project_root>/node_modules/.bin/<bin>` →
-    /// `lsp_paths_extra/<bin>` (in order) → PATH via `which`.
+    /// Resolution order: workspace `.venv`/`venv` →
+    /// workspace `node_modules/.bin` → `lsp_paths_extra` → PATH.
     pub lsp_paths_extra: Vec<PathBuf>,
     /// Binary names the hosting plugin knows how to auto-install.
     ///

--- a/crates/aft/src/config.rs
+++ b/crates/aft/src/config.rs
@@ -297,8 +297,9 @@ pub struct Config {
     /// The plugin populates these from its own auto-install cache (e.g.
     /// `~/.cache/aft/lsp-packages/<pkg>/node_modules/.bin/`) so a binary AFT
     /// installed itself is discoverable without needing it on PATH.
-    /// Resolution order: workspace `.venv`/`venv` →
-    /// workspace `node_modules/.bin` → `lsp_paths_extra` → PATH.
+    /// Resolution order: `<project_root>/node_modules/.bin/<bin>` →
+    /// `lsp_paths_extra/<bin>` (in order) → PATH via `which`. Python-family
+    /// servers additionally probe the selected workspace's `.venv`/`venv` first.
     pub lsp_paths_extra: Vec<PathBuf>,
     /// Binary names the hosting plugin knows how to auto-install.
     ///

--- a/crates/aft/src/lsp/client.rs
+++ b/crates/aft/src/lsp/client.rs
@@ -299,14 +299,11 @@ impl LspClient {
                         // - workspace/configuration expects Vec<Value> (one per item)
                         // - Everything else gets null (safe default for registration/progress)
                         let response_value = if method == "workspace/configuration" {
-                            // Return an array of null configs — one per requested item.
-                            // Servers fall back to filesystem config (tsconfig, pyrightconfig, etc.)
-                            let item_count = params
-                                .as_ref()
-                                .and_then(|p| p.get("items"))
-                                .and_then(|items| items.as_array())
-                                .map_or(1, |arr| arr.len());
-                            serde_json::Value::Array(vec![serde_json::Value::Null; item_count])
+                            workspace_configuration_response(
+                                &reader_kind,
+                                &reader_root,
+                                params.as_ref(),
+                            )
                         } else {
                             serde_json::Value::Null
                         };
@@ -878,6 +875,50 @@ fn record_watched_file_registration(
     }
 }
 
+fn workspace_configuration_response(
+    kind: &ServerKind,
+    root: &Path,
+    params: Option<&Value>,
+) -> Value {
+    let items = params
+        .and_then(|params| params.get("items"))
+        .and_then(Value::as_array);
+    let python_path = (kind == &ServerKind::Python)
+        .then(|| project_python_path(root))
+        .flatten();
+
+    Value::Array(match items {
+        Some(items) => items
+            .iter()
+            .map(|item| {
+                if item.get("section").and_then(Value::as_str) == Some("python") {
+                    if let Some(path) = &python_path {
+                        return json!({ "pythonPath": path });
+                    }
+                }
+                Value::Null
+            })
+            .collect(),
+        None => vec![Value::Null],
+    })
+}
+
+fn project_python_path(root: &Path) -> Option<PathBuf> {
+    [root.join(".venv"), root.join("venv")]
+        .into_iter()
+        .find_map(|virtualenv| {
+            if cfg!(windows) {
+                let candidate = virtualenv.join("Scripts").join("python.exe");
+                return candidate.is_file().then_some(candidate);
+            }
+
+            ["python", "python3"]
+                .into_iter()
+                .map(|binary| virtualenv.join("bin").join(binary))
+                .find(|candidate| candidate.is_file())
+        })
+}
+
 /// Parse `ServerDiagnosticCapabilities` from a re-serialized
 /// `ServerCapabilities` JSON value.
 ///
@@ -1005,5 +1046,47 @@ mod tests {
         assert!(caps.refresh_support);
         // No diagnosticProvider → pull still false
         assert!(!caps.pull_diagnostics);
+    }
+
+    #[test]
+    fn pyright_configuration_uses_workspace_virtualenv_interpreter() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let python = if cfg!(windows) {
+            root.join(".venv").join("Scripts").join("python.exe")
+        } else {
+            root.join(".venv").join("bin").join("python")
+        };
+        std::fs::create_dir_all(python.parent().unwrap()).unwrap();
+        std::fs::write(&python, []).unwrap();
+        let params = json!({
+            "items": [
+                { "section": "python" },
+                { "section": "pyright" }
+            ]
+        });
+
+        let response = workspace_configuration_response(&ServerKind::Python, root, Some(&params));
+
+        assert_eq!(response[0]["pythonPath"], python.display().to_string());
+        assert!(response[1].is_null());
+    }
+
+    #[test]
+    fn ty_configuration_does_not_receive_pyright_interpreter_settings() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let python = if cfg!(windows) {
+            root.join(".venv").join("Scripts").join("python.exe")
+        } else {
+            root.join(".venv").join("bin").join("python")
+        };
+        std::fs::create_dir_all(python.parent().unwrap()).unwrap();
+        std::fs::write(python, []).unwrap();
+        let params = json!({ "items": [{ "section": "python" }] });
+
+        let response = workspace_configuration_response(&ServerKind::Ty, root, Some(&params));
+
+        assert!(response[0].is_null());
     }
 }

--- a/crates/aft/src/lsp/client.rs
+++ b/crates/aft/src/lsp/client.rs
@@ -885,7 +885,11 @@ fn workspace_configuration_response(
         .and_then(Value::as_array);
     let python_path = (kind == &ServerKind::Python)
         .then(|| project_python_path(root))
-        .flatten();
+        .flatten()
+        // Lossy on purpose: PathBuf's Serialize rejects non-UTF-8 bytes and a
+        // panic here would wedge the reader thread mid-handshake. A lossy
+        // interpreter path degrades one exotic workspace instead.
+        .map(|path| path.to_string_lossy().into_owned());
 
     Value::Array(match items {
         Some(items) => items

--- a/crates/aft/src/lsp/manager.rs
+++ b/crates/aft/src/lsp/manager.rs
@@ -686,7 +686,7 @@ impl LspManager {
                     return client.state() != ServerState::Ready;
                 }
                 !self.failed_spawns.contains_key(&key)
-                    && self.resolve_binary(&definition, config).is_ok()
+                    && self.resolve_binary(&definition, &key.root, config).is_ok()
             })
     }
 

--- a/crates/aft/src/lsp/manager.rs
+++ b/crates/aft/src/lsp/manager.rs
@@ -24,7 +24,7 @@ use crate::lsp::pull_params::{
     AftDocumentDiagnosticParams, AftDocumentDiagnosticRequest, AftWorkspaceDiagnosticParams,
     AftWorkspaceDiagnosticRequest,
 };
-use crate::lsp::registry::{resolve_lsp_binary, servers_for_file, ServerDef, ServerKind};
+use crate::lsp::registry::{resolve_server_binary, servers_for_file, ServerDef, ServerKind};
 use crate::lsp::roots::ServerKey;
 use crate::lsp::LspError;
 use crate::slog_error;
@@ -2505,12 +2505,15 @@ impl LspManager {
             )));
         }
 
-        // Layered resolution:
-        resolve_lsp_binary(&def.binary, Some(root), &config.lsp_paths_extra)
-        .ok_or_else(|| {
+        resolve_server_binary(def, Some(root), config).ok_or_else(|| {
+            let searched = if matches!(def.kind, ServerKind::Python | ServerKind::Ty) {
+                "the workspace virtualenv, node_modules/.bin, lsp_paths_extra, or PATH"
+            } else {
+                "node_modules/.bin, lsp_paths_extra, or PATH"
+            };
             LspError::NotFound(format!(
-                "language server binary '{}' not found in the workspace virtualenv, node_modules/.bin, lsp_paths_extra, or PATH",
-                def.binary
+                "language server binary '{}' not found in {searched}",
+                def.binary,
             ))
         })
     }

--- a/crates/aft/src/lsp/manager.rs
+++ b/crates/aft/src/lsp/manager.rs
@@ -553,7 +553,7 @@ impl LspManager {
                     );
                     continue;
                 }
-                if self.resolve_binary(&definition, config).is_err() {
+                if self.resolve_binary(&definition, &key.root, config).is_err() {
                     producer_failures.insert(
                         key.clone(),
                         ApplicableServerFailure {
@@ -2433,7 +2433,7 @@ impl LspManager {
     ) -> Result<LspClient, LspError> {
         let initialization_options =
             initialization_options_for_spawn(def, source_file, root, config)?;
-        let binary = self.resolve_binary(def, config)?;
+        let binary = self.resolve_binary(def, root, config)?;
 
         // Merge the server-defined env with our test-injected env.
         // `extra_env` is empty in production; tests use it to drive fake
@@ -2477,7 +2477,12 @@ impl LspManager {
         Ok(client)
     }
 
-    fn resolve_binary(&self, def: &ServerDef, config: &Config) -> Result<PathBuf, LspError> {
+    fn resolve_binary(
+        &self,
+        def: &ServerDef,
+        root: &Path,
+        config: &Config,
+    ) -> Result<PathBuf, LspError> {
         if let Some(path) = self.binary_overrides.get(&def.kind) {
             if path.exists() {
                 return Ok(path.clone());
@@ -2501,17 +2506,10 @@ impl LspManager {
         }
 
         // Layered resolution:
-        //   1. <project_root>/node_modules/.bin/<binary>
-        //   2. config.lsp_paths_extra (plugin auto-install cache, etc.)
-        //   3. PATH via `which`
-        resolve_lsp_binary(
-            &def.binary,
-            config.project_root.as_deref(),
-            &config.lsp_paths_extra,
-        )
+        resolve_lsp_binary(&def.binary, Some(root), &config.lsp_paths_extra)
         .ok_or_else(|| {
             LspError::NotFound(format!(
-                "language server binary '{}' not found in node_modules/.bin, lsp_paths_extra, or PATH",
+                "language server binary '{}' not found in the workspace virtualenv, node_modules/.bin, lsp_paths_extra, or PATH",
                 def.binary
             ))
         })

--- a/crates/aft/src/lsp/registry.rs
+++ b/crates/aft/src/lsp/registry.rs
@@ -69,7 +69,14 @@ pub fn resolve_server_binary(
         }
     }
 
-    let project_root = config.project_root.as_deref().or(workspace_root);
+    // Python-family may fall back to the workspace root when no project root
+    // is configured; every other language keeps the pre-existing ladder rooted
+    // strictly at the configured project root.
+    let project_root = if python_family {
+        config.project_root.as_deref().or(workspace_root)
+    } else {
+        config.project_root.as_deref()
+    };
     resolve_lsp_binary(&server.binary, project_root, &config.lsp_paths_extra)
 }
 
@@ -1684,6 +1691,28 @@ mod tests {
         assert_eq!(
             resolved.as_deref(),
             Some(repository_bin.join("typescript-language-server").as_path())
+        );
+    }
+
+    #[test]
+    fn non_python_without_project_root_ignores_workspace_node_modules() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = tmp.path().join("backend");
+        let workspace_bin = workspace.join("node_modules").join(".bin");
+        touch_exe(&workspace_bin.join("typescript-language-server"));
+        let config = Config::default();
+        let server = builtin_servers()
+            .into_iter()
+            .find(|server| server.kind == ServerKind::TypeScript)
+            .unwrap();
+
+        // The generic ladder stays rooted at the configured project root only;
+        // with none configured it must not adopt the workspace root. (A PATH
+        // install may still resolve, so assert on provenance, not absence.)
+        let resolved = resolve_server_binary(&server, Some(&workspace), &config);
+        assert!(
+            resolved.map_or(true, |path| !path.starts_with(&workspace)),
+            "generic resolution must not adopt the workspace root"
         );
     }
 

--- a/crates/aft/src/lsp/registry.rs
+++ b/crates/aft/src/lsp/registry.rs
@@ -10,11 +10,12 @@ use crate::lsp::roots::{
 /// Resolve an LSP binary name to a full path.
 ///
 /// Resolution order (mirrors `format::resolve_tool` for formatters/checkers):
-/// 1. `<project_root>/node_modules/.bin/<binary>` — project devDependency
-/// 2. Each path in `extra_paths` joined with `<binary>` — plugin-supplied
+/// 1. `<project_root>/.venv` or `<project_root>/venv` — Python project tool
+/// 2. `<project_root>/node_modules/.bin/<binary>` — project devDependency
+/// 3. Each path in `extra_paths` joined with `<binary>` — plugin-supplied
 ///    auto-install cache locations such as
 ///    `~/.cache/aft/lsp-packages/<pkg>/node_modules/.bin/`
-/// 3. PATH via [`which::which`]
+/// 4. PATH via [`which::which`]
 ///
 /// On Windows, candidate directories are also probed with `.cmd`, `.exe`,
 /// and `.bat` extensions because npm-installed shims often use `.cmd`.
@@ -24,7 +25,22 @@ pub fn resolve_lsp_binary(
     project_root: Option<&Path>,
     extra_paths: &[PathBuf],
 ) -> Option<PathBuf> {
-    // 1. Project-local node_modules/.bin
+    // 1. Project-local Python virtual environment.
+    if let Some(root) = project_root {
+        if let Some(found) = probe_project_virtualenv(root, binary) {
+            return Some(found);
+        }
+    }
+
+    resolve_lsp_binary_outside_virtualenv(binary, project_root, extra_paths)
+}
+
+fn resolve_lsp_binary_outside_virtualenv(
+    binary: &str,
+    project_root: Option<&Path>,
+    extra_paths: &[PathBuf],
+) -> Option<PathBuf> {
+    // 2. Project-local node_modules/.bin
     if let Some(root) = project_root {
         let local_bin = root.join("node_modules").join(".bin");
         if let Some(found) = probe_dir(&local_bin, binary) {
@@ -32,15 +48,28 @@ pub fn resolve_lsp_binary(
         }
     }
 
-    // 2. Plugin-supplied extra paths (auto-install cache, etc.)
+    // 3. Plugin-supplied extra paths (auto-install cache, etc.)
     for dir in extra_paths {
         if let Some(found) = probe_dir(dir, binary) {
             return Some(found);
         }
     }
 
-    // 3. PATH fallback
+    // 4. PATH fallback
     which::which(binary).ok()
+}
+
+fn probe_project_virtualenv(root: &Path, binary: &str) -> Option<PathBuf> {
+    [root.join(".venv"), root.join("venv")]
+        .into_iter()
+        .find_map(|virtualenv| {
+            let bin_dir = if cfg!(windows) {
+                virtualenv.join("Scripts")
+            } else {
+                virtualenv.join("bin")
+            };
+            probe_dir(&bin_dir, binary)
+        })
 }
 
 /// Check `dir/<binary>` and (on Windows) `dir/<binary>.cmd|.exe|.bat`.
@@ -639,12 +668,102 @@ pub fn servers_for_file(path: &Path, config: &Config) -> Vec<ServerDef> {
         .and_then(|ext| ext.to_str())
         .unwrap_or_default();
 
-    resolved_servers(config)
+    let matching = resolved_servers(config)
         .into_iter()
         .filter(|server| !is_disabled(server, config))
-        .filter(|server| config.experimental_lsp_ty || server.kind != ServerKind::Ty)
         .filter(|server| server.matches_extension(extension))
-        .collect()
+        .collect::<Vec<_>>();
+
+    if !matches!(extension.to_ascii_lowercase().as_str(), "py" | "pyi") {
+        return matching
+            .into_iter()
+            .filter(|server| config.experimental_lsp_ty || server.kind != ServerKind::Ty)
+            .collect();
+    }
+
+    select_python_servers(path, config, matching)
+}
+
+fn select_python_servers(
+    path: &Path,
+    config: &Config,
+    mut matching: Vec<ServerDef>,
+) -> Vec<ServerDef> {
+    let python = matching
+        .iter()
+        .position(|server| server.kind == ServerKind::Python)
+        .map(|position| matching.remove(position));
+    let ty = matching
+        .iter()
+        .position(|server| server.kind == ServerKind::Ty)
+        .map(|position| matching.remove(position));
+
+    match (python, ty) {
+        (Some(python), Some(ty)) if config.experimental_lsp_ty => {
+            matching.extend([python, ty]);
+        }
+        (Some(python), Some(ty)) => {
+            matching.push(select_python_server(path, config, ty, python));
+        }
+        (Some(python), None) => matching.push(python),
+        (None, Some(ty)) if config.experimental_lsp_ty => matching.push(ty),
+        (None, Some(_)) | (None, None) => {}
+    }
+
+    matching
+}
+
+fn select_python_server(
+    path: &Path,
+    config: &Config,
+    ty: ServerDef,
+    pyright: ServerDef,
+) -> ServerDef {
+    let basedpyright = (pyright.binary == "pyright-langserver").then(|| ServerDef {
+        kind: ServerKind::Python,
+        name: "BasedPyright".to_string(),
+        extensions: pyright.extensions.clone(),
+        binary: "basedpyright-langserver".to_string(),
+        args: pyright.args.clone(),
+        root_markers: pyright.root_markers.clone(),
+        priority_root_markers: pyright.priority_root_markers.clone(),
+        env: pyright.env.clone(),
+        initialization_options: pyright.initialization_options.clone(),
+    });
+    let mut candidates = vec![ty, pyright];
+    if let Some(basedpyright) = basedpyright {
+        candidates.push(basedpyright);
+    }
+
+    for candidate in &candidates {
+        let Some(root) = candidate
+            .workspace_root_for_file_with_project_root(path, config.project_root.as_deref())
+        else {
+            continue;
+        };
+        if probe_project_virtualenv(&root, &candidate.binary).is_some() {
+            return candidate.clone();
+        }
+    }
+
+    for candidate in &candidates {
+        let Some(root) = candidate
+            .workspace_root_for_file_with_project_root(path, config.project_root.as_deref())
+        else {
+            continue;
+        };
+        if resolve_lsp_binary_outside_virtualenv(
+            &candidate.binary,
+            Some(&root),
+            &config.lsp_paths_extra,
+        )
+        .is_some()
+        {
+            return candidate.clone();
+        }
+    }
+
+    candidates.swap_remove(1)
 }
 
 /// Resolve the full server set after applying user overrides.
@@ -1463,6 +1582,153 @@ mod tests {
             resolved.as_deref(),
             Some(local_bin.join("pyright-langserver").as_path())
         );
+    }
+
+    #[test]
+    fn resolve_lsp_binary_prefers_project_virtualenv() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("project");
+        let extra = tmp.path().join("extra");
+        let virtualenv_bin = if cfg!(windows) {
+            project.join(".venv").join("Scripts")
+        } else {
+            project.join(".venv").join("bin")
+        };
+        touch_exe(&virtualenv_bin.join("ty"));
+        touch_exe(&extra.join("ty"));
+
+        let resolved = resolve_lsp_binary("ty", Some(&project), &[extra]);
+
+        assert_eq!(
+            resolved.as_deref(),
+            Some(virtualenv_bin.join("ty").as_path())
+        );
+    }
+
+    #[test]
+    fn python_auto_prefers_ty_from_nested_project_virtualenv() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repository = tmp.path();
+        let backend = repository.join("backend");
+        let source = backend.join("app").join("main.py");
+        std::fs::create_dir_all(source.parent().unwrap()).unwrap();
+        std::fs::write(backend.join("pyproject.toml"), "[project]\nname = 'demo'\n").unwrap();
+        let virtualenv_bin = if cfg!(windows) {
+            backend.join(".venv").join("Scripts")
+        } else {
+            backend.join(".venv").join("bin")
+        };
+        touch_exe(&virtualenv_bin.join("ty"));
+        let config = Config {
+            project_root: Some(repository.to_path_buf()),
+            ..Config::default()
+        };
+
+        let servers = servers_for_file(&source, &config);
+
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].kind, ServerKind::Ty);
+        assert_eq!(servers[0].binary, "ty");
+    }
+
+    #[test]
+    fn python_auto_uses_local_basedpyright_when_it_is_the_only_candidate() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path();
+        let source = project.join("main.py");
+        std::fs::write(project.join("pyproject.toml"), "[project]\nname = 'demo'\n").unwrap();
+        let virtualenv_bin = if cfg!(windows) {
+            project.join(".venv").join("Scripts")
+        } else {
+            project.join(".venv").join("bin")
+        };
+        touch_exe(&virtualenv_bin.join("basedpyright-langserver"));
+        let config = Config {
+            project_root: Some(project.to_path_buf()),
+            ..Config::default()
+        };
+
+        let servers = servers_for_file(&source, &config);
+
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].kind, ServerKind::Python);
+        assert_eq!(servers[0].name, "BasedPyright");
+        assert_eq!(servers[0].binary, "basedpyright-langserver");
+    }
+
+    #[test]
+    fn python_auto_prefers_virtualenv_pyright_over_cached_ty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("project");
+        let source = project.join("main.py");
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::write(project.join("pyproject.toml"), "[project]\nname = 'demo'\n").unwrap();
+        let virtualenv_bin = if cfg!(windows) {
+            project.join(".venv").join("Scripts")
+        } else {
+            project.join(".venv").join("bin")
+        };
+        touch_exe(&virtualenv_bin.join("pyright-langserver"));
+        let cache = tmp.path().join("cache");
+        touch_exe(&cache.join("ty"));
+        let config = Config {
+            project_root: Some(project.clone()),
+            lsp_paths_extra: vec![cache],
+            ..Config::default()
+        };
+
+        let servers = servers_for_file(&source, &config);
+
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].kind, ServerKind::Python);
+        assert_eq!(servers[0].binary, "pyright-langserver");
+    }
+
+    #[test]
+    fn python_auto_prefers_ty_when_only_global_candidates_exist() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("project");
+        let source = project.join("main.py");
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::write(project.join("pyproject.toml"), "[project]\nname = 'demo'\n").unwrap();
+        let cache = tmp.path().join("cache");
+        touch_exe(&cache.join("ty"));
+        touch_exe(&cache.join("pyright-langserver"));
+        let config = Config {
+            project_root: Some(project.clone()),
+            lsp_paths_extra: vec![cache],
+            ..Config::default()
+        };
+
+        let servers = servers_for_file(&source, &config);
+
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].kind, ServerKind::Ty);
+    }
+
+    #[test]
+    fn explicitly_disabled_ty_forces_pyright() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path();
+        let source = project.join("main.py");
+        std::fs::write(project.join("pyproject.toml"), "[project]\nname = 'demo'\n").unwrap();
+        let virtualenv_bin = if cfg!(windows) {
+            project.join(".venv").join("Scripts")
+        } else {
+            project.join(".venv").join("bin")
+        };
+        touch_exe(&virtualenv_bin.join("ty"));
+        let config = Config {
+            project_root: Some(project.to_path_buf()),
+            disabled_lsp: std::collections::HashSet::from(["ty".to_string()]),
+            ..Config::default()
+        };
+
+        let servers = servers_for_file(&source, &config);
+
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].kind, ServerKind::Python);
+        assert_eq!(servers[0].binary, "pyright-langserver");
     }
 
     #[test]

--- a/crates/aft/src/lsp/registry.rs
+++ b/crates/aft/src/lsp/registry.rs
@@ -43,8 +43,8 @@ pub fn resolve_lsp_binary(
     which::which(binary).ok()
 }
 
-/// Resolve a server binary, adding nested virtualenv lookup only for Python
-/// producers while preserving the generic resolver for every other language.
+/// Resolve a server binary, adding nested Python workspace lookup before the
+/// configured project-root resolver used by every other language.
 pub fn resolve_server_binary(
     server: &ServerDef,
     workspace_root: Option<&Path>,
@@ -56,6 +56,15 @@ pub fn resolve_server_binary(
         if let Some(root) = workspace_root.or(config.project_root.as_deref()) {
             if let Some(found) = probe_project_virtualenv(root, &server.binary) {
                 return Some(found);
+            }
+        }
+        if let Some(root) = workspace_root {
+            if config.project_root.as_deref() != Some(root) {
+                if let Some(found) =
+                    probe_dir(&root.join("node_modules").join(".bin"), &server.binary)
+                {
+                    return Some(found);
+                }
             }
         }
     }
@@ -1591,6 +1600,36 @@ mod tests {
         assert_eq!(
             resolve_server_binary(&server, Some(&workspace), &config),
             Some(hoisted)
+        );
+    }
+
+    #[test]
+    fn python_resolver_prefers_workspace_node_modules_over_project_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path();
+        let workspace = project.join("backend");
+        let workspace_bin = workspace.join("node_modules").join(".bin");
+        let project_bin = project.join("node_modules").join(".bin");
+        let binary_name = if cfg!(windows) {
+            "pyright-langserver.cmd"
+        } else {
+            "pyright-langserver"
+        };
+        let nested = workspace_bin.join(binary_name);
+        touch_exe(&nested);
+        touch_exe(&project_bin.join(binary_name));
+        let server = builtin_servers()
+            .into_iter()
+            .find(|server| server.kind == ServerKind::Python)
+            .unwrap();
+        let config = Config {
+            project_root: Some(project.to_path_buf()),
+            ..Config::default()
+        };
+
+        assert_eq!(
+            resolve_server_binary(&server, Some(&workspace), &config),
+            Some(nested)
         );
     }
 

--- a/crates/aft/src/lsp/registry.rs
+++ b/crates/aft/src/lsp/registry.rs
@@ -51,21 +51,17 @@ pub fn resolve_server_binary(
     config: &Config,
 ) -> Option<PathBuf> {
     let python_family = matches!(server.kind, ServerKind::Python | ServerKind::Ty);
-    let resolution_root = if python_family {
-        workspace_root.or(config.project_root.as_deref())
-    } else {
-        config.project_root.as_deref()
-    };
 
     if python_family {
-        if let Some(root) = resolution_root {
+        if let Some(root) = workspace_root.or(config.project_root.as_deref()) {
             if let Some(found) = probe_project_virtualenv(root, &server.binary) {
                 return Some(found);
             }
         }
     }
 
-    resolve_lsp_binary(&server.binary, resolution_root, &config.lsp_paths_extra)
+    let project_root = config.project_root.as_deref().or(workspace_root);
+    resolve_lsp_binary(&server.binary, project_root, &config.lsp_paths_extra)
 }
 
 fn probe_project_virtualenv(root: &Path, binary: &str) -> Option<PathBuf> {
@@ -1568,6 +1564,33 @@ mod tests {
         assert_eq!(
             resolved.as_deref(),
             Some(virtualenv_bin.join("pyright-langserver").as_path())
+        );
+    }
+
+    #[test]
+    fn python_resolver_falls_back_to_project_root_node_modules() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path();
+        let workspace = project.join("backend");
+        let project_bin = project.join("node_modules").join(".bin");
+        let hoisted = if cfg!(windows) {
+            project_bin.join("pyright-langserver.cmd")
+        } else {
+            project_bin.join("pyright-langserver")
+        };
+        touch_exe(&hoisted);
+        let server = builtin_servers()
+            .into_iter()
+            .find(|server| server.kind == ServerKind::Python)
+            .unwrap();
+        let config = Config {
+            project_root: Some(project.to_path_buf()),
+            ..Config::default()
+        };
+
+        assert_eq!(
+            resolve_server_binary(&server, Some(&workspace), &config),
+            Some(hoisted)
         );
     }
 

--- a/crates/aft/src/lsp/registry.rs
+++ b/crates/aft/src/lsp/registry.rs
@@ -10,12 +10,11 @@ use crate::lsp::roots::{
 /// Resolve an LSP binary name to a full path.
 ///
 /// Resolution order (mirrors `format::resolve_tool` for formatters/checkers):
-/// 1. `<project_root>/.venv` or `<project_root>/venv` — Python project tool
-/// 2. `<project_root>/node_modules/.bin/<binary>` — project devDependency
-/// 3. Each path in `extra_paths` joined with `<binary>` — plugin-supplied
+/// 1. `<project_root>/node_modules/.bin/<binary>` — project devDependency
+/// 2. Each path in `extra_paths` joined with `<binary>` — plugin-supplied
 ///    auto-install cache locations such as
 ///    `~/.cache/aft/lsp-packages/<pkg>/node_modules/.bin/`
-/// 4. PATH via [`which::which`]
+/// 3. PATH via [`which::which`]
 ///
 /// On Windows, candidate directories are also probed with `.cmd`, `.exe`,
 /// and `.bat` extensions because npm-installed shims often use `.cmd`.
@@ -25,22 +24,7 @@ pub fn resolve_lsp_binary(
     project_root: Option<&Path>,
     extra_paths: &[PathBuf],
 ) -> Option<PathBuf> {
-    // 1. Project-local Python virtual environment.
-    if let Some(root) = project_root {
-        if let Some(found) = probe_project_virtualenv(root, binary) {
-            return Some(found);
-        }
-    }
-
-    resolve_lsp_binary_outside_virtualenv(binary, project_root, extra_paths)
-}
-
-fn resolve_lsp_binary_outside_virtualenv(
-    binary: &str,
-    project_root: Option<&Path>,
-    extra_paths: &[PathBuf],
-) -> Option<PathBuf> {
-    // 2. Project-local node_modules/.bin
+    // 1. Project-local node_modules/.bin
     if let Some(root) = project_root {
         let local_bin = root.join("node_modules").join(".bin");
         if let Some(found) = probe_dir(&local_bin, binary) {
@@ -48,15 +32,40 @@ fn resolve_lsp_binary_outside_virtualenv(
         }
     }
 
-    // 3. Plugin-supplied extra paths (auto-install cache, etc.)
+    // 2. Plugin-supplied extra paths (auto-install cache, etc.)
     for dir in extra_paths {
         if let Some(found) = probe_dir(dir, binary) {
             return Some(found);
         }
     }
 
-    // 4. PATH fallback
+    // 3. PATH fallback
     which::which(binary).ok()
+}
+
+/// Resolve a server binary, adding nested virtualenv lookup only for Python
+/// producers while preserving the generic resolver for every other language.
+pub fn resolve_server_binary(
+    server: &ServerDef,
+    workspace_root: Option<&Path>,
+    config: &Config,
+) -> Option<PathBuf> {
+    let python_family = matches!(server.kind, ServerKind::Python | ServerKind::Ty);
+    let resolution_root = if python_family {
+        workspace_root.or(config.project_root.as_deref())
+    } else {
+        config.project_root.as_deref()
+    };
+
+    if python_family {
+        if let Some(root) = resolution_root {
+            if let Some(found) = probe_project_virtualenv(root, &server.binary) {
+                return Some(found);
+            }
+        }
+    }
+
+    resolve_lsp_binary(&server.binary, resolution_root, &config.lsp_paths_extra)
 }
 
 fn probe_project_virtualenv(root: &Path, binary: &str) -> Option<PathBuf> {
@@ -246,13 +255,22 @@ impl ServerDef {
             }
         }
 
+        let bounded_to_project = matches!(
+            self.kind,
+            ServerKind::Rust | ServerKind::Python | ServerKind::Ty
+        );
         for marker in &self.priority_root_markers {
-            if let Some(root) = find_workspace_root(file_path, &[marker.as_str()]) {
+            let root = if bounded_to_project {
+                find_workspace_root_within(file_path, &[marker.as_str()], project_root)
+            } else {
+                find_workspace_root(file_path, &[marker.as_str()])
+            };
+            if let Some(root) = root {
                 return Some(root);
             }
         }
 
-        if self.kind == ServerKind::Rust {
+        if bounded_to_project {
             find_workspace_root_within(file_path, &self.root_markers, project_root)
         } else {
             find_workspace_root(file_path, &self.root_markers)
@@ -668,102 +686,12 @@ pub fn servers_for_file(path: &Path, config: &Config) -> Vec<ServerDef> {
         .and_then(|ext| ext.to_str())
         .unwrap_or_default();
 
-    let matching = resolved_servers(config)
+    resolved_servers(config)
         .into_iter()
         .filter(|server| !is_disabled(server, config))
         .filter(|server| server.matches_extension(extension))
-        .collect::<Vec<_>>();
-
-    if !matches!(extension.to_ascii_lowercase().as_str(), "py" | "pyi") {
-        return matching
-            .into_iter()
-            .filter(|server| config.experimental_lsp_ty || server.kind != ServerKind::Ty)
-            .collect();
-    }
-
-    select_python_servers(path, config, matching)
-}
-
-fn select_python_servers(
-    path: &Path,
-    config: &Config,
-    mut matching: Vec<ServerDef>,
-) -> Vec<ServerDef> {
-    let python = matching
-        .iter()
-        .position(|server| server.kind == ServerKind::Python)
-        .map(|position| matching.remove(position));
-    let ty = matching
-        .iter()
-        .position(|server| server.kind == ServerKind::Ty)
-        .map(|position| matching.remove(position));
-
-    match (python, ty) {
-        (Some(python), Some(ty)) if config.experimental_lsp_ty => {
-            matching.extend([python, ty]);
-        }
-        (Some(python), Some(ty)) => {
-            matching.push(select_python_server(path, config, ty, python));
-        }
-        (Some(python), None) => matching.push(python),
-        (None, Some(ty)) if config.experimental_lsp_ty => matching.push(ty),
-        (None, Some(_)) | (None, None) => {}
-    }
-
-    matching
-}
-
-fn select_python_server(
-    path: &Path,
-    config: &Config,
-    ty: ServerDef,
-    pyright: ServerDef,
-) -> ServerDef {
-    let basedpyright = (pyright.binary == "pyright-langserver").then(|| ServerDef {
-        kind: ServerKind::Python,
-        name: "BasedPyright".to_string(),
-        extensions: pyright.extensions.clone(),
-        binary: "basedpyright-langserver".to_string(),
-        args: pyright.args.clone(),
-        root_markers: pyright.root_markers.clone(),
-        priority_root_markers: pyright.priority_root_markers.clone(),
-        env: pyright.env.clone(),
-        initialization_options: pyright.initialization_options.clone(),
-    });
-    let mut candidates = vec![ty, pyright];
-    if let Some(basedpyright) = basedpyright {
-        candidates.push(basedpyright);
-    }
-
-    for candidate in &candidates {
-        let Some(root) = candidate
-            .workspace_root_for_file_with_project_root(path, config.project_root.as_deref())
-        else {
-            continue;
-        };
-        if probe_project_virtualenv(&root, &candidate.binary).is_some() {
-            return candidate.clone();
-        }
-    }
-
-    for candidate in &candidates {
-        let Some(root) = candidate
-            .workspace_root_for_file_with_project_root(path, config.project_root.as_deref())
-        else {
-            continue;
-        };
-        if resolve_lsp_binary_outside_virtualenv(
-            &candidate.binary,
-            Some(&root),
-            &config.lsp_paths_extra,
-        )
-        .is_some()
-        {
-            return candidate.clone();
-        }
-    }
-
-    candidates.swap_remove(1)
+        .filter(|server| config.experimental_lsp_ty || server.kind != ServerKind::Ty)
+        .collect()
 }
 
 /// Resolve the full server set after applying user overrides.
@@ -1003,7 +931,10 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
 
-    use super::{is_config_file_path, resolve_lsp_binary, servers_for_file, ServerKind};
+    use super::{
+        builtin_servers, is_config_file_path, resolve_lsp_binary, resolve_server_binary,
+        servers_for_file, ServerKind,
+    };
     use crate::config::{Config, UserServerDef};
 
     fn matching_kinds(path: &str, config: &Config) -> Vec<ServerKind> {
@@ -1585,7 +1516,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_lsp_binary_prefers_project_virtualenv() {
+    fn generic_resolver_does_not_probe_project_virtualenv() {
         let tmp = tempfile::tempdir().unwrap();
         let project = tmp.path().join("project");
         let extra = tmp.path().join("extra");
@@ -1594,25 +1525,57 @@ mod tests {
         } else {
             project.join(".venv").join("bin")
         };
-        touch_exe(&virtualenv_bin.join("ty"));
-        touch_exe(&extra.join("ty"));
+        touch_exe(&virtualenv_bin.join("typescript-language-server"));
+        touch_exe(&extra.join("typescript-language-server"));
 
-        let resolved = resolve_lsp_binary("ty", Some(&project), &[extra]);
+        let resolved = resolve_lsp_binary(
+            "typescript-language-server",
+            Some(&project),
+            std::slice::from_ref(&extra),
+        );
 
         assert_eq!(
             resolved.as_deref(),
-            Some(virtualenv_bin.join("ty").as_path())
+            Some(extra.join("typescript-language-server").as_path())
         );
     }
 
     #[test]
-    fn python_auto_prefers_ty_from_nested_project_virtualenv() {
+    fn python_resolver_prefers_nested_project_virtualenv() {
         let tmp = tempfile::tempdir().unwrap();
         let repository = tmp.path();
         let backend = repository.join("backend");
-        let source = backend.join("app").join("main.py");
-        std::fs::create_dir_all(source.parent().unwrap()).unwrap();
-        std::fs::write(backend.join("pyproject.toml"), "[project]\nname = 'demo'\n").unwrap();
+        let virtualenv_bin = if cfg!(windows) {
+            backend.join(".venv").join("Scripts")
+        } else {
+            backend.join(".venv").join("bin")
+        };
+        touch_exe(&virtualenv_bin.join("pyright-langserver"));
+        let cache = repository.join("cache");
+        touch_exe(&cache.join("pyright-langserver"));
+        let config = Config {
+            project_root: Some(repository.to_path_buf()),
+            lsp_paths_extra: vec![cache],
+            ..Config::default()
+        };
+        let server = builtin_servers()
+            .into_iter()
+            .find(|server| server.kind == ServerKind::Python)
+            .unwrap();
+
+        let resolved = resolve_server_binary(&server, Some(&backend), &config);
+
+        assert_eq!(
+            resolved.as_deref(),
+            Some(virtualenv_bin.join("pyright-langserver").as_path())
+        );
+    }
+
+    #[test]
+    fn ty_resolver_prefers_nested_project_virtualenv() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repository = tmp.path();
+        let backend = repository.join("backend");
         let virtualenv_bin = if cfg!(windows) {
             backend.join(".venv").join("Scripts")
         } else {
@@ -1623,94 +1586,51 @@ mod tests {
             project_root: Some(repository.to_path_buf()),
             ..Config::default()
         };
+        let server = builtin_servers()
+            .into_iter()
+            .find(|server| server.kind == ServerKind::Ty)
+            .unwrap();
 
-        let servers = servers_for_file(&source, &config);
+        let resolved = resolve_server_binary(&server, Some(&backend), &config);
 
-        assert_eq!(servers.len(), 1);
-        assert_eq!(servers[0].kind, ServerKind::Ty);
-        assert_eq!(servers[0].binary, "ty");
+        assert_eq!(
+            resolved.as_deref(),
+            Some(virtualenv_bin.join("ty").as_path())
+        );
     }
 
     #[test]
-    fn python_auto_uses_local_basedpyright_when_it_is_the_only_candidate() {
+    fn non_python_resolver_keeps_configured_project_root() {
         let tmp = tempfile::tempdir().unwrap();
-        let project = tmp.path();
-        let source = project.join("main.py");
-        std::fs::write(project.join("pyproject.toml"), "[project]\nname = 'demo'\n").unwrap();
-        let virtualenv_bin = if cfg!(windows) {
-            project.join(".venv").join("Scripts")
-        } else {
-            project.join(".venv").join("bin")
-        };
-        touch_exe(&virtualenv_bin.join("basedpyright-langserver"));
+        let repository = tmp.path().join("repository");
+        let backend = repository.join("backend");
+        let repository_bin = repository.join("node_modules").join(".bin");
+        let backend_bin = backend.join("node_modules").join(".bin");
+        touch_exe(&repository_bin.join("typescript-language-server"));
+        touch_exe(&backend_bin.join("typescript-language-server"));
         let config = Config {
-            project_root: Some(project.to_path_buf()),
+            project_root: Some(repository.clone()),
             ..Config::default()
         };
+        let server = builtin_servers()
+            .into_iter()
+            .find(|server| server.kind == ServerKind::TypeScript)
+            .unwrap();
 
-        let servers = servers_for_file(&source, &config);
+        let resolved = resolve_server_binary(&server, Some(&backend), &config);
 
-        assert_eq!(servers.len(), 1);
-        assert_eq!(servers[0].kind, ServerKind::Python);
-        assert_eq!(servers[0].name, "BasedPyright");
-        assert_eq!(servers[0].binary, "basedpyright-langserver");
+        assert_eq!(
+            resolved.as_deref(),
+            Some(repository_bin.join("typescript-language-server").as_path())
+        );
     }
 
     #[test]
-    fn python_auto_prefers_virtualenv_pyright_over_cached_ty() {
+    fn python_auto_stays_on_pyright_when_local_ty_exists() {
         let tmp = tempfile::tempdir().unwrap();
         let project = tmp.path().join("project");
         let source = project.join("main.py");
         std::fs::create_dir_all(&project).unwrap();
-        std::fs::write(project.join("pyproject.toml"), "[project]\nname = 'demo'\n").unwrap();
-        let virtualenv_bin = if cfg!(windows) {
-            project.join(".venv").join("Scripts")
-        } else {
-            project.join(".venv").join("bin")
-        };
-        touch_exe(&virtualenv_bin.join("pyright-langserver"));
-        let cache = tmp.path().join("cache");
-        touch_exe(&cache.join("ty"));
-        let config = Config {
-            project_root: Some(project.clone()),
-            lsp_paths_extra: vec![cache],
-            ..Config::default()
-        };
-
-        let servers = servers_for_file(&source, &config);
-
-        assert_eq!(servers.len(), 1);
-        assert_eq!(servers[0].kind, ServerKind::Python);
-        assert_eq!(servers[0].binary, "pyright-langserver");
-    }
-
-    #[test]
-    fn python_auto_prefers_ty_when_only_global_candidates_exist() {
-        let tmp = tempfile::tempdir().unwrap();
-        let project = tmp.path().join("project");
-        let source = project.join("main.py");
-        std::fs::create_dir_all(&project).unwrap();
-        std::fs::write(project.join("pyproject.toml"), "[project]\nname = 'demo'\n").unwrap();
-        let cache = tmp.path().join("cache");
-        touch_exe(&cache.join("ty"));
-        touch_exe(&cache.join("pyright-langserver"));
-        let config = Config {
-            project_root: Some(project.clone()),
-            lsp_paths_extra: vec![cache],
-            ..Config::default()
-        };
-
-        let servers = servers_for_file(&source, &config);
-
-        assert_eq!(servers.len(), 1);
-        assert_eq!(servers[0].kind, ServerKind::Ty);
-    }
-
-    #[test]
-    fn explicitly_disabled_ty_forces_pyright() {
-        let tmp = tempfile::tempdir().unwrap();
-        let project = tmp.path();
-        let source = project.join("main.py");
         std::fs::write(project.join("pyproject.toml"), "[project]\nname = 'demo'\n").unwrap();
         let virtualenv_bin = if cfg!(windows) {
             project.join(".venv").join("Scripts")
@@ -1719,8 +1639,7 @@ mod tests {
         };
         touch_exe(&virtualenv_bin.join("ty"));
         let config = Config {
-            project_root: Some(project.to_path_buf()),
-            disabled_lsp: std::collections::HashSet::from(["ty".to_string()]),
+            project_root: Some(project.clone()),
             ..Config::default()
         };
 
@@ -1729,6 +1648,40 @@ mod tests {
         assert_eq!(servers.len(), 1);
         assert_eq!(servers[0].kind, ServerKind::Python);
         assert_eq!(servers[0].binary, "pyright-langserver");
+    }
+
+    #[test]
+    fn python_workspace_root_does_not_escape_configured_project() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ancestor = tmp.path();
+        let project = ancestor.join("project");
+        let source = project.join("src").join("main.py");
+        std::fs::create_dir_all(source.parent().unwrap()).unwrap();
+        std::fs::write(&source, "print('ok')\n").unwrap();
+        std::fs::write(
+            ancestor.join("pyproject.toml"),
+            "[project]\nname = 'outside'\n",
+        )
+        .unwrap();
+        let outside_python = if cfg!(windows) {
+            ancestor.join(".venv").join("Scripts").join("python.exe")
+        } else {
+            ancestor.join(".venv").join("bin").join("python")
+        };
+        touch_exe(&outside_python);
+
+        for kind in [ServerKind::Python, ServerKind::Ty] {
+            let server = builtin_servers()
+                .into_iter()
+                .find(|server| server.kind == kind)
+                .unwrap();
+            assert!(
+                server
+                    .workspace_root_for_file_with_project_root(&source, Some(&project))
+                    .is_none(),
+                "{kind:?} must not select a marker above project_root"
+            );
+        }
     }
 
     #[test]

--- a/crates/aft/tests/integration/configure_test.rs
+++ b/crates/aft/tests/integration/configure_test.rs
@@ -461,6 +461,117 @@ fn configure_warns_for_missing_builtin_and_custom_lsp_binaries() {
 }
 
 #[test]
+fn configure_finds_pyright_in_nested_workspace_virtualenv() {
+    let dir = tempfile::tempdir().unwrap();
+    let backend = dir.path().join("backend");
+    std::fs::create_dir_all(backend.join("app")).unwrap();
+    std::fs::write(backend.join("pyproject.toml"), "[project]\nname = 'demo'\n").unwrap();
+    std::fs::write(backend.join("app").join("main.py"), "print('ok')\n").unwrap();
+    let virtualenv_bin = if cfg!(windows) {
+        backend.join(".venv").join("Scripts")
+    } else {
+        backend.join(".venv").join("bin")
+    };
+    std::fs::create_dir_all(&virtualenv_bin).unwrap();
+    let binary = if cfg!(windows) {
+        virtualenv_bin.join("pyright-langserver.exe")
+    } else {
+        virtualenv_bin.join("pyright-langserver")
+    };
+    std::fs::write(binary, []).unwrap();
+
+    let path = empty_path();
+    let mut aft = AftProcess::spawn_with_env(&[("PATH", path.as_os_str())]);
+    let configure = aft.send(
+        &json!({
+            "id": "cfg-nested-python-lsp",
+            "command": "configure",
+            "harness": "opencode",
+            "project_root": dir.path(),
+            "lsp_auto_install_binaries": ["pyright-langserver"],
+        })
+        .to_string(),
+    );
+
+    assert_eq!(
+        configure["success"], true,
+        "configure failed: {configure:?}"
+    );
+    let configure = aft.merge_configure_warnings(configure);
+    assert!(
+        warning_with_kind(
+            &configure,
+            "lsp_binary_missing",
+            "binary",
+            "pyright-langserver",
+        )
+        .is_none(),
+        "nested virtualenv binary should suppress the missing warning: {configure:?}"
+    );
+
+    let shutdown = aft.shutdown();
+    assert!(shutdown.success());
+}
+
+#[test]
+fn configure_deduplicates_nested_python_builtin_override() {
+    let dir = tempfile::tempdir().unwrap();
+    let backend = dir.path().join("backend");
+    std::fs::create_dir_all(backend.join("app")).unwrap();
+    std::fs::write(backend.join("pyproject.toml"), "[project]\nname = 'demo'\n").unwrap();
+    std::fs::write(backend.join("app").join("main.py"), "print('ok')\n").unwrap();
+    let virtualenv_bin = if cfg!(windows) {
+        backend.join(".venv").join("Scripts")
+    } else {
+        backend.join(".venv").join("bin")
+    };
+    std::fs::create_dir_all(&virtualenv_bin).unwrap();
+    let binary_name = "nested-pyright";
+    let binary = if cfg!(windows) {
+        virtualenv_bin.join(format!("{binary_name}.exe"))
+    } else {
+        virtualenv_bin.join(binary_name)
+    };
+    std::fs::write(binary, []).unwrap();
+
+    let path = empty_path();
+    let mut aft = AftProcess::spawn_with_env(&[("PATH", path.as_os_str())]);
+    let configure = aft.send(
+        &json!({
+            "id": "cfg-nested-python-override",
+            "command": "configure",
+            "harness": "opencode",
+            "project_root": dir.path(),
+            "lsp_auto_install_binaries": [binary_name],
+            "config": user_config(serde_json::json!({
+                "lsp": {
+                    "servers": {
+                        "python": {
+                            "binary": binary_name,
+                            "root_markers": ["pyproject.toml"]
+                        }
+                    }
+                }
+            }))
+        })
+        .to_string(),
+    );
+
+    assert_eq!(
+        configure["success"], true,
+        "configure failed: {configure:?}"
+    );
+    let configure = aft.merge_configure_warnings(configure);
+    assert!(
+        warning_with_kind(&configure, "lsp_binary_missing", "binary", binary_name,).is_none(),
+        "file-driven resolution should deduplicate the raw override: {configure:?}"
+    );
+
+    let shutdown = aft.shutdown();
+    assert!(shutdown.success());
+}
+
+#[test]
 fn configure_does_not_warn_for_file_discovered_non_auto_installable_lsp() {
     let dir = tempfile::tempdir().unwrap();
     std::fs::write(dir.path().join("Program.cs"), "class Program {}\n").unwrap();

--- a/crates/aft/tests/integration/lsp_diagnostics_test.rs
+++ b/crates/aft/tests/integration/lsp_diagnostics_test.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
+use std::process::Command;
 use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -210,7 +211,15 @@ fn config_change_type(params: &serde_json::Value, suffix: &str) -> i64 {
 }
 
 fn pyright_langserver_available() -> bool {
-    which::which("pyright-langserver").is_ok()
+    pyright_langserver_path().is_some()
+}
+
+fn pyright_langserver_path() -> Option<PathBuf> {
+    which::which("pyright-langserver").ok().or_else(|| {
+        std::env::var_os("AFT_TEST_PYRIGHT_LANGSERVER")
+            .map(PathBuf::from)
+            .filter(|path| path.is_file())
+    })
 }
 
 fn pyright_extra_paths_workspace() -> (tempfile::TempDir, PathBuf, PathBuf, String) {
@@ -374,6 +383,66 @@ fn pyright_uses_pyrightconfig_extra_paths_above_nearer_requirements_marker() {
     assert!(
         !has_fakepkg_missing_import(&resolved_diagnostics),
         "pyright should honor pyrightconfig.json extraPaths from the selected workspace root; diagnostics: {resolved_diagnostics:?}"
+    );
+}
+
+#[test]
+fn pyright_uses_nested_workspace_virtualenv_for_imports() {
+    let Some(pyright) = pyright_langserver_path() else {
+        eprintln!(
+            "skipping nested virtualenv test: pyright-langserver not on PATH or AFT_TEST_PYRIGHT_LANGSERVER"
+        );
+        return;
+    };
+    let Ok(python) = which::which("python3").or_else(|_| which::which("python")) else {
+        eprintln!("skipping nested virtualenv test: Python interpreter not on PATH");
+        return;
+    };
+
+    let temp_dir = tempdir().expect("tempdir");
+    let repository = temp_dir.path().join("repository");
+    let backend = repository.join("backend");
+    let source = backend.join("app").join("main.py");
+    let virtualenv = backend.join(".venv");
+    fs::create_dir_all(source.parent().unwrap()).expect("create source directory");
+    fs::write(backend.join("pyproject.toml"), "[project]\nname = 'demo'\n")
+        .expect("write pyproject");
+    let status = Command::new(python)
+        .args(["-m", "venv"])
+        .arg(&virtualenv)
+        .status()
+        .expect("run python -m venv");
+    if !status.success() {
+        eprintln!("skipping nested virtualenv test: python -m venv failed");
+        return;
+    }
+    let virtualenv_python = if cfg!(windows) {
+        virtualenv.join("Scripts").join("python.exe")
+    } else {
+        virtualenv.join("bin").join("python")
+    };
+    let site_packages = Command::new(&virtualenv_python)
+        .args(["-c", "import site; print(site.getsitepackages()[0])"])
+        .output()
+        .expect("query virtualenv site-packages");
+    assert!(site_packages.status.success());
+    let fake_package =
+        PathBuf::from(String::from_utf8(site_packages.stdout).unwrap().trim()).join("fakepkg");
+    fs::create_dir_all(&fake_package).expect("create fake package");
+    fs::write(fake_package.join("__init__.py"), "VALUE = 1\n").expect("write fake package");
+    let source_text = "import fakepkg\n\nVALUE = fakepkg.VALUE\n";
+    fs::write(&source, source_text).expect("write source");
+    let config = Config {
+        project_root: Some(repository),
+        lsp_paths_extra: vec![pyright.parent().unwrap().to_path_buf()],
+        ..Config::default()
+    };
+
+    let diagnostics = pyright_diagnostics_for(&source, source_text, &config);
+
+    assert!(
+        !has_fakepkg_missing_import(&diagnostics),
+        "Pyright should resolve packages from the nested workspace virtualenv: {diagnostics:?}"
     );
 }
 

--- a/crates/aft/tests/integration/lsp_diagnostics_test.rs
+++ b/crates/aft/tests/integration/lsp_diagnostics_test.rs
@@ -412,10 +412,9 @@ fn pyright_uses_nested_workspace_virtualenv_for_imports() {
         .arg(&virtualenv)
         .status()
         .expect("run python -m venv");
-    if !status.success() {
-        eprintln!("skipping nested virtualenv test: python -m venv failed");
-        return;
-    }
+    // A present-but-broken Python is an environment failure, not a missing
+    // prerequisite: fail loud so the CI lane cannot go vacuously green.
+    assert!(status.success(), "python -m venv failed");
     let virtualenv_python = if cfg!(windows) {
         virtualenv.join("Scripts").join("python.exe")
     } else {

--- a/crates/aft/tests/integration/lsp_inspect_test.rs
+++ b/crates/aft/tests/integration/lsp_inspect_test.rs
@@ -204,10 +204,7 @@ fn lsp_inspect_reports_nested_python_virtualenv_binary() {
     std::fs::copy(&fake_server, &installed_server).unwrap();
     warm_executable(&installed_server, &["--stdio"]);
 
-    let mut aft = AftProcess::spawn_with_env(&[
-        ("AFT_FAKE_LSP_PULL", std::ffi::OsStr::new("1")),
-        ("PATH", empty_path().as_os_str()),
-    ]);
+    let mut aft = AftProcess::spawn_with_env(&[("PATH", empty_path().as_os_str())]);
     let configure = aft.send(
         &json!({
             "id": "cfg-nested-python-lsp",
@@ -242,7 +239,12 @@ fn lsp_inspect_reports_nested_python_virtualenv_binary() {
         installed_server.display().to_string()
     );
     assert_eq!(servers[0]["spawn_status"], "ok");
-    assert_eq!(response["diagnostics_count"], 1);
+    assert_eq!(response["diagnostics_complete"], false);
+    assert_eq!(response["diagnostics_gaps"][0]["server_id"], "python");
+    assert_eq!(
+        response["diagnostics_gaps"][0]["reason"],
+        "pull_not_supported"
+    );
 
     let shutdown = aft.shutdown();
     assert!(shutdown.success());

--- a/crates/aft/tests/integration/lsp_inspect_test.rs
+++ b/crates/aft/tests/integration/lsp_inspect_test.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use serde_json::json;
 use tempfile::tempdir;
 
-use super::helpers::{user_config, warm_executable, AftProcess};
+use super::helpers::{canonicalize_like_product, user_config, warm_executable, AftProcess};
 
 fn empty_path() -> std::ffi::OsString {
     std::ffi::OsString::new()
@@ -233,10 +233,15 @@ fn lsp_inspect_reports_nested_python_virtualenv_binary() {
     assert_eq!(servers.len(), 1, "response: {response:?}");
     assert_eq!(servers[0]["id"], "python");
     assert_eq!(servers[0]["binary_source"], "project_virtualenv");
-    assert_eq!(servers[0]["workspace_root"], backend.display().to_string());
+    assert_eq!(
+        servers[0]["workspace_root"],
+        canonicalize_like_product(&backend).display().to_string()
+    );
     assert_eq!(
         servers[0]["binary_path"],
-        installed_server.display().to_string()
+        canonicalize_like_product(&installed_server)
+            .display()
+            .to_string()
     );
     assert_eq!(servers[0]["spawn_status"], "ok");
     assert_eq!(response["diagnostics_complete"], false);
@@ -300,10 +305,15 @@ fn lsp_inspect_classifies_nested_python_node_modules_binary() {
     assert_eq!(response["success"], true, "inspect failed: {response:?}");
     let server = &response["matching_servers"][0];
     assert_eq!(server["binary_source"], "project_node_modules");
-    assert_eq!(server["workspace_root"], backend.display().to_string());
+    assert_eq!(
+        server["workspace_root"],
+        canonicalize_like_product(&backend).display().to_string()
+    );
     assert_eq!(
         server["binary_path"],
-        installed_server.display().to_string()
+        canonicalize_like_product(&installed_server)
+            .display()
+            .to_string()
     );
     assert_eq!(server["spawn_status"], "ok");
 
@@ -364,7 +374,10 @@ fn lsp_inspect_classifies_non_python_binary_against_project_root() {
         .find(|server| server["id"] == "typescript")
         .expect("TypeScript server inspection");
     assert_eq!(server["binary_source"], "project_node_modules");
-    assert_eq!(server["workspace_root"], package.display().to_string());
+    assert_eq!(
+        server["workspace_root"],
+        canonicalize_like_product(&package).display().to_string()
+    );
     assert_eq!(
         server["binary_path"],
         installed_server.display().to_string()

--- a/crates/aft/tests/integration/lsp_inspect_test.rs
+++ b/crates/aft/tests/integration/lsp_inspect_test.rs
@@ -251,6 +251,67 @@ fn lsp_inspect_reports_nested_python_virtualenv_binary() {
 }
 
 #[test]
+fn lsp_inspect_classifies_nested_python_node_modules_binary() {
+    let dir = tempdir().unwrap();
+    let repository = dir.path().join("repository");
+    let backend = repository.join("backend");
+    let file = backend.join("app").join("main.py");
+    std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+    std::fs::write(backend.join("pyproject.toml"), "[project]\nname = 'demo'\n").unwrap();
+    std::fs::write(&file, "print('ok')\n").unwrap();
+
+    let nested_bin = backend.join("node_modules").join(".bin");
+    std::fs::create_dir_all(&nested_bin).unwrap();
+    let installed_server = if cfg!(windows) {
+        nested_bin.join("pyright-langserver.exe")
+    } else {
+        nested_bin.join("pyright-langserver")
+    };
+    std::fs::copy(fake_server_path(), &installed_server).unwrap();
+    warm_executable(&installed_server, &["--stdio"]);
+
+    let mut aft = AftProcess::spawn_with_env(&[
+        ("AFT_FAKE_LSP_PULL", std::ffi::OsStr::new("1")),
+        ("PATH", empty_path().as_os_str()),
+    ]);
+    let configure = aft.send(
+        &json!({
+            "id": "cfg-nested-python-node-lsp",
+            "command": "configure",
+            "harness": "opencode",
+            "project_root": repository,
+        })
+        .to_string(),
+    );
+    assert_eq!(
+        configure["success"], true,
+        "configure failed: {configure:?}"
+    );
+
+    let response = aft.send(
+        &json!({
+            "id": "inspect-nested-python-node-lsp",
+            "command": "lsp_inspect",
+            "file": file,
+        })
+        .to_string(),
+    );
+
+    assert_eq!(response["success"], true, "inspect failed: {response:?}");
+    let server = &response["matching_servers"][0];
+    assert_eq!(server["binary_source"], "project_node_modules");
+    assert_eq!(server["workspace_root"], backend.display().to_string());
+    assert_eq!(
+        server["binary_path"],
+        installed_server.display().to_string()
+    );
+    assert_eq!(server["spawn_status"], "ok");
+
+    let shutdown = aft.shutdown();
+    assert!(shutdown.success());
+}
+
+#[test]
 fn lsp_inspect_classifies_non_python_binary_against_project_root() {
     let dir = tempdir().unwrap();
     let repository = dir.path().join("repository");

--- a/crates/aft/tests/integration/lsp_inspect_test.rs
+++ b/crates/aft/tests/integration/lsp_inspect_test.rs
@@ -179,3 +179,135 @@ fn lsp_inspect_reports_custom_server_ok_with_diagnostics() {
     let shutdown = aft.shutdown();
     assert!(shutdown.success());
 }
+
+#[test]
+fn lsp_inspect_reports_nested_python_virtualenv_binary() {
+    let dir = tempdir().unwrap();
+    let backend = dir.path().join("backend");
+    let file = backend.join("app").join("main.py");
+    std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+    std::fs::write(backend.join("pyproject.toml"), "[project]\nname = 'demo'\n").unwrap();
+    std::fs::write(&file, "print('ok')\n").unwrap();
+
+    let fake_server = fake_server_path();
+    let virtualenv_bin = if cfg!(windows) {
+        backend.join(".venv").join("Scripts")
+    } else {
+        backend.join(".venv").join("bin")
+    };
+    std::fs::create_dir_all(&virtualenv_bin).unwrap();
+    let installed_server = if cfg!(windows) {
+        virtualenv_bin.join("pyright-langserver.exe")
+    } else {
+        virtualenv_bin.join("pyright-langserver")
+    };
+    std::fs::copy(&fake_server, &installed_server).unwrap();
+    warm_executable(&installed_server, &["--stdio"]);
+
+    let mut aft = AftProcess::spawn_with_env(&[
+        ("AFT_FAKE_LSP_PULL", std::ffi::OsStr::new("1")),
+        ("PATH", empty_path().as_os_str()),
+    ]);
+    let configure = aft.send(
+        &json!({
+            "id": "cfg-nested-python-lsp",
+            "command": "configure",
+            "harness": "opencode",
+            "project_root": dir.path(),
+        })
+        .to_string(),
+    );
+    assert_eq!(
+        configure["success"], true,
+        "configure failed: {configure:?}"
+    );
+
+    let response = aft.send(
+        &json!({
+            "id": "inspect-nested-python-lsp",
+            "command": "lsp_inspect",
+            "file": file,
+        })
+        .to_string(),
+    );
+
+    assert_eq!(response["success"], true, "inspect failed: {response:?}");
+    let servers = response["matching_servers"].as_array().unwrap();
+    assert_eq!(servers.len(), 1, "response: {response:?}");
+    assert_eq!(servers[0]["id"], "python");
+    assert_eq!(servers[0]["binary_source"], "project_virtualenv");
+    assert_eq!(servers[0]["workspace_root"], backend.display().to_string());
+    assert_eq!(
+        servers[0]["binary_path"],
+        installed_server.display().to_string()
+    );
+    assert_eq!(servers[0]["spawn_status"], "ok");
+    assert_eq!(response["diagnostics_count"], 1);
+
+    let shutdown = aft.shutdown();
+    assert!(shutdown.success());
+}
+
+#[test]
+fn lsp_inspect_classifies_non_python_binary_against_project_root() {
+    let dir = tempdir().unwrap();
+    let repository = dir.path().join("repository");
+    let package = repository.join("packages").join("app");
+    let file = package.join("main.ts");
+    std::fs::create_dir_all(&package).unwrap();
+    std::fs::write(package.join("package.json"), "{\"name\":\"app\"}\n").unwrap();
+    std::fs::write(&file, "export const value = 1;\n").unwrap();
+
+    let fake_server = fake_server_path();
+    let project_bin = repository.join("node_modules").join(".bin");
+    std::fs::create_dir_all(&project_bin).unwrap();
+    let installed_server = if cfg!(windows) {
+        project_bin.join("typescript-language-server.exe")
+    } else {
+        project_bin.join("typescript-language-server")
+    };
+    std::fs::copy(&fake_server, &installed_server).unwrap();
+    warm_executable(&installed_server, &["--stdio"]);
+
+    let mut aft = AftProcess::spawn_with_env(&[("AFT_FAKE_LSP_PULL", std::ffi::OsStr::new("1"))]);
+    let configure = aft.send(
+        &json!({
+            "id": "cfg-nested-typescript-lsp",
+            "command": "configure",
+            "harness": "opencode",
+            "project_root": repository,
+        })
+        .to_string(),
+    );
+    assert_eq!(
+        configure["success"], true,
+        "configure failed: {configure:?}"
+    );
+
+    let response = aft.send(
+        &json!({
+            "id": "inspect-nested-typescript-lsp",
+            "command": "lsp_inspect",
+            "file": file,
+        })
+        .to_string(),
+    );
+
+    assert_eq!(response["success"], true, "inspect failed: {response:?}");
+    let server = response["matching_servers"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|server| server["id"] == "typescript")
+        .expect("TypeScript server inspection");
+    assert_eq!(server["binary_source"], "project_node_modules");
+    assert_eq!(server["workspace_root"], package.display().to_string());
+    assert_eq!(
+        server["binary_path"],
+        installed_server.display().to_string()
+    );
+    assert_eq!(server["spawn_status"], "ok");
+
+    let shutdown = aft.shutdown();
+    assert!(shutdown.success());
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -33,19 +33,19 @@ managed ONNX cache so the next bridge launch redownloads. Each step asks confirm
 before mutating state.
 
 **`doctor lsp <file>`** — Per-file LSP triage. Shows which servers AFT registered for the
-file's extension, where each binary resolves (project `node_modules/.bin` → `lsp_paths_extra`
-→ `PATH` → not found), whether the workspace root marker resolves walking up from the file,
-the spawn outcome, and the diagnostics returned (if any). Use this when `lsp_diagnostics`
-returns `total: 0` and you can't tell whether the file is genuinely clean or no server ever
-spawned. Pass `--harness opencode` or `--harness pi` if you have both plugins installed and
-need to disambiguate. Example output:
+file's extension, where each binary resolves (Python workspace virtualenv, project
+`node_modules/.bin`, `lsp_paths_extra`, `PATH`, or not found), whether the workspace root marker
+resolves walking up from the file, the spawn outcome, and the diagnostics returned (if any). Use
+this when `lsp_diagnostics` returns `total: 0` and you can't tell whether the file is genuinely
+clean or no server ever spawned. Pass `--harness opencode` or `--harness pi` if you have both
+plugins installed and need to disambiguate. Example output:
 
 ```
 $ npx @cortexkit/aft@latest doctor lsp ./python/main.py
 
 Server attempts:
   ✗ ty
-    Binary: ty (NOT FOUND on PATH or in lsp_paths_extra)
+    Binary: ty (NOT FOUND in workspace virtualenv, node_modules/.bin, lsp_paths_extra, or PATH)
     Workspace root: /repo/python (markers: requirements.txt)
     Status: binary not installed
     Action: Install with `uv tool install ty` or `pip install ty`.

--- a/docs/config.md
+++ b/docs/config.md
@@ -339,9 +339,10 @@ canonical shape is the top-level `bash` block shown above. `experimental` now ho
 ## Language servers (LSP)
 
 AFT runs language servers in-process for post-edit diagnostics and on-demand `lsp_diagnostics`
-calls. Servers are spawned lazily, only when a file matching their extensions is touched. Binary
-resolution prefers the selected nested workspace's `.venv` or `venv`, then its
-`node_modules/.bin`, AFT's managed cache, and finally `PATH`.
+calls. Servers are spawned lazily — only when a file matching their extensions is touched, and
+only if their binary can be resolved from project `node_modules/.bin`, AFT's managed cache, or
+`PATH`. Python-family servers additionally check the selected nested workspace's `.venv` or
+`venv` first.
 
 **Built-in servers** (auto-registered, no config needed):
 
@@ -354,13 +355,17 @@ resolution prefers the selected nested workspace's `.venv` or `venv`, then its
 | bash-language-server | `.sh .bash .zsh` | `bash-language-server` |
 | yaml-language-server | `.yaml .yml` | `yaml-language-server` |
 
-**Python selection:** `lsp.python` defaults to `"auto"`. Auto runs exactly one producer and checks
-the nested Python workspace before global tools, in this order: `ty`, Pyright, BasedPyright. A
-workspace-local candidate always wins over a global candidate. BasedPyright occupies the existing
-`python` producer slot and is selected only when `basedpyright-langserver` is already installed;
-AFT does not auto-install it. Set `lsp.python: "ty"` or `"pyright"` to force that producer without
-fallback. The legacy `experimental.lsp_ty: true` setting still runs ty alongside Pyright unless
-Pyright is disabled.
+**Experimental:** `ty` (Astral's Python type checker) — gated behind
+`experimental.lsp_ty: true` or `lsp.python: "ty"`. When enabled, ty runs alongside Pyright
+unless you also disable Pyright via `lsp.disabled: ["python"]` (or use `lsp.python: "ty"`
+which does both automatically). Python-family servers first look for their binary in the selected
+nested workspace's `.venv` or `venv`, before falling back to workspace `node_modules/.bin`, AFT's
+managed cache, and `PATH`. While ty remains alpha, `lsp.python: "auto"` stays on Pyright rather
+than silently changing diagnostic semantics based on which binaries happen to be installed.
+For Pyright, AFT also returns the selected virtualenv interpreter through Pyright's
+`workspace/configuration` request so imports resolve against that environment.
+Project-local language-server binaries and the interpreter selected for Pyright can execute with
+the user's privileges; enable LSPs only for projects and virtual environments you trust.
 
 **Registering a custom server:** add it under `lsp.servers` in your config. The example
 configuration above shows registering `tinymist` for Typst files. Required fields per server:

--- a/docs/config.md
+++ b/docs/config.md
@@ -339,8 +339,9 @@ canonical shape is the top-level `bash` block shown above. `experimental` now ho
 ## Language servers (LSP)
 
 AFT runs language servers in-process for post-edit diagnostics and on-demand `lsp_diagnostics`
-calls. Servers are spawned lazily — only when a file matching their extensions is touched, and
-only if their binary is on `PATH`.
+calls. Servers are spawned lazily, only when a file matching their extensions is touched. Binary
+resolution prefers the selected nested workspace's `.venv` or `venv`, then its
+`node_modules/.bin`, AFT's managed cache, and finally `PATH`.
 
 **Built-in servers** (auto-registered, no config needed):
 
@@ -353,10 +354,13 @@ only if their binary is on `PATH`.
 | bash-language-server | `.sh .bash .zsh` | `bash-language-server` |
 | yaml-language-server | `.yaml .yml` | `yaml-language-server` |
 
-**Experimental:** `ty` (Astral's Python type checker) — gated behind
-`experimental.lsp_ty: true` or `lsp.python: "ty"`. When enabled, ty runs alongside Pyright
-unless you also disable Pyright via `lsp.disabled: ["python"]` (or use `lsp.python: "ty"`
-which does both automatically).
+**Python selection:** `lsp.python` defaults to `"auto"`. Auto runs exactly one producer and checks
+the nested Python workspace before global tools, in this order: `ty`, Pyright, BasedPyright. A
+workspace-local candidate always wins over a global candidate. BasedPyright occupies the existing
+`python` producer slot and is selected only when `basedpyright-langserver` is already installed;
+AFT does not auto-install it. Set `lsp.python: "ty"` or `"pyright"` to force that producer without
+fallback. The legacy `experimental.lsp_ty: true` setting still runs ty alongside Pyright unless
+Pyright is disabled.
 
 **Registering a custom server:** add it under `lsp.servers` in your config. The example
 configuration above shows registering `tinymist` for Typst files. Required fields per server:

--- a/docs/config.md
+++ b/docs/config.md
@@ -359,9 +359,10 @@ only if their binary can be resolved from project `node_modules/.bin`, AFT's man
 `experimental.lsp_ty: true` or `lsp.python: "ty"`. When enabled, ty runs alongside Pyright
 unless you also disable Pyright via `lsp.disabled: ["python"]` (or use `lsp.python: "ty"`
 which does both automatically). Python-family servers first look for their binary in the selected
-nested workspace's `.venv` or `venv`, before falling back to workspace `node_modules/.bin`, AFT's
-managed cache, and `PATH`. While ty remains alpha, `lsp.python: "auto"` stays on Pyright rather
-than silently changing diagnostic semantics based on which binaries happen to be installed.
+nested workspace's `.venv` or `venv`, then its `node_modules/.bin`, the configured project root's
+`node_modules/.bin`, AFT's managed cache, and `PATH`. While ty remains alpha,
+`lsp.python: "auto"` stays on Pyright rather than silently changing diagnostic semantics based on
+which binaries happen to be installed.
 For Pyright, AFT also returns the selected virtualenv interpreter through Pyright's
 `workspace/configuration` request so imports resolve against that environment.
 Project-local language-server binaries and the interpreter selected for Pyright can execute with

--- a/docs/v0.49-agent-prefix-capture.json
+++ b/docs/v0.49-agent-prefix-capture.json
@@ -1,7 +1,7 @@
 {
   "artifact_id": "ART-V049-S5-AGENT-PREFIX-CAPTURE-001",
   "artifact_version": "0.49.0",
-  "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+  "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
   "capture_scope": "complete plugin-owned production agent-prefix input for every checked host profile; host-owned base prompt text is outside the plugin boundary",
   "captures": [
     {
@@ -18,7 +18,7 @@
         "exposed": false,
         "source": "host did not expose a production cache key"
       },
-      "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+      "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
       "prefix_input": {
         "registered_tool_names": [
           "aft_outline",
@@ -201,7 +201,7 @@
         "exposed": false,
         "source": "host did not expose a production cache key"
       },
-      "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+      "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
       "prefix_input": {
         "registered_tool_names": [
           "aft_conflicts",
@@ -1061,7 +1061,7 @@
         "exposed": false,
         "source": "host did not expose a production cache key"
       },
-      "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+      "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
       "prefix_input": {
         "registered_tool_names": [
           "aft_callgraph",
@@ -2090,7 +2090,7 @@
         "exposed": false,
         "source": "host did not expose a production cache key"
       },
-      "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+      "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
       "prefix_input": {
         "registered_tool_names": [
           "aft_outline",
@@ -2281,7 +2281,7 @@
         "exposed": false,
         "source": "host did not expose a production cache key"
       },
-      "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+      "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
       "prefix_input": {
         "registered_tool_names": [
           "aft_conflicts",
@@ -3249,7 +3249,7 @@
         "exposed": false,
         "source": "host did not expose a production cache key"
       },
-      "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+      "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
       "prefix_input": {
         "registered_tool_names": [
           "aft_callgraph",

--- a/docs/v0.49-agent-surface-manifest.json
+++ b/docs/v0.49-agent-surface-manifest.json
@@ -3,7 +3,7 @@
   "artifact_id": "ART-V049-S5-AGENT-SURFACE-MANIFEST-001",
   "artifact_version": "0.49.0",
   "manifest_id": "MAN-V049-S5-AGENT-SURFACE-001",
-  "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+  "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
   "source_inventory": "docs/v0.49-agent-surface-sources.json",
   "hash_rule": "Hash exact UTF-8 file bytes from the source commit; do not normalize newlines, reserialize JSON, or apply test-only normalization.",
   "artifacts": [
@@ -17,7 +17,7 @@
         "REG-V049-OC-REC",
         "REG-V049-OC-ALL"
       ],
-      "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+      "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
       "encoding": "UTF-8",
       "byte_length": 49224,
       "sha256": "939b6f8e5c8f0f51c29668381154ec176c2ef40ba4ccd92efdb408295aed8a0b"
@@ -32,7 +32,7 @@
         "REG-V049-OC-REC",
         "REG-V049-OC-ALL"
       ],
-      "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+      "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
       "encoding": "UTF-8",
       "byte_length": 17922,
       "sha256": "2d41d04ad7e0cb97d0b1064ab584e7daa8f1db5f7a8cb4d73732c0db1696e9df"
@@ -45,7 +45,7 @@
       "profiles": [
         "REG-V049-OC-ALL"
       ],
-      "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+      "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
       "encoding": "UTF-8",
       "byte_length": 7944,
       "sha256": "673c050c76f1ae592440c4574d07708b26a98ba0af5f2bace81c690be289f676"
@@ -60,7 +60,7 @@
         "REG-V049-OC-REC",
         "REG-V049-OC-ALL"
       ],
-      "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+      "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
       "encoding": "UTF-8",
       "byte_length": 8228,
       "sha256": "83185ecfad76ac049bddb97a82b9c0265976067107f2cd5e13d69b6acc7352ca"
@@ -74,7 +74,7 @@
         "REG-V049-OC-REC",
         "REG-V049-OC-ALL"
       ],
-      "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+      "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
       "encoding": "UTF-8",
       "byte_length": 6092,
       "sha256": "4dc0ba1675a425dcfe9fa08fb49bda9d3fedaa7044a25f9b6ac333ee79c3b46e"
@@ -87,7 +87,7 @@
       "profiles": [
         "REG-V049-OC-ALL"
       ],
-      "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+      "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
       "encoding": "UTF-8",
       "byte_length": 7766,
       "sha256": "1db4595041262d7e0a977154c2e1eca67b2d7fd1509428322aba6b7b58164f0e"
@@ -102,7 +102,7 @@
         "REG-V049-OC-REC",
         "REG-V049-OC-ALL"
       ],
-      "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+      "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
       "encoding": "UTF-8",
       "byte_length": 12504,
       "sha256": "213ef9b09bcc8854e00a4a3240791223ed0d338a33ee9667368075ab1b486954"
@@ -117,7 +117,7 @@
         "REG-V049-PI-REC",
         "REG-V049-PI-ALL"
       ],
-      "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+      "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
       "encoding": "UTF-8",
       "byte_length": 44341,
       "sha256": "f7a7c3374e8d5a1a15fd0d831c09fdf2dbcf88db041dccb5cb25392a2b04477f"
@@ -132,7 +132,7 @@
         "REG-V049-PI-REC",
         "REG-V049-PI-ALL"
       ],
-      "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+      "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
       "encoding": "UTF-8",
       "byte_length": 21652,
       "sha256": "719b244afe0ac41e167db6ce1714f89fea6daa5d6cab79113b184b41bb1edaeb"
@@ -145,7 +145,7 @@
       "profiles": [
         "REG-V049-PI-ALL"
       ],
-      "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+      "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
       "encoding": "UTF-8",
       "byte_length": 8789,
       "sha256": "7f8764e69b85378cb820c3963116ab65296fc45310d2555d096ff5fdee87cee2"
@@ -160,7 +160,7 @@
         "REG-V049-PI-REC",
         "REG-V049-PI-ALL"
       ],
-      "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+      "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
       "encoding": "UTF-8",
       "byte_length": 9499,
       "sha256": "8261d91d898f1423ddb591d8c30d0285492c19f841d0f3721c05d2f0842ff5c2"
@@ -174,7 +174,7 @@
         "REG-V049-PI-REC",
         "REG-V049-PI-ALL"
       ],
-      "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+      "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
       "encoding": "UTF-8",
       "byte_length": 8182,
       "sha256": "b26a8f7761f99dfdd46b9f1b96115377d6102f0cbd4ecb3b4c1f2599c7a743fb"
@@ -187,7 +187,7 @@
       "profiles": [
         "REG-V049-PI-ALL"
       ],
-      "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+      "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
       "encoding": "UTF-8",
       "byte_length": 8760,
       "sha256": "47f557a3b8ead3a9c863e99218b6016959de85a4c8be48a2e2e5b65e4742c836"
@@ -200,7 +200,7 @@
       "profiles": [
         "REG-V049-PI-ALL"
       ],
-      "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+      "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
       "encoding": "UTF-8",
       "byte_length": 9967,
       "sha256": "416d5dcf384248e0727d9a04e23556d14b98a51dfd57a9ae2c350ebaf285a51a"
@@ -215,7 +215,7 @@
         "REG-V049-PI-REC",
         "REG-V049-PI-ALL"
       ],
-      "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+      "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
       "encoding": "UTF-8",
       "byte_length": 11887,
       "sha256": "5c67943dc898c2a4235c033c5947faa30d64c05de7dc75dee3f2e842dcf89b4a"
@@ -233,7 +233,7 @@
         "REG-V049-PI-REC",
         "REG-V049-PI-ALL"
       ],
-      "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+      "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
       "encoding": "UTF-8",
       "byte_length": 44313,
       "sha256": "b604c6f80c2527582b457a4d8538bd9c4cc8987a6fac449a60e21e8780faa131"
@@ -248,7 +248,7 @@
         "REG-V049-PI-REC",
         "REG-V049-PI-ALL"
       ],
-      "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+      "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
       "encoding": "UTF-8",
       "byte_length": 7483,
       "sha256": "9af0a724fe023baa16657f1c698936e17b73fd943453882117ebda79a19b2ac2"
@@ -259,7 +259,7 @@
       "kind": "generated subc manifest schema",
       "owner": "subc-schema-generation",
       "profiles": [],
-      "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+      "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
       "encoding": "UTF-8",
       "byte_length": 42488,
       "sha256": "f1e5fc8b62510c99d182a076a4903a24e5d7d8e33fb909e9e1cf73ed0b428205"
@@ -277,7 +277,7 @@
         "REG-V049-PI-REC",
         "REG-V049-PI-ALL"
       ],
-      "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+      "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
       "encoding": "UTF-8",
       "byte_length": 6583,
       "sha256": "1a6bb079d906d983b8bd5493ffb0a345b33e550f983233fa8b525151a31c3700"
@@ -295,7 +295,7 @@
         "REG-V049-PI-REC",
         "REG-V049-PI-ALL"
       ],
-      "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+      "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
       "encoding": "UTF-8",
       "byte_length": 5519,
       "sha256": "98fe609fa669db5a64f751f44a097131298c6783868e31fc22d4e1e1c98aac62"
@@ -313,10 +313,10 @@
         "REG-V049-PI-REC",
         "REG-V049-PI-ALL"
       ],
-      "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+      "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
       "encoding": "UTF-8",
       "byte_length": 223287,
-      "sha256": "a4499703132346563aea127984108b6b0e1ce0b723e23c7e833fbf3832380408"
+      "sha256": "a0d3286c5fb917ddafdd2683b0a5357fdf3aa3a53a78f03d03dcb98d9561bd1e"
     },
     {
       "id": "ART-V049-S5-AUDIT-IMPLEMENTATION-001",
@@ -331,7 +331,7 @@
         "REG-V049-PI-REC",
         "REG-V049-PI-ALL"
       ],
-      "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+      "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
       "encoding": "UTF-8",
       "byte_length": 23451,
       "sha256": "c72cc1c1bc82575057552d62900174e57a31e50abf6e6d38b1c25679bcaaa872"
@@ -349,10 +349,10 @@
         "REG-V049-PI-REC",
         "REG-V049-PI-ALL"
       ],
-      "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+      "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
       "encoding": "UTF-8",
       "byte_length": 246315,
-      "sha256": "45a0ce4b72b2419b29a67af2c97243129b1e37d1f201e36c856ffaab19054593"
+      "sha256": "c70cf741f7b2dc72c4682728017cf2283aaf177543028d0514a8c1649dbc698a"
     }
   ]
 }

--- a/docs/v0.49-legacy-vocabulary-allowlist.json
+++ b/docs/v0.49-legacy-vocabulary-allowlist.json
@@ -2652,8 +2652,8 @@
     },
     {
       "path": "packages/aft-cli/src/commands/lsp.ts",
-      "location": "line 83, column 3",
-      "line": 83,
+      "location": "line 85, column 3",
+      "line": 85,
       "column": 3,
       "token": "filePath",
       "class": "internal-compatibility",
@@ -2661,8 +2661,8 @@
     },
     {
       "path": "packages/aft-cli/src/commands/lsp.ts",
-      "location": "line 86, column 45",
-      "line": 86,
+      "location": "line 88, column 45",
+      "line": 88,
       "column": 45,
       "token": "filePath",
       "class": "internal-compatibility",

--- a/docs/v0.49-release-manifest.json
+++ b/docs/v0.49-release-manifest.json
@@ -3,7 +3,7 @@
   "artifact_id": "ART-V049-S6-RELEASE-MANIFEST-001",
   "artifact_version": "0.49.0",
   "manifest_id": "MAN-V049-S6-RELEASE-001",
-  "source_commit": "aa2e6aef954e9b3a6ecd12e82c0b4212d2f54a29",
+  "source_commit": "83d64bf6a23facd53fc0538e4a73f79fba913723",
   "source_surface_manifest": "docs/v0.49-agent-surface-manifest.json",
   "distribution_manifest": "MAN-V049-DISTRIBUTION-ARTIFACTS-001",
   "hash_rule": "Hash exact UTF-8 bytes and binary bytes; do not normalize newlines, reserialize JSON, or use test-only normalization.",

--- a/packages/aft-cli/src/commands/lsp-doctor.test.ts
+++ b/packages/aft-cli/src/commands/lsp-doctor.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { HarnessAdapter, HarnessConfigPaths } from "../adapters/types.js";
 import type { AftRequest } from "../lib/aft-bridge.js";
-import { findProjectRootForFile, runLspDoctor } from "./lsp.js";
+import { findProjectRootForFile, renderLspInspection, runLspDoctor } from "./lsp.js";
 
 function makeAdapter(configDir: string): HarnessAdapter {
   const configPaths: HarnessConfigPaths = {
@@ -120,5 +120,22 @@ describe("doctor lsp project root detection", () => {
     const outside = tempRoot("aft-lsp-fallback-");
     const looseFile = join(tempRoot("aft-lsp-loose-"), "src", "main.py");
     expect(findProjectRootForFile(looseFile, outside)).toBe(outside);
+  });
+});
+
+describe("doctor lsp diagnostics completeness", () => {
+  test("does not render a push-only empty snapshot as checked clean", () => {
+    const rendered = renderLspInspection("main.py", {
+      success: true,
+      diagnostics_complete: false,
+      diagnostics_gaps: [{ server_id: "python", reason: "pull_not_supported" }],
+      diagnostics_count: 0,
+      diagnostics: [],
+    });
+
+    expect(rendered).toContain("Diagnostics incomplete (0 observed):");
+    expect(rendered).toContain("(none observed yet)");
+    expect(rendered).toContain("Gap: python: pull_not_supported");
+    expect(rendered).not.toContain("Diagnostics (0 found):");
   });
 });

--- a/packages/aft-cli/src/commands/lsp.ts
+++ b/packages/aft-cli/src/commands/lsp.ts
@@ -32,6 +32,8 @@ export interface LspInspectResponse {
   disabled_lsp?: string[];
   lsp_paths_extra?: string[];
   matching_servers?: LspServerInspection[];
+  diagnostics_complete?: boolean;
+  diagnostics_gaps?: Array<{ server_id: string; reason: string }>;
   diagnostics_count?: number;
   diagnostics?: LspDiagnostic[];
   typescript_package_warning?: string;
@@ -223,14 +225,23 @@ export function renderLspInspection(inputFile: string, response: LspInspectRespo
 
   const diagnostics = response.diagnostics ?? [];
   lines.push("");
-  lines.push(`Diagnostics (${response.diagnostics_count ?? diagnostics.length} found):`);
+  const diagnosticsComplete = response.diagnostics_complete !== false;
+  const observed = response.diagnostics_count ?? diagnostics.length;
+  lines.push(
+    diagnosticsComplete
+      ? `Diagnostics (${observed} found):`
+      : `Diagnostics incomplete (${observed} observed):`,
+  );
   if (diagnostics.length === 0) {
-    lines.push("  (none)");
+    lines.push(diagnosticsComplete ? "  (none)" : "  (none observed yet)");
   }
   for (const diagnostic of diagnostics) {
     lines.push(
       `  ${diagnostic.file}:${diagnostic.line}:${diagnostic.column} [${diagnostic.severity}] ${diagnostic.message}`,
     );
+  }
+  for (const gap of response.diagnostics_gaps ?? []) {
+    lines.push(`  Gap: ${gap.server_id}: ${gap.reason}`);
   }
 
   return lines.join("\n");

--- a/packages/aft-cli/src/commands/lsp.ts
+++ b/packages/aft-cli/src/commands/lsp.ts
@@ -302,7 +302,11 @@ function childDirs(path: string): string[] {
 
 function formatBinary(server: LspServerInspection): string {
   if (!server.binary_path) {
-    return `${server.binary_name} (NOT FOUND in workspace virtualenv, node_modules/.bin, lsp_paths_extra, or PATH)`;
+    const locations =
+      server.kind === "python" || server.kind === "ty"
+        ? "workspace virtualenv, node_modules/.bin, lsp_paths_extra, or PATH"
+        : "node_modules/.bin, lsp_paths_extra, or PATH";
+    return `${server.binary_name} (NOT FOUND in ${locations})`;
   }
   return `${server.binary_path} (found via ${server.binary_source})`;
 }

--- a/packages/aft-cli/src/commands/lsp.ts
+++ b/packages/aft-cli/src/commands/lsp.ts
@@ -302,7 +302,7 @@ function childDirs(path: string): string[] {
 
 function formatBinary(server: LspServerInspection): string {
   if (!server.binary_path) {
-    return `${server.binary_name} (NOT FOUND on PATH or in lsp_paths_extra)`;
+    return `${server.binary_name} (NOT FOUND in workspace virtualenv, node_modules/.bin, lsp_paths_extra, or PATH)`;
   }
   return `${server.binary_path} (found via ${server.binary_source})`;
 }

--- a/packages/opencode-plugin/scripts/build-schema.ts
+++ b/packages/opencode-plugin/scripts/build-schema.ts
@@ -494,9 +494,9 @@ function buildSchema(): Record<string, unknown> {
           python: {
             type: "string",
             enum: ["pyright", "ty", "auto"],
-            default: "pyright",
+            default: "auto",
             description:
-              "Which Python LSP to use. 'ty' is experimental and falls back to pyright if unavailable.",
+              "Which Python LSP to use. 'auto' stays on Pyright while ty is experimental; select 'ty' explicitly to opt in without fallback.",
           },
           diagnostics_on_edit: {
             type: "boolean",

--- a/packages/opencode-plugin/scripts/build-schema.ts
+++ b/packages/opencode-plugin/scripts/build-schema.ts
@@ -469,7 +469,7 @@ function buildSchema(): Record<string, unknown> {
             type: "boolean",
             default: false,
             description:
-              "Use experimental Python `ty` type checker. Falls back to pyright if unavailable.",
+              "Run the experimental Python `ty` type checker alongside Pyright. Use lsp.python = 'ty' to select ty exclusively.",
           },
         },
         additionalProperties: false,


### PR DESCRIPTION
Closes #258

## Summary

- resolve Python-family language servers from the computed nested workspace, preferring `.venv`/`venv`, then workspace `node_modules/.bin`, before the configured project-root, managed-cache, and `PATH` tiers
- keep `lsp.python = "auto"` conservative on Pyright while `ty` remains alpha; explicit `lsp.python = "ty"` selects the workspace-local ty binary
- answer Pyright's `workspace/configuration` request with the nested virtualenv interpreter so imports resolve from the active project environment
- keep configure warnings, spawn resolution, cold navigation, `lsp_inspect`, CLI doctor output, schema, and documentation on the same resolution contract
- report push-only or failed diagnostic pulls as incomplete instead of implying a checked-clean file
- run the real Pyright virtualenv regression in Linux integration shards with pinned Pyright 1.1.411

## Resolution order

For Python-family servers:

1. nested workspace `.venv` / `venv`
2. nested workspace `node_modules/.bin`
3. configured project-root `node_modules/.bin`
4. `lsp_paths_extra`
5. `PATH`

Non-Python resolution remains unchanged.

## Validation

- `cargo check -p agent-file-tools`
- `cargo fmt --all -- --check`
- 41 LSP registry tests passed
- 115 LSP integration tests passed, including a non-vacuous real-Pyright virtualenv import regression
- nested virtualenv, nested `node_modules`, root-hoisted Pyright, explicit ty, non-Python resolution, pull-failure completeness, and cold-navigation protocol scenarios passed
- CLI LSP doctor tests and typecheck passed
- generated schema freshness and workflow YAML parsing passed
- final goal, code-quality, security, hands-on QA, and upstream-context review gates passed

The full local library suite has root/environment-sensitive failures that reproduce on unmodified `main`; focused changed-area gates above are green and CI remains authoritative for the full matrix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790219799&installation_model_id=22398&pr_number=260&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F260&signature=5616abf0b1aee3fa06701c681179ac5f5d628199177b59a9ce7c39f98e88dcb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve Python LSPs from the active workspace’s virtualenv and configure `pyright` with that interpreter so imports resolve from the project environment. Previously we only searched `node_modules/.bin`/extras/`PATH` and returned null config; now we probe `.venv`/`venv` first, report honest diagnostics completeness, and harden edge cases.

- Resolution (Python-family): workspace `.venv`/`venv` → workspace `node_modules/.bin` → project `node_modules/.bin` → `lsp_paths_extra` → `PATH`. Non-Python resolution stays rooted at the configured project root and does not adopt the workspace root when none is set.
- Answer `workspace/configuration` for `pyright` with the workspace virtualenv interpreter; do not send interpreter settings to `ty`. Handle non-UTF-8 workspace paths lossily to avoid reader-thread panics.
- `lsp_inspect` reports canonicalized workspace roots and classifies binary provenance (`project_virtualenv`, `project_node_modules`); the response includes `diagnostics_complete` and `diagnostics_gaps`. `doctor lsp` renders “Diagnostics incomplete” instead of implying a clean file when pulls are missing.
- Configure warnings: detect per‑workspace Python binaries and deduplicate file‑driven vs explicit servers to avoid duplicate “missing” messages; explicit server checks use the same nested resolver.
- Schema/defaults: `lsp.python` now defaults to `auto` and keeps `pyright` while `ty` is experimental; `experimental.lsp_ty` runs `ty` alongside `pyright`. Migration: if you set `lsp.python: "ty"` expecting fallback to `pyright`, switch to `auto` or ensure `ty` is installed.
- CI: Linux integrations install `pyright@1.1.411` and run a real virtualenv import regression; venv setup failures fail the lane; tests canonicalize workspace roots on macOS/Windows.

<sup>Written for commit 3baa0bc491c86ba90eac877d2e5bed64c305ad26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds nested-workspace Python LSP resolution, supplies Pyright with the selected virtualenv interpreter, and exposes diagnostic completeness through inspection and CLI output.

- Prioritizes workspace virtualenv and `node_modules/.bin` binaries for Python-family servers.
- Aligns configure warnings, spawning, inspection, schema, documentation, and integration coverage with the new resolution contract.
- Distinguishes incomplete diagnostic pulls from checked-clean results.
</details>


<h3>Confidence Score: 2/5</h3>

The PR does not appear safe to merge until invalid nested LSP candidates stop masking usable fallbacks and the newly added workflow action is pinned to an immutable revision.

Nested candidates are still selected solely because they are files, so a stale or non-executable workspace binary can prevent Python language features even when a valid lower-tier server exists; the Linux integration job also continues to execute a mutable setup-action reference.

**Files Needing Attention:** crates/aft/src/lsp/registry.rs, crates/aft/src/lsp/manager.rs, .github/workflows/_unit-suite.yml

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/aft/src/lsp/registry.rs | Adds workspace-aware Python binary resolution, but higher-priority candidates remain accepted based only on file existence and can mask usable fallbacks. |
| crates/aft/src/lsp/manager.rs | Routes readiness and spawn resolution through the selected workspace root; failed selected binaries do not recover through lower resolution tiers. |
| crates/aft/src/lsp/client.rs | Returns Pyright-specific workspace configuration using the nested virtualenv interpreter while leaving ty configuration unchanged. |
| crates/aft/src/commands/lsp_inspect.rs | Reports workspace-aware binary provenance and explicitly marks failed or unsupported diagnostic pulls as incomplete. |
| crates/aft/src/commands/configure.rs | Makes missing-binary warnings workspace-aware and deduplicates file-driven and explicit server checks. |
| packages/aft-cli/src/commands/lsp.ts | Updates CLI doctor rendering to communicate diagnostic incompleteness and gaps. |
| .github/workflows/_unit-suite.yml | Installs pinned Pyright for Linux integration coverage, but the newly added setup action remains referenced by a mutable tag. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  F[Python source file] --> W[Select nested workspace root]
  W --> V[Workspace .venv or venv]
  V --> N[Workspace node_modules/.bin]
  N --> R[Project-root node_modules/.bin]
  R --> E[lsp_paths_extra]
  E --> P[PATH]
  V --> S[Spawn Python LSP]
  N --> S
  R --> S
  E --> S
  P --> S
  W --> C[Pyright workspace configuration]
  C --> I[Workspace virtualenv interpreter]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: harden virtualenv resolution edges ..."](https://github.com/cortexkit/aft/commit/3baa0bc491c86ba90eac877d2e5bed64c305ad26) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56510477)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Configuration and workspaces](https://app.greptile.com/cortexkit/-/custom-context/knowledge-base/cortexkit/aft/-/docs/configuration-and-workspaces.md)
- Knowledge Base — [Code intelligence](https://app.greptile.com/cortexkit/-/custom-context/knowledge-base/cortexkit/aft/-/docs/code-intelligence.md)
- Knowledge Base — [LSP integration](https://app.greptile.com/cortexkit/-/custom-context/knowledge-base/cortexkit/aft/-/docs/lsp-integration.md)
</details>


<!-- /greptile_comment -->