### PR TITLE
fix: launch Windows batch tool shims

### DIFF
--- a/crates/aft/src/format.rs
+++ b/crates/aft/src/format.rs
@@ -599,8 +599,11 @@ fn ruff_format_available_uncached(project_root: Option<&Path>) -> bool {
         Some(command) => command,
         None => return false,
     };
-    let output = match crate::effective_path::new_command(&command)
-        .arg("--version")
+    let mut version_command = match external_tool_command(&command, &["--version"]) {
+        Ok(command) => command,
+        Err(_) => return false,
+    };
+    let output = match version_command
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .output()

--- a/crates/aft/src/format.rs
+++ b/crates/aft/src/format.rs
@@ -152,6 +152,25 @@ fn kill_process_tree(child: &mut Child) {
     let _ = child.kill();
 }
 
+/// Build the command used by formatter and checker subprocesses.
+fn external_tool_command(command: &str, args: &[&str]) -> Result<Command, FormatError> {
+    #[cfg(windows)]
+    if crate::windows_command::is_batch_file(Path::new(command)) {
+        return crate::windows_command::batch_command(
+            Path::new(command),
+            args.iter().map(|arg| std::ffi::OsStr::new(*arg)),
+        )
+        .map_err(|error| FormatError::Failed {
+            tool: command.to_string(),
+            stderr: error.to_string(),
+        });
+    }
+
+    let mut cmd = crate::effective_path::new_command(command);
+    cmd.args(args);
+    Ok(cmd)
+}
+
 /// Spawn a subprocess and wait for completion with timeout protection.
 ///
 /// Polls `try_wait()` at 50ms intervals. On timeout, kills the child process
@@ -163,8 +182,8 @@ pub fn run_external_tool(
     working_dir: Option<&Path>,
     timeout_secs: u32,
 ) -> Result<ExternalToolResult, FormatError> {
-    let mut cmd = crate::effective_path::new_command(command);
-    cmd.args(args).stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut cmd = external_tool_command(command, args)?;
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
 
     if let Some(dir) = working_dir {
         cmd.current_dir(dir);
@@ -1615,8 +1634,8 @@ pub fn run_external_tool_capture(
     working_dir: Option<&Path>,
     timeout_secs: u32,
 ) -> Result<ExternalToolResult, FormatError> {
-    let mut cmd = crate::effective_path::new_command(command);
-    cmd.args(args).stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut cmd = external_tool_command(command, args)?;
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
 
     if let Some(dir) = working_dir {
         cmd.current_dir(dir);
@@ -2425,6 +2444,19 @@ mod tests {
         let res = result.unwrap();
         assert_eq!(res.exit_code, 0);
         assert!(res.stdout.contains("hello"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn run_external_tool_invokes_npm_style_batch_shim() {
+        let temp = tempfile::tempdir().unwrap();
+        let shim = temp.path().join("formatter shim.cmd");
+        std::fs::write(&shim, "@echo off\r\necho %~1\r\n").unwrap();
+
+        let result =
+            run_external_tool(shim.to_str().unwrap(), &["--stdin-filepath"], None, 5).unwrap();
+
+        assert_eq!(result.stdout.trim(), "--stdin-filepath");
     }
 
     #[cfg(unix)]

--- a/crates/aft/src/lib.rs
+++ b/crates/aft/src/lib.rs
@@ -132,6 +132,7 @@ pub mod watcher_filter;
 // `commands::bash::try_spawn_with_fallback` can exercise the retry
 // decision logic without a real Windows runtime. The module itself only
 // uses portable APIs; only its callers are Windows-gated.
+pub(crate) mod windows_command;
 pub mod windows_shell;
 
 #[cfg(test)]

--- a/crates/aft/src/lsp/client.rs
+++ b/crates/aft/src/lsp/client.rs
@@ -34,13 +34,6 @@ const STDERR_LINE_BYTES: usize = 4 * 1024;
 type PendingMap = HashMap<RequestId, Sender<JsonRpcResponse>>;
 type WatchedFileRegistrations = Arc<Mutex<HashSet<String>>>;
 
-#[cfg(windows)]
-fn is_windows_batch_file(path: &Path) -> bool {
-    path.extension()
-        .and_then(|ext| ext.to_str())
-        .is_some_and(|ext| ext.eq_ignore_ascii_case("cmd") || ext.eq_ignore_ascii_case("bat"))
-}
-
 /// Lifecycle state of a language server.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ServerState {
@@ -178,17 +171,22 @@ impl LspClient {
         reclaim_root: Option<&Path>,
     ) -> io::Result<Self> {
         #[cfg(windows)]
-        let mut command = if is_windows_batch_file(binary) {
-            let mut command = Command::new("cmd.exe");
-            command.arg("/C").arg(binary.as_os_str());
-            command
+        let is_batch_file = crate::windows_command::is_batch_file(binary);
+        #[cfg(windows)]
+        let mut command = if is_batch_file {
+            crate::windows_command::batch_command(binary, args.iter())?
         } else {
             Command::new(binary)
         };
         #[cfg(not(windows))]
         let mut command = crate::effective_path::new_command(binary);
+        #[cfg(windows)]
+        if !is_batch_file {
+            command.args(args);
+        }
+        #[cfg(not(windows))]
+        command.args(args);
         command
-            .args(args)
             .current_dir(&root)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())

--- a/crates/aft/src/lsp/client.rs
+++ b/crates/aft/src/lsp/client.rs
@@ -195,7 +195,7 @@ impl LspClient {
             .stderr(Stdio::piped());
         for (key, value) in env {
             #[cfg(windows)]
-            if is_batch_file && crate::windows_command::is_batch_internal_env(key) {
+            if is_batch_file && crate::windows_command::is_batch_internal_env(key, args.len()) {
                 crate::slog_warn!(
                     "ignoring reserved batch-shim environment variable {key} for LSP server"
                 );

--- a/crates/aft/src/lsp/client.rs
+++ b/crates/aft/src/lsp/client.rs
@@ -194,6 +194,13 @@ impl LspClient {
             // actionable diagnostics without risking pipe-buffer deadlock.
             .stderr(Stdio::piped());
         for (key, value) in env {
+            #[cfg(windows)]
+            if is_batch_file && crate::windows_command::is_batch_internal_env(key) {
+                crate::slog_warn!(
+                    "ignoring reserved batch-shim environment variable {key} for LSP server"
+                );
+                continue;
+            }
             command.env(key, value);
         }
 

--- a/crates/aft/src/windows_command.rs
+++ b/crates/aft/src/windows_command.rs
@@ -27,11 +27,22 @@ pub(crate) fn is_batch_file(path: &Path) -> bool {
 /// Callers that add their own child environment must not override these values,
 /// because `cmd.exe` expands the command tail using them.
 #[cfg(windows)]
-pub(crate) fn is_batch_internal_env(key: &str) -> bool {
-    key.eq_ignore_ascii_case(BATCH_COMMAND_ENV)
-        || key
-            .to_ascii_uppercase()
-            .starts_with(BATCH_ARGUMENT_ENV_PREFIX)
+pub(crate) fn is_batch_internal_env(key: &str, argument_count: usize) -> bool {
+    if key.eq_ignore_ascii_case(BATCH_COMMAND_ENV) {
+        return true;
+    }
+
+    let Some(suffix) = key.get(BATCH_ARGUMENT_ENV_PREFIX.len()..) else {
+        return false;
+    };
+    if !key[..BATCH_ARGUMENT_ENV_PREFIX.len()].eq_ignore_ascii_case(BATCH_ARGUMENT_ENV_PREFIX) {
+        return false;
+    }
+
+    suffix
+        .parse::<usize>()
+        .ok()
+        .is_some_and(|index| index < argument_count && suffix == index.to_string())
 }
 
 /// Build a safe `cmd.exe` invocation for a `.cmd`/`.bat` shim.
@@ -49,7 +60,12 @@ where
 {
     use std::os::windows::process::CommandExt;
 
-    let command_path = binary.to_string_lossy();
+    let command_path = binary.to_str().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "batch path cannot be represented safely for cmd.exe",
+        )
+    })?;
     if command_path.contains(['\0', '\r', '\n', '"']) {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -60,7 +76,12 @@ where
     let mut command_line = format!("\"\"%{BATCH_COMMAND_ENV}%\"");
     let mut argument_env = Vec::new();
     for (index, arg) in args.into_iter().enumerate() {
-        let arg = arg.as_ref().to_string_lossy();
+        let arg = arg.as_ref().to_str().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "batch argument cannot be represented safely for cmd.exe",
+            )
+        })?;
         if arg.contains(['\0', '\r', '\n', '"']) {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -72,7 +93,7 @@ where
         command_line.push('%');
         command_line.push_str(&name);
         command_line.push_str("%\"");
-        argument_env.push((name, arg.into_owned()));
+        argument_env.push((name, arg.to_owned()));
     }
     command_line.push('"');
 
@@ -128,8 +149,23 @@ mod tests {
 
     #[test]
     fn launcher_environment_names_are_reserved() {
-        assert!(is_batch_internal_env("AFT_BATCH_COMMAND"));
-        assert!(is_batch_internal_env("aft_batch_argument_0"));
-        assert!(!is_batch_internal_env("AFT_BATCH_OTHER"));
+        assert!(is_batch_internal_env("AFT_BATCH_COMMAND", 1));
+        assert!(is_batch_internal_env("aft_batch_argument_0", 1));
+        assert!(!is_batch_internal_env("AFT_BATCH_ARGUMENT_1", 1));
+        assert!(!is_batch_internal_env("AFT_BATCH_ARGUMENT_00", 1));
+        assert!(!is_batch_internal_env("AFT_BATCH_OTHER", 1));
+    }
+
+    #[test]
+    fn batch_command_rejects_non_unicode_arguments() {
+        use std::os::windows::ffi::OsStringExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let shim = temp.path().join("formatter.cmd");
+        let invalid = std::ffi::OsString::from_wide(&[0xd800]);
+
+        let error = batch_command(&shim, [invalid]).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
     }
 }

--- a/crates/aft/src/windows_command.rs
+++ b/crates/aft/src/windows_command.rs
@@ -1,0 +1,90 @@
+//! Safe Windows process invocation for `.cmd` and `.bat` wrapper scripts.
+
+#[cfg(windows)]
+use std::ffi::OsStr;
+#[cfg(windows)]
+use std::io;
+#[cfg(windows)]
+use std::path::Path;
+#[cfg(windows)]
+use std::process::Command;
+
+#[cfg(windows)]
+const BATCH_COMMAND_ENV: &str = "AFT_BATCH_COMMAND";
+
+/// Whether `path` must be dispatched by `cmd.exe` on Windows.
+#[cfg(windows)]
+pub(crate) fn is_batch_file(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("cmd") || ext.eq_ignore_ascii_case("bat"))
+}
+
+/// Build a safe `cmd.exe` invocation for a `.cmd`/`.bat` shim.
+///
+/// Windows cannot spawn batch files directly. Passing a batch path and its arguments
+/// as separate `cmd /C` arguments is unreliable because `cmd.exe` reparses its
+/// command tail. Keep the executable path in the environment (so literal `%` in a
+/// path is not expanded), then pass one explicitly quoted command tail.
+#[cfg(windows)]
+pub(crate) fn batch_command<I, S>(binary: &Path, args: I) -> io::Result<Command>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    use std::os::windows::process::CommandExt;
+
+    let command_path = binary.to_string_lossy();
+    if command_path.contains(['\0', '\r', '\n', '"']) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "batch path cannot be represented safely for cmd.exe",
+        ));
+    }
+
+    let mut command_line = format!("\"\"%{BATCH_COMMAND_ENV}%\"");
+    for arg in args {
+        let arg = arg.as_ref().to_string_lossy();
+        if arg.contains(['\0', '\r', '\n', '"', '%']) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "batch argument cannot be represented safely for cmd.exe",
+            ));
+        }
+        command_line.push_str(" \"");
+        command_line.push_str(&arg);
+        command_line.push('"');
+    }
+    command_line.push('"');
+
+    let mut command = Command::new(
+        std::env::var_os("ComSpec")
+            .or_else(|| std::env::var_os("COMSPEC"))
+            .unwrap_or_else(|| "cmd.exe".into()),
+    );
+    command
+        .args(["/d", "/s", "/v:off", "/c"])
+        // `cmd.exe` must receive the complete command tail verbatim. Normal
+        // argument escaping would add another quoting layer and break paths
+        // containing spaces.
+        .raw_arg(command_line)
+        .env(BATCH_COMMAND_ENV, binary);
+    Ok(command)
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn batch_command_invokes_a_spaced_shim_with_args() {
+        let temp = tempfile::tempdir().unwrap();
+        let shim = temp.path().join("language server.cmd");
+        std::fs::write(&shim, "@echo off\r\necho %~1\r\n").unwrap();
+
+        let output = batch_command(&shim, ["--stdio"]).unwrap().output().unwrap();
+
+        assert!(output.status.success());
+        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "--stdio");
+    }
+}

--- a/crates/aft/src/windows_command.rs
+++ b/crates/aft/src/windows_command.rs
@@ -11,6 +11,8 @@ use std::process::Command;
 
 #[cfg(windows)]
 const BATCH_COMMAND_ENV: &str = "AFT_BATCH_COMMAND";
+#[cfg(windows)]
+const BATCH_ARGUMENT_ENV_PREFIX: &str = "AFT_BATCH_ARGUMENT_";
 
 /// Whether `path` must be dispatched by `cmd.exe` on Windows.
 #[cfg(windows)]
@@ -20,12 +22,25 @@ pub(crate) fn is_batch_file(path: &Path) -> bool {
         .is_some_and(|ext| ext.eq_ignore_ascii_case("cmd") || ext.eq_ignore_ascii_case("bat"))
 }
 
+/// Whether `key` is reserved for the batch-shim launcher.
+///
+/// Callers that add their own child environment must not override these values,
+/// because `cmd.exe` expands the command tail using them.
+#[cfg(windows)]
+pub(crate) fn is_batch_internal_env(key: &str) -> bool {
+    key.eq_ignore_ascii_case(BATCH_COMMAND_ENV)
+        || key
+            .to_ascii_uppercase()
+            .starts_with(BATCH_ARGUMENT_ENV_PREFIX)
+}
+
 /// Build a safe `cmd.exe` invocation for a `.cmd`/`.bat` shim.
 ///
 /// Windows cannot spawn batch files directly. Passing a batch path and its arguments
 /// as separate `cmd /C` arguments is unreliable because `cmd.exe` reparses its
-/// command tail. Keep the executable path in the environment (so literal `%` in a
-/// path is not expanded), then pass one explicitly quoted command tail.
+/// command tail. Keep the executable path and arguments in the environment (so
+/// literal `%` remains literal after single-pass expansion), then pass one
+/// explicitly quoted command tail.
 #[cfg(windows)]
 pub(crate) fn batch_command<I, S>(binary: &Path, args: I) -> io::Result<Command>
 where
@@ -43,17 +58,21 @@ where
     }
 
     let mut command_line = format!("\"\"%{BATCH_COMMAND_ENV}%\"");
-    for arg in args {
+    let mut argument_env = Vec::new();
+    for (index, arg) in args.into_iter().enumerate() {
         let arg = arg.as_ref().to_string_lossy();
-        if arg.contains(['\0', '\r', '\n', '"', '%']) {
+        if arg.contains(['\0', '\r', '\n', '"']) {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "batch argument cannot be represented safely for cmd.exe",
             ));
         }
+        let name = format!("{BATCH_ARGUMENT_ENV_PREFIX}{index}");
         command_line.push_str(" \"");
-        command_line.push_str(&arg);
-        command_line.push('"');
+        command_line.push('%');
+        command_line.push_str(&name);
+        command_line.push_str("%\"");
+        argument_env.push((name, arg.into_owned()));
     }
     command_line.push('"');
 
@@ -68,7 +87,8 @@ where
         // argument escaping would add another quoting layer and break paths
         // containing spaces.
         .raw_arg(command_line)
-        .env(BATCH_COMMAND_ENV, binary);
+        .env(BATCH_COMMAND_ENV, binary)
+        .envs(argument_env);
     Ok(command)
 }
 
@@ -86,5 +106,30 @@ mod tests {
 
         assert!(output.status.success());
         assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "--stdio");
+    }
+
+    #[test]
+    fn batch_command_preserves_percent_in_argument() {
+        let temp = tempfile::tempdir().unwrap();
+        let shim = temp.path().join("formatter.cmd");
+        std::fs::write(&shim, "@echo off\r\necho %~1\r\n").unwrap();
+
+        let output = batch_command(&shim, ["100%coverage%"])
+            .unwrap()
+            .output()
+            .unwrap();
+
+        assert!(output.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            "100%coverage%"
+        );
+    }
+
+    #[test]
+    fn launcher_environment_names_are_reserved() {
+        assert!(is_batch_internal_env("AFT_BATCH_COMMAND"));
+        assert!(is_batch_internal_env("aft_batch_argument_0"));
+        assert!(!is_batch_internal_env("AFT_BATCH_OTHER"));
     }
 }


### PR DESCRIPTION
## Summary
- launch npm-installed Windows .cmd/.bat LSP shims through cmd.exe safely
- reuse the launcher for formatter and checker subprocesses
- add Windows regressions for LSP and formatter batch shims

## Tests
- cargo fmt --check
- cargo test -p agent-file-tools format::tests --lib
- cargo test -p agent-file-tools lsp::client::tests --lib

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790963926&installation_model_id=22398&pr_number=287&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F287&signature=824cbcc2cce86b2481b663182ee0582944c75f1d74f6f7f9ac324621d1cee84f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Windows `.cmd`/`.bat` shims previously failed or launched unreliably for LSP servers and external tools; they now run through a shared `cmd.exe` launcher that preserves spaced paths, arguments, and literal `%` values. Batch LSP launches also prevent caller-provided environment variables from overriding launcher internals.

- Reuses the launcher for formatters, checkers, and Ruff version checks.
- Rejects unsafe batch paths and arguments that cannot be represented safely.
- Adds Windows regressions for spaced shim paths, percent-containing arguments, and reserved environment variables.

<sup>Written for commit 38d2cb1e29fac16d50f49f956bb5321f91d79926. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds a shared Windows batch-shim launcher and uses it for LSP, formatter, checker, and Ruff-version subprocesses.
- Routes `.cmd` and `.bat` tools through `cmd.exe` with paths and arguments transported through reserved environment variables.
- Prevents LSP-provided environment values from overriding active launcher variables.
- Adds Windows regression coverage for spaced shim paths, literal percent arguments, formatter invocation, and invalid Unicode input.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/aft/src/windows_command.rs | Introduces the shared Windows batch launcher, reserved-environment detection, input validation, and focused regression tests. |
| crates/aft/src/format.rs | Routes formatter, checker, capture, and Ruff-version subprocesses through the shared launcher when the selected Windows tool is a batch shim. |
| crates/aft/src/lsp/client.rs | Replaces direct `cmd.exe` batch launching with the shared helper and protects active launcher environment variables from caller overrides. |
| crates/aft/src/lib.rs | Registers the new internal Windows command module. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Caller["LSP / formatter / checker"] --> Detect{".cmd or .bat on Windows?"}
  Detect -->|No| Direct["Launch tool directly"]
  Detect -->|Yes| Encode["Store tool path and arguments in reserved environment variables"]
  Encode --> Cmd["Launch cmd.exe /d /s /v:off /c"]
  Cmd --> Shim["Run batch shim with expanded quoted arguments"]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: scope Windows batch shim environmen..."](https://github.com/cortexkit/aft/commit/38d2cb1e29fac16d50f49f956bb5321f91d79926) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59615116)</sub>

<!-- /greptile_comment -->