### PR TITLE
PROBE: name the Windows process-killing lib test (do not merge)

### DIFF
--- a/scripts/rust-test-gate.sh
+++ b/scripts/rust-test-gate.sh
@@ -225,8 +225,11 @@ if phase_enabled lib; then
       cargo nextest run --workspace --lib --bins --profile unit -- \
         --skip platform_verifier_tls_client_subprocess
   else
-    run_phase "cargo test --workspace --lib --bins --quiet" \
-      cargo test --workspace --lib --bins --quiet -- \
+    # PROBE (branch-only): serial, named output - the log's last started test
+    # is the one terminating the process on Windows.
+    run_phase "cargo test --workspace --lib --bins (serial probe)" \
+      cargo test --workspace --lib --bins -- \
+        --test-threads=1 \
         --skip platform_verifier_tls_client_subprocess
   fi
 fi


### PR DESCRIPTION
Serial named-output probe for the orphan-sweep re-land Windows fatal (clean exit 1 mid-run, no libtest summary, death moved 348->435 after the Drop containment). The Windows libtest job's log will end at the guilty test's name. Do not merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790295570&installation_model_id=22398&pr_number=264&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F264&signature=2251326f2538294841b0b0e3c01e4013c911527e41cd31a1bbcb2a04b6ad9785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->