### PR TITLE
fix(windows): preserve unsupported verbatim namespaces

### DIFF
--- a/crates/aft/src/inspect/job.rs
+++ b/crates/aft/src/inspect/job.rs
@@ -814,7 +814,7 @@ pub(crate) fn normalize_path(path: &Path) -> PathBuf {
     // normalizers must stay in agreement or membership/strip_prefix checks
     // that cross the engine boundary silently miss on Windows.
     #[cfg(windows)]
-    let path = &windows_non_verbatim_path(path);
+    let path = &crate::windows_path::normalize_windows_path(path);
 
     let mut result = PathBuf::new();
     for component in path.components() {
@@ -842,27 +842,6 @@ pub(crate) fn canonicalize_normalized(path: &Path) -> PathBuf {
         Ok(canonical) => normalize_path(&canonical),
         Err(_) => normalize_path(path),
     }
-}
-
-#[cfg(windows)]
-fn windows_non_verbatim_path(path: &Path) -> PathBuf {
-    let mut raw = path.to_string_lossy().replace('/', "\\");
-    if let Some(stripped) = raw.strip_prefix("\\\\?\\UNC\\") {
-        raw = format!("\\\\{stripped}");
-    } else if let Some(stripped) = raw.strip_prefix("\\\\?\\") {
-        raw = stripped.to_string();
-    } else if let Some(stripped) = raw.strip_prefix("\\\\??\\") {
-        raw = stripped.to_string();
-    }
-
-    if raw.as_bytes().get(1) == Some(&b':') {
-        let drive = raw.as_bytes()[0];
-        if drive.is_ascii_lowercase() {
-            raw.replace_range(0..1, &(drive as char).to_ascii_uppercase().to_string());
-        }
-    }
-
-    PathBuf::from(raw)
 }
 
 #[cfg(test)]

--- a/crates/aft/src/inspect/oxc_engine/resolver.rs
+++ b/crates/aft/src/inspect/oxc_engine/resolver.rs
@@ -639,7 +639,7 @@ fn remap_build_output_to_src(rel: &str) -> Option<String> {
 
 #[cfg(windows)]
 pub fn normalize_path(path: &Path) -> PathBuf {
-    normalize_path_components(&windows_non_verbatim_path(path))
+    normalize_path_components(&crate::windows_path::normalize_windows_path(path))
 }
 
 #[cfg(not(windows))]
@@ -659,35 +659,6 @@ fn normalize_path_components(path: &Path) -> PathBuf {
         }
     }
     normalized
-}
-
-#[cfg(windows)]
-fn windows_non_verbatim_path(path: &Path) -> PathBuf {
-    let mut raw = path.to_string_lossy().replace('/', "\\");
-    if let Some(stripped) = strip_ascii_prefix(&raw, "\\\\?\\UNC\\") {
-        raw = format!("\\\\{}", stripped);
-    } else if let Some(stripped) = strip_ascii_prefix(&raw, "\\\\?\\") {
-        raw = stripped.to_string();
-    } else if let Some(stripped) = strip_ascii_prefix(&raw, "\\\\??\\") {
-        raw = stripped.to_string();
-    }
-
-    if raw.as_bytes().get(1) == Some(&b':') {
-        let drive = raw.as_bytes()[0];
-        if drive.is_ascii_lowercase() {
-            raw.replace_range(0..1, &(drive as char).to_ascii_uppercase().to_string());
-        }
-    }
-
-    PathBuf::from(raw)
-}
-
-#[cfg(windows)]
-fn strip_ascii_prefix<'a>(value: &'a str, prefix: &str) -> Option<&'a str> {
-    value
-        .get(..prefix.len())
-        .is_some_and(|head| head.eq_ignore_ascii_case(prefix))
-        .then(|| &value[prefix.len()..])
 }
 
 fn slash_path(path: &Path) -> String {

--- a/crates/aft/src/lib.rs
+++ b/crates/aft/src/lib.rs
@@ -148,6 +148,7 @@ pub mod watcher_filter;
 // decision logic without a real Windows runtime. The module itself only
 // uses portable APIs; only its callers are Windows-gated.
 pub(crate) mod windows_command;
+pub mod windows_path;
 pub mod windows_shell;
 
 #[cfg(test)]

--- a/crates/aft/src/lsp/position.rs
+++ b/crates/aft/src/lsp/position.rs
@@ -171,13 +171,7 @@ pub fn uri_to_path(uri: &lsp_types::Uri) -> Option<PathBuf> {
 }
 
 fn normalize_windows_path_for_uri(path: &str) -> String {
-    if let Some(stripped) = path.strip_prefix(r"\\?\UNC\") {
-        format!(r"\\{}", stripped)
-    } else if let Some(stripped) = path.strip_prefix(r"\\?\") {
-        stripped.to_string()
-    } else {
-        path.to_string()
-    }
+    crate::windows_path::non_verbatim_path_text(path).unwrap_or_else(|| path.to_string())
 }
 
 fn split_unc_path(path: &str) -> Option<(&str, &str)> {
@@ -339,6 +333,12 @@ mod tests {
             url_to_path(&uri).expect("path"),
             PathBuf::from(r"\\server\share\dir\file.rs")
         );
+    }
+
+    #[test]
+    fn windows_extended_volume_path_is_not_misrepresented_as_a_file_uri() {
+        let path = Path::new(r"\\?\Volume{1234}\repo\main.rs");
+        assert!(path_to_uri(path).is_err());
     }
 
     // Unix-absolute path syntax; not a valid Windows absolute path so the

--- a/crates/aft/src/windows_command.rs
+++ b/crates/aft/src/windows_command.rs
@@ -77,7 +77,8 @@ where
     // batch file through that namespace, and npm shims additionally derive
     // `%~dp0` paths that fail with "The system cannot find the path specified."
     // Convert only the namespace spelling; the path remains canonical.
-    let command_path = cmd_compatible_path(command_path);
+    let command_path = crate::windows_path::non_verbatim_path_text(command_path)
+        .unwrap_or_else(|| command_path.to_string());
 
     let mut command_line = format!("\"\"%{BATCH_COMMAND_ENV}%\"");
     let mut argument_env = Vec::new();
@@ -119,49 +120,6 @@ where
     Ok(command)
 }
 
-#[cfg(windows)]
-fn cmd_compatible_path(path: &str) -> String {
-    for prefix in [r"\\?\UNC\", r"\\??\UNC\", r"\??\UNC\"] {
-        if let Some(tail) = strip_ascii_prefix(path, prefix) {
-            let mut components = tail
-                .split(['\\', '/'])
-                .filter(|component| !component.is_empty());
-            if components.next().is_some() && components.next().is_some() {
-                return format!(r"\\{tail}");
-            }
-            return path.to_string();
-        }
-    }
-
-    for prefix in [r"\\?\", r"\\??\", r"\??\"] {
-        if let Some(tail) = strip_ascii_prefix(path, prefix) {
-            let bytes = tail.as_bytes();
-            if bytes.len() >= 3
-                && bytes[0].is_ascii_alphabetic()
-                && bytes[1] == b':'
-                && matches!(bytes[2], b'\\' | b'/')
-            {
-                return tail.to_string();
-            }
-            // Namespaces such as `\\?\Volume{GUID}\` cannot be safely
-            // converted into a DOS path by dropping their prefix.
-            return path.to_string();
-        }
-    }
-
-    path.to_string()
-}
-
-#[cfg(windows)]
-fn strip_ascii_prefix<'a>(value: &'a str, prefix: &str) -> Option<&'a str> {
-    let head = value.get(..prefix.len())?;
-    if head.eq_ignore_ascii_case(prefix) {
-        value.get(prefix.len()..)
-    } else {
-        None
-    }
-}
-
 #[cfg(all(test, windows))]
 mod tests {
     use super::*;
@@ -169,16 +127,16 @@ mod tests {
     #[test]
     fn cmd_compatible_path_only_converts_dos_and_unc_namespaces() {
         assert_eq!(
-            cmd_compatible_path(r"\\?\C:\cache\server.cmd"),
+            crate::windows_path::non_verbatim_path_text(r"\\?\C:\cache\server.cmd").unwrap(),
             r"C:\cache\server.cmd"
         );
         assert_eq!(
-            cmd_compatible_path(r"\\?\unc\host\share\server.cmd"),
+            crate::windows_path::non_verbatim_path_text(r"\\?\unc\host\share\server.cmd").unwrap(),
             r"\\host\share\server.cmd"
         );
         assert_eq!(
-            cmd_compatible_path(r"\\?\Volume{1234}\server.cmd"),
-            r"\\?\Volume{1234}\server.cmd"
+            crate::windows_path::non_verbatim_path_text(r"\\?\Volume{1234}\server.cmd"),
+            None
         );
     }
 

--- a/crates/aft/src/windows_path.rs
+++ b/crates/aft/src/windows_path.rs
@@ -1,0 +1,100 @@
+//! Windows extended-length path normalization.
+//!
+//! `std::fs::canonicalize` returns paths in the extended-length namespace on
+//! Windows. Only DOS-drive and UNC names have a safe non-verbatim spelling;
+//! other namespaces (for example `\\?\Volume{GUID}\`) must retain their prefix.
+
+use std::path::{Path, PathBuf};
+
+/// Normalize a Windows path for comparisons and Win32 APIs.
+///
+/// Valid DOS and UNC extended-length paths lose their verbatim prefix. Other
+/// namespaces remain untouched because they cannot be represented safely
+/// without that prefix. Separators and drive letter casing are also normalized.
+pub fn normalize_windows_path(path: &Path) -> PathBuf {
+    let raw = path.to_string_lossy().replace('/', "\\");
+    let mut normalized = non_verbatim_path_text(&raw).unwrap_or(raw);
+    if normalized.as_bytes().get(1) == Some(&b':') {
+        let drive = normalized.as_bytes()[0];
+        if drive.is_ascii_lowercase() {
+            normalized.replace_range(0..1, &(drive as char).to_ascii_uppercase().to_string());
+        }
+    }
+    PathBuf::from(normalized)
+}
+
+/// String form of the strict verbatim-prefix conversion, for APIs that require a command line
+/// or URI rather than a [`Path`].
+pub fn non_verbatim_path_text(path: &str) -> Option<String> {
+    for prefix in [r"\\?\UNC\", r"\\??\UNC\", r"\??\UNC\"] {
+        if let Some(tail) = strip_ascii_prefix(path, prefix) {
+            let mut components = tail
+                .split(['\\', '/'])
+                .filter(|component| !component.is_empty());
+            if components.next().is_some() && components.next().is_some() {
+                return Some(format!(r"\\{tail}"));
+            }
+            return None;
+        }
+    }
+
+    for prefix in [r"\\?\", r"\\??\", r"\??\"] {
+        if let Some(tail) = strip_ascii_prefix(path, prefix) {
+            let bytes = tail.as_bytes();
+            if bytes.len() >= 3
+                && bytes[0].is_ascii_alphabetic()
+                && bytes[1] == b':'
+                && matches!(bytes[2], b'\\' | b'/')
+            {
+                return Some(tail.to_string());
+            }
+            return None;
+        }
+    }
+
+    None
+}
+
+fn strip_ascii_prefix<'a>(value: &'a str, prefix: &str) -> Option<&'a str> {
+    let head = value.get(..prefix.len())?;
+    if head.eq_ignore_ascii_case(prefix) {
+        value.get(prefix.len()..)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{non_verbatim_path_text, normalize_windows_path};
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn converts_only_valid_dos_and_unc_verbatim_paths() {
+        assert_eq!(
+            non_verbatim_path_text(r"\\?\C:\cache\server.cmd"),
+            Some(r"C:\cache\server.cmd".to_string())
+        );
+        assert_eq!(
+            non_verbatim_path_text(r"\\?\unc\host\share\server.cmd"),
+            Some(r"\\host\share\server.cmd".to_string())
+        );
+        assert_eq!(
+            normalize_windows_path(Path::new(r"\\??\d:\repo")),
+            PathBuf::from(r"D:\repo")
+        );
+    }
+
+    #[test]
+    fn preserves_unsupported_or_malformed_verbatim_namespaces() {
+        for path in [
+            r"\\?\Volume{1234}\server.cmd",
+            r"\\?\UNC\host",
+            r"\\?\C:relative",
+            r"\\?\relative",
+            r"C:\ordinary\path",
+        ] {
+            assert_eq!(non_verbatim_path_text(path), None, "{path}");
+        }
+    }
+}

--- a/crates/aft/src/windows_path.rs
+++ b/crates/aft/src/windows_path.rs
@@ -28,10 +28,7 @@ pub fn normalize_windows_path(path: &Path) -> PathBuf {
 pub fn non_verbatim_path_text(path: &str) -> Option<String> {
     for prefix in [r"\\?\UNC\", r"\\??\UNC\", r"\??\UNC\"] {
         if let Some(tail) = strip_ascii_prefix(path, prefix) {
-            let mut components = tail
-                .split(['\\', '/'])
-                .filter(|component| !component.is_empty());
-            if components.next().is_some() && components.next().is_some() {
+            if is_safe_unc_tail(tail) {
                 return Some(format!(r"\\{tail}"));
             }
             return None;
@@ -45,6 +42,7 @@ pub fn non_verbatim_path_text(path: &str) -> Option<String> {
                 && bytes[0].is_ascii_alphabetic()
                 && bytes[1] == b':'
                 && matches!(bytes[2], b'\\' | b'/')
+                && !has_dot_component(tail)
             {
                 return Some(tail.to_string());
             }
@@ -53,6 +51,18 @@ pub fn non_verbatim_path_text(path: &str) -> Option<String> {
     }
 
     None
+}
+
+fn is_safe_unc_tail(tail: &str) -> bool {
+    let mut components = tail.split(['\\', '/']);
+    components.next().is_some_and(|server| !server.is_empty())
+        && components.next().is_some_and(|share| !share.is_empty())
+        && !has_dot_component(tail)
+}
+
+fn has_dot_component(path: &str) -> bool {
+    path.split(['\\', '/'])
+        .any(|component| matches!(component, "." | ".."))
 }
 
 fn strip_ascii_prefix<'a>(value: &'a str, prefix: &str) -> Option<&'a str> {
@@ -90,6 +100,10 @@ mod tests {
         for path in [
             r"\\?\Volume{1234}\server.cmd",
             r"\\?\UNC\host",
+            r"\\?\UNC\\host\share",
+            r"\\??\UNC\\host\share",
+            r"\\?\UNC\host\share\..\file",
+            r"\\?\C:\repo\..\other",
             r"\\?\C:relative",
             r"\\?\relative",
             r"C:\ordinary\path",

--- a/packages/aft-bridge/src/__tests__/project-identity.test.ts
+++ b/packages/aft-bridge/src/__tests__/project-identity.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync, realpathSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { canonicalizeProjectRoot, projectRootKeyHash } from "../project-identity.js";
+import {
+  canonicalizeProjectRoot,
+  normalizeWindowsRoot,
+  projectRootKeyHash,
+} from "../project-identity.js";
 
 describe("project-identity canonicalization", () => {
   test("trailing separators collapse to one identity", () => {
@@ -77,5 +81,22 @@ describe("project-identity canonicalization", () => {
     const missing = join(tmpdir(), "aft-pid-definitely-missing-xyz", "sub", "..");
     expect(() => canonicalizeProjectRoot(missing)).not.toThrow();
     expect(projectRootKeyHash(missing)).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  test("Windows verbatim normalization converts only safe DOS and UNC namespaces", () => {
+    const win32 = "win32";
+    expect(normalizeWindowsRoot("\\\\?\\c:\\repo", win32)).toBe("C:\\repo");
+    expect(normalizeWindowsRoot("\\\\?\\UNC\\server\\share\\repo", win32)).toBe(
+      "\\\\server\\share\\repo",
+    );
+    for (const path of [
+      "\\\\?\\Volume{1234}\\repo",
+      "\\\\?\\UNC\\\\server\\share",
+      "\\\\??\\UNC\\\\server\\share",
+      "\\\\?\\C:\\repo\\..\\other",
+      "\\\\?\\UNC\\server\\share\\.\\repo",
+    ]) {
+      expect(normalizeWindowsRoot(path, win32)).toBe(path);
+    }
   });
 });

--- a/packages/aft-bridge/src/project-identity.ts
+++ b/packages/aft-bridge/src/project-identity.ts
@@ -35,18 +35,27 @@ export function canonicalizeProjectRoot(dir: string): string {
 }
 
 /**
- * Strip Windows extended-length verbatim prefixes (`\\?\`, `\\?\UNC\`) and
- * uppercase a lowercase drive letter so `c:\x` and `C:\x` collapse to one
- * identity. Mirrors `cortexkit-paths`' `windows_non_verbatim_path`. No-op off
- * Windows.
+ * Strip only safely convertible Windows extended-length DOS and UNC prefixes,
+ * and uppercase a lowercase drive letter so `c:\x` and `C:\x` collapse to one
+ * identity. Namespaces such as `\\?\Volume{GUID}\` must retain their prefix.
+ * No-op off Windows.
  */
 function normalizeWindowsRoot(p: string): string {
   if (process.platform !== "win32") return p;
   let s = p;
-  if (s.startsWith("\\\\?\\UNC\\")) {
-    s = `\\\\${s.slice("\\\\?\\UNC\\".length)}`;
-  } else if (s.startsWith("\\\\?\\")) {
-    s = s.slice("\\\\?\\".length);
+  const lower = s.toLowerCase();
+  const uncPrefix = ["\\\\?\\unc\\", "\\\\??\\unc\\", "\\??\\unc\\"].find((prefix) =>
+    lower.startsWith(prefix),
+  );
+  if (uncPrefix) {
+    const tail = s.slice(uncPrefix.length);
+    if (tail.split(/[\\/]+/).filter(Boolean).length >= 2) s = `\\\\${tail}`;
+  } else {
+    const dosPrefix = ["\\\\?\\", "\\\\??\\", "\\??\\"].find((prefix) => lower.startsWith(prefix));
+    if (dosPrefix) {
+      const tail = s.slice(dosPrefix.length);
+      if (/^[a-z]:[\\/]/i.test(tail)) s = tail;
+    }
   }
   if (s.length >= 2 && s[1] === ":") {
     const drive = s.charCodeAt(0);

--- a/packages/aft-bridge/src/project-identity.ts
+++ b/packages/aft-bridge/src/project-identity.ts
@@ -38,10 +38,10 @@ export function canonicalizeProjectRoot(dir: string): string {
  * Strip only safely convertible Windows extended-length DOS and UNC prefixes,
  * and uppercase a lowercase drive letter so `c:\x` and `C:\x` collapse to one
  * identity. Namespaces such as `\\?\Volume{GUID}\` must retain their prefix.
- * No-op off Windows.
+ * `platform` is injectable for cross-platform regression tests. No-op off Windows.
  */
-function normalizeWindowsRoot(p: string): string {
-  if (process.platform !== "win32") return p;
+export function normalizeWindowsRoot(p: string, platform = process.platform): string {
+  if (platform !== "win32") return p;
   let s = p;
   const lower = s.toLowerCase();
   const uncPrefix = ["\\\\?\\unc\\", "\\\\??\\unc\\", "\\??\\unc\\"].find((prefix) =>
@@ -49,12 +49,14 @@ function normalizeWindowsRoot(p: string): string {
   );
   if (uncPrefix) {
     const tail = s.slice(uncPrefix.length);
-    if (tail.split(/[\\/]+/).filter(Boolean).length >= 2) s = `\\\\${tail}`;
+    if (/^[^\\/]+[\\/][^\\/]+(?:[\\/]|$)/.test(tail) && !hasDotComponent(tail)) {
+      s = `\\\\${tail}`;
+    }
   } else {
     const dosPrefix = ["\\\\?\\", "\\\\??\\", "\\??\\"].find((prefix) => lower.startsWith(prefix));
     if (dosPrefix) {
       const tail = s.slice(dosPrefix.length);
-      if (/^[a-z]:[\\/]/i.test(tail)) s = tail;
+      if (/^[a-z]:[\\/]/i.test(tail) && !hasDotComponent(tail)) s = tail;
     }
   }
   if (s.length >= 2 && s[1] === ":") {
@@ -64,6 +66,10 @@ function normalizeWindowsRoot(p: string): string {
     }
   }
   return s;
+}
+
+function hasDotComponent(path: string): boolean {
+  return path.split(/[\\/]/).some((component) => component === "." || component === "..");
 }
 
 /**


### PR DESCRIPTION
## Summary
- centralize strict Windows verbatim-path conversion for only valid DOS and UNC namespaces
- update inspect normalization, LSP URI rendering, batch-shim execution, and bridge root identity to preserve unsupported namespaces such as `\\?\Volume{GUID}\`
- add regression coverage for malformed and unsupported namespace spellings

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p agent-file-tools --lib windows_path`
- `cargo test -p agent-file-tools --lib windows_extended_`
- `bun x @biomejs/biome check packages/aft-bridge/src/project-identity.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/aft/pr/302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791430234&installation_model_id=22398&pr_number=302&repository=cortexkit%2Faft&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Faft%2Fpull%2F302&signature=51305785cf7a56033b301a4c42f4a495f323d3d2b2c21186408a95ab5462984d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows extended-length path normalization so only valid DOS and UNC namespaces lose their `\\?\` prefix; unsupported namespaces like `\\?\Volume{GUID}\` are now preserved instead of being corrupted.

- Centralizes strict verbatim-prefix conversion in `windows_path` for inspect normalization, LSP URI rendering, batch-shim execution, and bridge root identity.
- Rejects malformed spellings (dot components, incomplete UNC) and unsupported namespaces rather than stripping their prefix; LSP URI conversion now errors on preserved verbatim paths instead of emitting a bogus UNC URI.
- Adds regression coverage in Rust and bridge TypeScript tests.

<sup>Written for commit a7049dbba5d9e25029c625f0b4374742f399578f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/aft/pull/302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



Closes #303


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR centralizes strict Windows verbatim-path normalization and prevents unsupported or malformed namespaces from being corrupted by indiscriminate prefix removal.
- Converts only valid extended-length DOS-drive and UNC paths.
- Preserves unsupported namespaces such as volume GUID paths.
- Reuses the normalization behavior across inspection, LSP URI handling, batch command execution, and bridge project identity.
- Adds Rust and TypeScript regression coverage for supported and preserved path forms.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no outstanding correctness or repository-rule violations.

The previously reported LSP concern was manually resolved after the author documented that URL parsing rejects the malformed representation, and the bridge coverage concern is fully addressed by the new injectable-platform regression tests. No new actionable failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/aft/src/windows_path.rs | Introduces the shared strict converter for valid DOS and UNC verbatim paths while preserving unsupported or malformed namespaces. |
| crates/aft/src/lsp/position.rs | Routes URI path normalization through the shared converter and covers unsupported volume namespaces. |
| crates/aft/src/windows_command.rs | Uses the shared conversion before invoking batch shims and preserves paths that cannot be converted safely. |
| packages/aft-bridge/src/project-identity.ts | Mirrors strict Windows project-root normalization and exposes an injectable platform for portable testing. |
| packages/aft-bridge/src/__tests__/project-identity.test.ts | Adds direct win32 coverage for valid DOS and UNC paths plus unsupported and malformed namespace spellings. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Input[Windows path] --> Validate{Valid verbatim DOS or UNC?}
  Validate -->|Yes| Convert[Remove verbatim namespace safely]
  Validate -->|No| Preserve[Preserve original namespace]
  Convert --> Consumers[Inspect, LSP, commands, bridge identity]
  Preserve --> Consumers
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(windows): reject malformed verbatim ..."](https://github.com/cortexkit/aft/commit/a7049dbba5d9e25029c625f0b4374742f399578f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61447770)</sub>

<!-- /greptile_comment -->