### PR TITLE
ci-probe: Windows sweep after train 20b (do not merge)

### DIFF
--- a/crates/aft/src/callgraph_store/disk_facts.rs
+++ b/crates/aft/src/callgraph_store/disk_facts.rs
@@ -67,6 +67,10 @@ impl ProjectFacts for DiskFacts {
             path.strip_prefix(&self.project_root).unwrap_or(&path),
         ))
     }
+    fn canonical_path(&self, root: &Path, rel: &[u8]) -> Option<PathBuf> {
+        let path = root.join(byte_path(rel));
+        Some(super::canonicalize_path(&path))
+    }
     fn list_dir(&self, rel: &[u8]) -> Vec<DirEntry> {
         let dir = self.project_root.join(byte_path(rel));
         let Ok(boundary) = crate::walk_boundary::DeviceBoundary::for_root(&self.project_root)

--- a/crates/aft/src/callgraph_store/facts.rs
+++ b/crates/aft/src/callgraph_store/facts.rs
@@ -29,6 +29,9 @@ pub(crate) trait ProjectFacts {
     fn config_bytes(&self, rel: &[u8]) -> Option<Arc<[u8]>>;
     fn symlink_target(&self, rel: &[u8]) -> Option<&[u8]>;
     fn canonical(&self, rel: &[u8]) -> Option<Vec<u8>>;
+    fn canonical_path(&self, root: &Path, rel: &[u8]) -> Option<PathBuf> {
+        Some(root.join(byte_path(&self.canonical(rel)?)))
+    }
     fn list_dir(&self, rel: &[u8]) -> Vec<DirEntry>;
 }
 
@@ -197,10 +200,7 @@ impl FactPaths<'_> {
         self.facts.config_bytes(&self.rel(path)?)
     }
     pub fn canonical(&self, path: &Path) -> Option<PathBuf> {
-        Some(
-            self.root
-                .join(byte_path(&self.facts.canonical(&self.rel(path)?)?)),
-        )
+        self.facts.canonical_path(self.root, &self.rel(path)?)
     }
     pub fn list_dir(&self, path: &Path) -> Vec<DirEntry> {
         self.rel(path)

--- a/crates/aft/src/executor/tests.rs
+++ b/crates/aft/src/executor/tests.rs
@@ -2604,7 +2604,6 @@ fn bind_blocker_snapshot_labels_reader_parked_before_execution_as_zombie() {
         "parked-before-execution".to_string(),
         Box::new(|_| ok("parked-before-execution")),
     );
-    let deadline = Instant::now() + Duration::from_secs(1);
     loop {
         let admitted = executor
             .inner
@@ -2616,8 +2615,7 @@ fn bind_blocker_snapshot_labels_reader_parked_before_execution_as_zombie() {
         if admitted {
             break;
         }
-        assert!(Instant::now() < deadline, "reader was not dispatched");
-        std::thread::sleep(Duration::from_millis(2));
+        std::thread::yield_now();
     }
 
     let bind = executor.submit(
@@ -2626,9 +2624,13 @@ fn bind_blocker_snapshot_labels_reader_parked_before_execution_as_zombie() {
         "subc-bind-zombie-census".to_string(),
         Box::new(|_| ok("subc-bind-zombie-census")),
     );
-    let snapshot = executor
-        .try_bind_blocker_snapshot(&root, "subc-bind-zombie-census")
-        .expect("zombie bind blocker snapshot");
+    let snapshot = loop {
+        if let Some(snapshot) = executor.try_bind_blocker_snapshot(&root, "subc-bind-zombie-census")
+        {
+            break snapshot;
+        }
+        std::thread::yield_now();
+    };
     assert!(snapshot
         .blockers
         .iter()

--- a/crates/aft/src/executor/tests.rs
+++ b/crates/aft/src/executor/tests.rs
@@ -2604,6 +2604,9 @@ fn bind_blocker_snapshot_labels_reader_parked_before_execution_as_zombie() {
         "parked-before-execution".to_string(),
         Box::new(|_| ok("parked-before-execution")),
     );
+    // Bounded: a reader that never dispatches must fail the test, not hang it.
+    // The bound is generous because it measures CI scheduling, not our code.
+    let deadline = Instant::now() + Duration::from_secs(30);
     loop {
         let admitted = executor
             .inner
@@ -2615,6 +2618,10 @@ fn bind_blocker_snapshot_labels_reader_parked_before_execution_as_zombie() {
         if admitted {
             break;
         }
+        assert!(
+            Instant::now() < deadline,
+            "reader was not dispatched within 30s"
+        );
         std::thread::yield_now();
     }
 
@@ -2624,11 +2631,17 @@ fn bind_blocker_snapshot_labels_reader_parked_before_execution_as_zombie() {
         "subc-bind-zombie-census".to_string(),
         Box::new(|_| ok("subc-bind-zombie-census")),
     );
+    // The snapshot is a try-lock read; under contention it returns None until
+    // the scheduler releases the state lock, so retry - but bounded.
     let snapshot = loop {
         if let Some(snapshot) = executor.try_bind_blocker_snapshot(&root, "subc-bind-zombie-census")
         {
             break snapshot;
         }
+        assert!(
+            Instant::now() < deadline,
+            "zombie bind blocker snapshot not readable within 30s"
+        );
         std::thread::yield_now();
     };
     assert!(snapshot

--- a/crates/aft/src/views/mod.rs
+++ b/crates/aft/src/views/mod.rs
@@ -837,7 +837,7 @@ fn checkpoint_and_sync_database(
     // Open directly and treat NotFound as "nothing left to sync" instead of
     // probing first.
     let wal_path = PathBuf::from(format!("{}-wal", path.display()));
-    match File::open(&wal_path) {
+    match open_file_for_sync(&wal_path) {
         Ok(file) => file.sync_all()?,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
         Err(error) => return Err(ViewError::Io(error)),
@@ -903,8 +903,21 @@ fn sync_file_and_parent(path: &Path) -> Result<()> {
 }
 
 fn sync_file(path: &Path) -> Result<()> {
-    File::open(path)?.sync_all()?;
+    open_file_for_sync(path)?.sync_all()?;
     Ok(())
+}
+
+fn open_file_for_sync(path: &Path) -> std::io::Result<File> {
+    #[cfg(windows)]
+    {
+        // FlushFileBuffers rejects read-only handles, so Windows must open
+        // durability inputs for writing even though no bytes are changed.
+        OpenOptions::new().write(true).open(path)
+    }
+    #[cfg(not(windows))]
+    {
+        File::open(path)
+    }
 }
 
 fn sync_parent(path: &Path) -> Result<()> {
@@ -971,6 +984,15 @@ mod tests {
             failures.is_empty(),
             "concurrent artifact checkpoints must wait out the WAL switch: {failures:?}"
         );
+    }
+
+    #[test]
+    fn sync_file_flushes_an_existing_artifact() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let artifact = dir.path().join("artifact.bin");
+        fs::write(&artifact, b"durable").expect("artifact");
+
+        sync_file(&artifact).expect("flush pre-existing artifact");
     }
 
     #[test]

--- a/crates/aft/tests/integration/bash_pty_test.rs
+++ b/crates/aft/tests/integration/bash_pty_test.rs
@@ -10,6 +10,7 @@ use aft::bash_background::pty_runtime::CompletionCoordinator;
 use aft::bash_background::{BgCompletion, BgTaskRegistry, BgTaskStatus};
 use serde_json::json;
 
+#[cfg(unix)]
 use super::helpers::ReleaseOnDrop;
 
 const SESSION: &str = "pty-phase-1a";

--- a/crates/aft/tests/integration/bash_watch_test.rs
+++ b/crates/aft/tests/integration/bash_watch_test.rs
@@ -1,3 +1,4 @@
+#[cfg(unix)]
 use std::fs;
 use std::path::Path;
 use std::time::{Duration, Instant};

--- a/packages/aft-bridge/src/__tests__/paths.test.ts
+++ b/packages/aft-bridge/src/__tests__/paths.test.ts
@@ -34,10 +34,21 @@ describe("CortexKit config paths", () => {
   const originalUserProfile = process.env.USERPROFILE;
   const originalXdg = process.env.XDG_CONFIG_HOME;
 
+  // `process.env.KEY = undefined` stores the string "undefined"; a variable that
+  // was unset before the test must be deleted so later-spawned processes do not
+  // inherit USERPROFILE=undefined (or XDG_CONFIG_HOME=undefined on macOS).
+  const restoreEnv = (key: string, value: string | undefined) => {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  };
+
   afterEach(() => {
-    process.env.HOME = originalHome;
-    process.env.USERPROFILE = originalUserProfile;
-    process.env.XDG_CONFIG_HOME = originalXdg;
+    restoreEnv("HOME", originalHome);
+    restoreEnv("USERPROFILE", originalUserProfile);
+    restoreEnv("XDG_CONFIG_HOME", originalXdg);
   });
 
   test("user config honors absolute XDG_CONFIG_HOME", () => {

--- a/packages/opencode-plugin/src/__tests__/configure-tiers-shape.test.ts
+++ b/packages/opencode-plugin/src/__tests__/configure-tiers-shape.test.ts
@@ -92,14 +92,29 @@ function representativeProcessState(root: string): Record<string, unknown> {
   };
 }
 
+/**
+ * Assigning `undefined` to a `process.env` key stores the string "undefined"
+ * (Node and Bun both stringify), so a variable that was unset before the test
+ * comes back as `XDG_CONFIG_HOME=undefined` for every process this test file's
+ * successors spawn - the login-shell PATH probe then ran fish with that value
+ * and fish created `./undefined/fish/` inside the repository. Unset means delete.
+ */
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}
+
 afterEach(() => {
   for (const root of tempRoots) {
     rmSync(root, { recursive: true, force: true });
   }
   tempRoots.clear();
-  process.env.HOME = originalEnv.HOME;
-  process.env.XDG_CONFIG_HOME = originalEnv.XDG_CONFIG_HOME;
-  process.env.OPENCODE_CONFIG_DIR = originalEnv.OPENCODE_CONFIG_DIR;
+  restoreEnv("HOME", originalEnv.HOME);
+  restoreEnv("XDG_CONFIG_HOME", originalEnv.XDG_CONFIG_HOME);
+  restoreEnv("OPENCODE_CONFIG_DIR", originalEnv.OPENCODE_CONFIG_DIR);
   __resetConfigureWarningQueuesForTests();
 });
 

--- a/packages/pi-plugin/src/__tests__/configure-tiers-shape.test.ts
+++ b/packages/pi-plugin/src/__tests__/configure-tiers-shape.test.ts
@@ -92,9 +92,23 @@ afterEach(() => {
     rmSync(root, { recursive: true, force: true });
   }
   tempRoots.clear();
-  process.env.HOME = originalHome;
-  process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+  restoreEnv("HOME", originalHome);
+  restoreEnv("XDG_CONFIG_HOME", originalXdgConfigHome);
 });
+
+/**
+ * `process.env.KEY = undefined` stores the string "undefined" (Node and Bun both
+ * stringify), which then reaches every process spawned by later test files in
+ * the run. A variable that was unset before the test must be deleted, not
+ * assigned back.
+ */
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}
 
 describe("Pi configure config tiers cutover", () => {
   test("sends raw config tiers plus process-state keys and no resolved core-domain flat params", () => {


### PR DESCRIPTION
Probe branch to run the Windows lanes on the sweep fixes; merged via cherry-pick onto main, this PR closes without merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791219484&installation_model_id=22398&pr_number=296&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F296&signature=61600b92c51171b34d5d71a8e5d66d519dac9ca32e8f5321ba59222ed8713fc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Probe branch to run Windows CI on the sweep fixes; the changes land on main via cherry-pick and this PR closes without merging.

**Windows fixes**
- Open durability handles with write access so `FlushFileBuffers` works on read-only files.
- Add `canonical_path` to preserve canonical path rendering on Windows.
- Gate Unix-only test imports with `#[cfg(unix)]`.

**Test stability**
- Bound zombie-census waits at 30 seconds so they fail instead of hanging.
- Restore unset env vars by deleting them; assigning `undefined` leaked the literal string "undefined" to child processes.

<sup>Written for commit 71035a370e74ad4369d09db84c8b14d75277bcbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

